### PR TITLE
feat(tui): auto-destroy lifecycle and results cleanup UX

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -122,7 +122,7 @@ func (a *App) createStatusView(infra core.InfraOutputs) core.View {
 	provider := aws.NewProvider(awsCfg, log)
 	// counter is nil — falls back to Storage.Count(). A DynamoDB counter
 	// implementation can be wired here for 1M+ target scale.
-	return nmapview.NewStatus(infra, provider.Queue(), provider.Storage(), provider.Compute(), nil, a.newTracker())
+	return nmapview.NewStatus(infra, provider.Queue(), provider.Storage(), provider.Compute(), nil, a.newTracker(), a.buildDestroyer(infra.TerraformDir))
 }
 
 
@@ -146,12 +146,28 @@ func (a *App) createGenericStatusView(infra core.InfraOutputs) core.View {
 	}
 	log := nopLogger{}
 	provider := aws.NewProvider(awsCfg, log)
-	return genericview.NewStatus(infra, provider.Queue(), provider.Storage(), provider.Compute(), nil, a.newTracker())
+	return genericview.NewStatus(infra, provider.Queue(), provider.Storage(), provider.Compute(), nil, a.newTracker(), a.buildDestroyer(infra.TerraformDir))
 }
 
 func (a *App) createGenericResultsView(infra core.InfraOutputs) core.View {
 	source, destroyer := a.buildResultsDeps(infra, infra.ToolName)
 	return genericview.NewResults(infra, source, destroyer)
+}
+
+// buildDestroyer creates a Destroyer for the given terraform directory, or nil
+// if no directory is provided.
+func (a *App) buildDestroyer(terraformDir string) core.Destroyer {
+	if terraformDir == "" {
+		return nil
+	}
+	log := nopLogger{}
+	tf := infraPkg.NewTerraformClient(log)
+	return &core.TerraformDestroyer{
+		DestroyFunc: func(ctx context.Context, workDir string) error {
+			return tf.Destroy(ctx, workDir, io.Discard)
+		},
+		WorkDir: terraformDir,
+	}
 }
 
 // buildResultsDeps returns the appropriate ResultsSource and Destroyer for a
@@ -181,18 +197,7 @@ func (a *App) buildResultsDeps(infra core.InfraOutputs, toolName string) (core.R
 		}
 	}
 
-	var destroyer core.Destroyer
-	if infra.TerraformDir != "" {
-		log := nopLogger{}
-		tf := infraPkg.NewTerraformClient(log)
-		destroyer = &core.TerraformDestroyer{
-			DestroyFunc: func(ctx context.Context, workDir string) error {
-				return tf.Destroy(ctx, workDir, io.Discard)
-			},
-			WorkDir: infra.TerraformDir,
-		}
-	}
-
+	destroyer := a.buildDestroyer(infra.TerraformDir)
 	return source, destroyer
 }
 

--- a/internal/tui/core/types.go
+++ b/internal/tui/core/types.go
@@ -124,6 +124,10 @@ type InfraOutputs struct {
 	// Export state — set by status view after successful local export.
 	Exported  bool   // true if results were exported locally
 	ExportDir string // directory where results were exported
+
+	// Cleanup outcome — set by status view after auto-destroy attempt.
+	Destroyed  bool   // true if infra was automatically destroyed after export
+	DestroyErr string // non-empty if auto-destroy was attempted but failed
 }
 
 // LifecycleCheckMsg carries the result of a lifecycle probe back to the deploy view.

--- a/internal/tui/views/generic/results.go
+++ b/internal/tui/views/generic/results.go
@@ -103,13 +103,23 @@ func NewResults(infra core.InfraOutputs, source core.ResultsSource, destroyer co
 		FullSeparator:  lipgloss.NewStyle().Foreground(core.Steel),
 		Ellipsis:       lipgloss.NewStyle().Foreground(core.Steel),
 	}
-	return &ResultsModel{
+	m := &ResultsModel{
 		source:    source,
 		destroyer: destroyer,
 		infra:     infra,
 		results:   make(map[string]*worker.Result),
 		help:      h,
 	}
+
+	// Seed cleanup outcome from auto-destroy (set by status view).
+	if infra.Destroyed {
+		m.destroyed = true
+		m.destroyMsg = "Infrastructure destroyed successfully"
+	} else if infra.DestroyErr != "" {
+		m.destroyMsg = fmt.Sprintf("Auto-destroy failed: %s", infra.DestroyErr)
+	}
+
+	return m
 }
 
 func (m *ResultsModel) Init() tea.Cmd {
@@ -215,10 +225,11 @@ func (m *ResultsModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 
 	case destroyCompleteMsg:
 		m.destroying = false
-		m.destroyed = true
 		if msg.err != nil {
-			m.destroyMsg = fmt.Sprintf("Destroy failed: %v", msg.err)
+			m.destroyed = false // allow manual retry via 'd'
+			m.destroyMsg = fmt.Sprintf("Destroy failed: %v — press d to retry", msg.err)
 		} else {
+			m.destroyed = true
 			m.destroyMsg = "Infrastructure destroyed successfully"
 		}
 	}
@@ -234,7 +245,7 @@ func (m *ResultsModel) View() string {
 	b.WriteString("\n\n")
 
 	// Cleanup / export summary.
-	if m.infra.CleanupPolicy != "" || m.infra.Exported {
+	if m.infra.CleanupPolicy != "" || m.infra.Exported || m.destroyed {
 		summaryStyle := lipgloss.NewStyle().Foreground(core.Steel)
 		var parts []string
 		if m.infra.Reused {
@@ -245,6 +256,11 @@ func (m *ResultsModel) View() string {
 		}
 		if m.infra.Exported {
 			parts = append(parts, "exported: "+m.infra.ExportDir)
+		}
+		if m.destroyed {
+			parts = append(parts, "infra: destroyed")
+		} else if m.infra.DestroyErr != "" && !m.destroying {
+			parts = append(parts, "infra: retained (destroy failed)")
 		}
 		if len(parts) > 0 {
 			b.WriteString("  " + summaryStyle.Render(strings.Join(parts, "  |  ")) + "\n\n")
@@ -316,7 +332,11 @@ func (m *ResultsModel) View() string {
 	}
 
 	b.WriteString("\n\n")
-	helpBar := core.StatusBarStyle.Render(m.help.View(resultsKeys))
+	keys := resultsKeys
+	if m.destroyed {
+		keys.Destroy = key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "destroy infra"), key.WithDisabled())
+	}
+	helpBar := core.StatusBarStyle.Render(m.help.View(keys))
 	b.WriteString(helpBar)
 
 	content := b.String()

--- a/internal/tui/views/generic/results_test.go
+++ b/internal/tui/views/generic/results_test.go
@@ -324,4 +324,120 @@ func TestGenericResultsDestroyFailure(t *testing.T) {
 	if !strings.Contains(m.destroyMsg, "Destroy failed") {
 		t.Fatalf("expected failure message, got %q", m.destroyMsg)
 	}
+	if m.destroyed {
+		t.Fatal("expected destroyed=false after failure (should allow retry)")
+	}
+}
+
+func TestGenericResultsAutoDestroyedHidesKey(t *testing.T) {
+	source := &mockResultsSource{keys: []string{}}
+	infra := testResultInfra()
+	infra.Destroyed = true
+	infra.Exported = true
+	infra.ExportDir = "/tmp/out"
+	infra.CleanupPolicy = "destroy-after"
+	m := NewResults(infra, source, nil)
+	cmd := m.Init()
+	msg := cmd()
+	m.Update(msg)
+
+	// Should be seeded as destroyed.
+	if !m.destroyed {
+		t.Fatal("expected destroyed=true from InfraOutputs")
+	}
+	if !strings.Contains(m.destroyMsg, "destroyed successfully") {
+		t.Fatalf("expected success message, got %q", m.destroyMsg)
+	}
+
+	// View should show "infra: destroyed" summary and no destroy key help.
+	v := m.View()
+	if !strings.Contains(v, "infra: destroyed") {
+		t.Fatal("expected 'infra: destroyed' in summary")
+	}
+
+	// Press d — should be a no-op.
+	_, cmd = m.Update(tea.KeyPressMsg{Code: 'd'})
+	if cmd != nil {
+		t.Fatal("expected no command (already destroyed)")
+	}
+}
+
+func TestGenericResultsAutoDestroyFailureShowsMessage(t *testing.T) {
+	source := &mockResultsSource{keys: []string{}}
+	destroyer := &mockDestroyer{}
+	infra := testResultInfra()
+	infra.DestroyErr = "timeout waiting for resources"
+	infra.Exported = true
+	infra.ExportDir = "/tmp/out"
+	m := NewResults(infra, source, destroyer)
+	cmd := m.Init()
+	msg := cmd()
+	m.Update(msg)
+
+	// Should show auto-destroy failure message.
+	if !strings.Contains(m.destroyMsg, "Auto-destroy failed") {
+		t.Fatalf("expected auto-destroy failure message, got %q", m.destroyMsg)
+	}
+	if m.destroyed {
+		t.Fatal("expected destroyed=false for failed auto-destroy")
+	}
+
+	// View should show "infra: retained" summary.
+	v := m.View()
+	if !strings.Contains(v, "infra: retained") {
+		t.Fatal("expected 'infra: retained' in summary")
+	}
+
+	// Manual retry via d should work.
+	_, cmd = m.Update(tea.KeyPressMsg{Code: 'd'})
+	if cmd == nil {
+		t.Fatal("expected destroy command (manual retry)")
+	}
+	msg = cmd()
+	m.Update(msg)
+
+	if !destroyer.called {
+		t.Fatal("expected destroyer to be called on retry")
+	}
+	if !m.destroyed {
+		t.Fatal("expected destroyed=true after successful retry")
+	}
+}
+
+func TestGenericResultsDestroyRetryAfterFailure(t *testing.T) {
+	source := &mockResultsSource{keys: []string{}}
+	destroyer := &mockDestroyer{err: fmt.Errorf("first failure")}
+	infra := testResultInfra()
+	infra.Exported = true
+	infra.ExportDir = "/tmp/out"
+	m := NewResults(infra, source, destroyer)
+	cmd := m.Init()
+	msg := cmd()
+	m.Update(msg)
+
+	// First destroy attempt fails.
+	_, cmd = m.Update(tea.KeyPressMsg{Code: 'd'})
+	msg = cmd()
+	m.Update(msg)
+
+	if m.destroyed {
+		t.Fatal("expected destroyed=false after failure")
+	}
+	if !strings.Contains(m.destroyMsg, "press d to retry") {
+		t.Fatalf("expected retry hint, got %q", m.destroyMsg)
+	}
+
+	// Second attempt succeeds.
+	destroyer.err = nil
+	destroyer.called = false
+	_, cmd = m.Update(tea.KeyPressMsg{Code: 'd'})
+	if cmd == nil {
+		t.Fatal("expected destroy command on retry")
+	}
+	msg = cmd()
+	m.Update(msg)
+
+	if !m.destroyed {
+		t.Fatal("expected destroyed=true after successful retry")
+	}
 }

--- a/internal/tui/views/generic/status.go
+++ b/internal/tui/views/generic/status.go
@@ -23,11 +23,12 @@ import (
 type statusPhase int
 
 const (
-	phaseUploading statusPhase = iota // wordlist only: uploading chunks
+	phaseUploading  statusPhase = iota // wordlist only: uploading chunks
 	phaseEnqueuing
 	phaseLaunching
 	phaseScanning
-	phaseExporting // exporting results locally before cleanup
+	phaseExporting  // exporting results locally before cleanup
+	phaseDestroying // auto-destroying infrastructure after export
 	phaseComplete
 )
 
@@ -57,6 +58,11 @@ type exportCompleteMsg struct {
 	dir   string
 	count int
 	err   error
+}
+
+// autoDestroyCompleteMsg reports the outcome of auto-destroy in the status view.
+type autoDestroyCompleteMsg struct {
+	err error
 }
 
 type uploadCompleteMsg struct {
@@ -154,7 +160,8 @@ type StatusModel struct {
 	tracker    GenericTracker
 	uploader   GenericUploader
 	jobTracker *operator.Tracker
-	storage    cloud.Storage // for local export on completion
+	storage    cloud.Storage    // for local export on completion
+	destroyer  core.Destroyer   // for auto-destroy after export (nil = no destroy)
 	infra      core.InfraOutputs
 
 	phase        statusPhase
@@ -184,7 +191,7 @@ type rateSample struct {
 }
 
 // NewStatus creates a status view with real cloud clients.
-func NewStatus(infra core.InfraOutputs, q cloud.Queue, s cloud.Storage, c cloud.Compute, counter cloud.ProgressCounter, jt *operator.Tracker) *StatusModel {
+func NewStatus(infra core.InfraOutputs, q cloud.Queue, s cloud.Storage, c cloud.Compute, counter cloud.ProgressCounter, jt *operator.Tracker, destroyer core.Destroyer) *StatusModel {
 	targets := parseTargetLines(infra.TargetsContent)
 	useCounter := counter != nil && len(targets) >= 10_000
 
@@ -195,6 +202,7 @@ func NewStatus(infra core.InfraOutputs, q cloud.Queue, s cloud.Storage, c cloud.
 		jt,
 	)
 	m.storage = s
+	m.destroyer = destroyer
 	return m
 }
 
@@ -435,9 +443,26 @@ func (m *StatusModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 	case exportCompleteMsg:
 		if msg.err != nil {
 			m.cleanupWarning = fmt.Sprintf("destroy-after skipped: export failed (%v)", msg.err)
+			m.phase = phaseComplete
+			return m, m.navigateToResults()
+		}
+		m.infra.Exported = true
+		m.infra.ExportDir = msg.dir
+		// Auto-destroy if destroy-after policy and destroyer is available.
+		if m.destroyer != nil {
+			m.phase = phaseDestroying
+			return m, m.runAutoDestroy()
+		}
+		m.cleanupWarning = "destroy-after skipped: no terraform directory"
+		m.phase = phaseComplete
+		return m, m.navigateToResults()
+
+	case autoDestroyCompleteMsg:
+		if msg.err != nil {
+			m.infra.DestroyErr = msg.err.Error()
+			m.cleanupWarning = fmt.Sprintf("destroy failed: %v", msg.err)
 		} else {
-			m.infra.Exported = true
-			m.infra.ExportDir = msg.dir
+			m.infra.Destroyed = true
 		}
 		m.phase = phaseComplete
 		return m, m.navigateToResults()
@@ -522,12 +547,23 @@ func (m *StatusModel) View() string {
 		fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Output:"), m.infra.OutputDir)
 		fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Elapsed:"), elapsed.String())
 
+	case phaseDestroying:
+		b.WriteString(core.SelectedStyle.Render("  Destroying infrastructure...") + "\n\n")
+		fmt.Fprintf(&b, "  %s%d / %d\n", labelStyle.Render("Completed:"), m.completed, m.totalTargets)
+		if m.infra.Exported {
+			fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Exported:"), m.infra.ExportDir)
+		}
+		fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Elapsed:"), elapsed.String())
+
 	case phaseComplete:
 		b.WriteString(core.SuccessStyle.Render("  Scan complete!") + "\n\n")
 		fmt.Fprintf(&b, "  %s%d / %d\n", labelStyle.Render("Completed:"), m.completed, m.totalTargets)
 		fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Elapsed:"), elapsed.String())
 		if m.infra.Exported {
 			fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Exported:"), m.infra.ExportDir)
+		}
+		if m.infra.Destroyed {
+			fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Infra:"), "destroyed")
 		}
 	}
 
@@ -635,6 +671,14 @@ func (m *StatusModel) exportResults() tea.Cmd {
 			return exportCompleteMsg{err: err}
 		}
 		return exportCompleteMsg{dir: result.Dir, count: result.ResultCount + result.ArtifactCount}
+	}
+}
+
+func (m *StatusModel) runAutoDestroy() tea.Cmd {
+	d := m.destroyer
+	return func() tea.Msg {
+		err := d.Destroy(context.Background())
+		return autoDestroyCompleteMsg{err: err}
 	}
 }
 

--- a/internal/tui/views/generic/status_test.go
+++ b/internal/tui/views/generic/status_test.go
@@ -587,13 +587,13 @@ func TestGenericStatusAutoDestroyEndToEnd(t *testing.T) {
 	m.phase = phaseScanning
 
 	// Scan complete triggers export.
-	_, cmd := m.Update(scanProgressMsg{completed: 2})
+	_, _ = m.Update(scanProgressMsg{completed: 2})
 	if m.phase != phaseExporting {
 		t.Fatalf("expected phaseExporting, got %d", m.phase)
 	}
 
 	// Export succeeds, triggers destroy.
-	_, cmd = m.Update(exportCompleteMsg{dir: "/tmp/export/httpx/job-1", count: 2})
+	_, cmd := m.Update(exportCompleteMsg{dir: "/tmp/export/httpx/job-1", count: 2})
 	if m.phase != phaseDestroying {
 		t.Fatalf("expected phaseDestroying, got %d", m.phase)
 	}

--- a/internal/tui/views/generic/status_test.go
+++ b/internal/tui/views/generic/status_test.go
@@ -451,6 +451,191 @@ func (s *mockExportStorage) Download(context.Context, string, string) ([]byte, e
 func (s *mockExportStorage) List(context.Context, string, string) ([]string, error)   { return nil, nil }
 func (s *mockExportStorage) Count(context.Context, string, string) (int, error)       { return 0, nil }
 
+// --- Track 1 PR 5.12: auto-destroy lifecycle tests ---
+
+func TestGenericStatusExportSuccess_DestroyAfter_TriggersDestroy(t *testing.T) {
+	infra := testInfra()
+	infra.CleanupPolicy = "destroy-after"
+	infra.OutputDir = "/tmp/export"
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{}, &mockUploader{})
+	m.storage = &mockExportStorage{}
+	m.destroyer = &mockDestroyer{}
+	m.phase = phaseExporting
+
+	_, cmd := m.Update(exportCompleteMsg{dir: "/tmp/export/httpx/job-1", count: 3})
+	if m.phase != phaseDestroying {
+		t.Fatalf("expected phaseDestroying, got %d", m.phase)
+	}
+	if !m.infra.Exported {
+		t.Fatal("expected Exported to be true")
+	}
+	if cmd == nil {
+		t.Fatal("expected destroy command")
+	}
+}
+
+func TestGenericStatusExportSuccess_NoDestroyer_ShowsWarning(t *testing.T) {
+	infra := testInfra()
+	infra.CleanupPolicy = "destroy-after"
+	infra.OutputDir = "/tmp/export"
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{}, &mockUploader{})
+	m.storage = &mockExportStorage{}
+	// destroyer is nil
+	m.phase = phaseExporting
+
+	_, cmd := m.Update(exportCompleteMsg{dir: "/tmp/export/httpx/job-1", count: 3})
+	if m.phase != phaseComplete {
+		t.Fatalf("expected phaseComplete when destroyer is nil, got %d", m.phase)
+	}
+	if !strings.Contains(m.cleanupWarning, "no terraform directory") {
+		t.Fatalf("expected terraform warning, got %q", m.cleanupWarning)
+	}
+	if cmd == nil {
+		t.Fatal("expected navigate command")
+	}
+}
+
+func TestGenericStatusDestroySuccess_SetsDestroyed(t *testing.T) {
+	infra := testInfra()
+	infra.CleanupPolicy = "destroy-after"
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{}, &mockUploader{})
+	m.phase = phaseDestroying
+
+	_, cmd := m.Update(autoDestroyCompleteMsg{err: nil})
+	if m.phase != phaseComplete {
+		t.Fatalf("expected phaseComplete, got %d", m.phase)
+	}
+	if !m.infra.Destroyed {
+		t.Fatal("expected Destroyed to be true")
+	}
+	if m.infra.DestroyErr != "" {
+		t.Fatalf("expected no DestroyErr, got %q", m.infra.DestroyErr)
+	}
+	if cmd == nil {
+		t.Fatal("expected navigate command")
+	}
+}
+
+func TestGenericStatusDestroyFailure_SetsDestroyErr(t *testing.T) {
+	infra := testInfra()
+	infra.CleanupPolicy = "destroy-after"
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{}, &mockUploader{})
+	m.phase = phaseDestroying
+
+	_, cmd := m.Update(autoDestroyCompleteMsg{err: fmt.Errorf("terraform timeout")})
+	if m.phase != phaseComplete {
+		t.Fatalf("expected phaseComplete, got %d", m.phase)
+	}
+	if m.infra.Destroyed {
+		t.Fatal("expected Destroyed to remain false")
+	}
+	if m.infra.DestroyErr == "" {
+		t.Fatal("expected DestroyErr to be set")
+	}
+	if !strings.Contains(m.cleanupWarning, "destroy failed") {
+		t.Fatalf("expected destroy failure warning, got %q", m.cleanupWarning)
+	}
+	if cmd == nil {
+		t.Fatal("expected navigate command")
+	}
+}
+
+func TestGenericStatusViewShowsDestroyingPhase(t *testing.T) {
+	infra := testInfra()
+	infra.CleanupPolicy = "destroy-after"
+	infra.Exported = true
+	infra.ExportDir = "/tmp/export/httpx/job-1"
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{}, &mockUploader{})
+	m.totalTargets = 10
+	m.completed = 10
+	m.phase = phaseDestroying
+
+	v := m.View()
+	if !strings.Contains(v, "Destroying") {
+		t.Fatal("expected 'Destroying' in view during phaseDestroying")
+	}
+	if !strings.Contains(v, "/tmp/export/httpx/job-1") {
+		t.Fatal("expected export dir in view during phaseDestroying")
+	}
+}
+
+func TestGenericStatusViewShowsDestroyedOnComplete(t *testing.T) {
+	infra := testInfra()
+	infra.Exported = true
+	infra.ExportDir = "/tmp/export/httpx/job-1"
+	infra.Destroyed = true
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{}, &mockUploader{})
+	m.totalTargets = 10
+	m.completed = 10
+	m.phase = phaseComplete
+
+	v := m.View()
+	if !strings.Contains(v, "destroyed") {
+		t.Fatal("expected 'destroyed' label in view")
+	}
+}
+
+func TestGenericStatusAutoDestroyEndToEnd(t *testing.T) {
+	infra := testInfra()
+	infra.CleanupPolicy = "destroy-after"
+	infra.OutputDir = "/tmp/export"
+	destroyer := &mockDestroyer{}
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{}, &mockUploader{})
+	m.storage = &mockExportStorage{}
+	m.destroyer = destroyer
+	m.totalTargets = 2
+	m.phase = phaseScanning
+
+	// Scan complete triggers export.
+	_, cmd := m.Update(scanProgressMsg{completed: 2})
+	if m.phase != phaseExporting {
+		t.Fatalf("expected phaseExporting, got %d", m.phase)
+	}
+
+	// Export succeeds, triggers destroy.
+	_, cmd = m.Update(exportCompleteMsg{dir: "/tmp/export/httpx/job-1", count: 2})
+	if m.phase != phaseDestroying {
+		t.Fatalf("expected phaseDestroying, got %d", m.phase)
+	}
+
+	// Execute the destroy command.
+	msg := cmd()
+	destroyMsg, ok := msg.(autoDestroyCompleteMsg)
+	if !ok {
+		t.Fatalf("expected autoDestroyCompleteMsg, got %T", msg)
+	}
+	if !destroyer.called {
+		t.Fatal("expected destroyer to be called")
+	}
+
+	// Destroy complete, navigates to results.
+	_, cmd = m.Update(destroyMsg)
+	if m.phase != phaseComplete {
+		t.Fatalf("expected phaseComplete, got %d", m.phase)
+	}
+	if !m.infra.Destroyed {
+		t.Fatal("expected Destroyed to be true")
+	}
+	if cmd == nil {
+		t.Fatal("expected navigate command")
+	}
+	navMsg := cmd()
+	nav, ok := navMsg.(core.NavigateWithDataMsg)
+	if !ok {
+		t.Fatalf("expected NavigateWithDataMsg, got %T", navMsg)
+	}
+	if nav.Target != core.ViewGenericResults {
+		t.Fatalf("expected ViewGenericResults, got %v", nav.Target)
+	}
+	navInfra, ok := nav.Data.(core.InfraOutputs)
+	if !ok {
+		t.Fatalf("expected InfraOutputs in nav data, got %T", nav.Data)
+	}
+	if !navInfra.Destroyed {
+		t.Fatal("expected nav data to carry Destroyed=true")
+	}
+}
+
 func TestParseTargetLines(t *testing.T) {
 	tests := []struct {
 		content string

--- a/internal/tui/views/nmap/results.go
+++ b/internal/tui/views/nmap/results.go
@@ -100,7 +100,7 @@ func NewResults(infra core.InfraOutputs, source core.ResultsSource, destroyer co
 		FullSeparator:  lipgloss.NewStyle().Foreground(core.Steel),
 		Ellipsis:       lipgloss.NewStyle().Foreground(core.Steel),
 	}
-	return &ResultsModel{
+	m := &ResultsModel{
 		source:    source,
 		destroyer: destroyer,
 		infra:     infra,
@@ -108,6 +108,16 @@ func NewResults(infra core.InfraOutputs, source core.ResultsSource, destroyer co
 
 		help: h,
 	}
+
+	// Seed cleanup outcome from auto-destroy (set by status view).
+	if infra.Destroyed {
+		m.destroyed = true
+		m.destroyMsg = "Infrastructure destroyed successfully"
+	} else if infra.DestroyErr != "" {
+		m.destroyMsg = fmt.Sprintf("Auto-destroy failed: %s", infra.DestroyErr)
+	}
+
+	return m
 }
 
 func (m *ResultsModel) Init() tea.Cmd {
@@ -205,10 +215,11 @@ func (m *ResultsModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 
 	case destroyCompleteMsg:
 		m.destroying = false
-		m.destroyed = true
 		if msg.err != nil {
-			m.destroyMsg = fmt.Sprintf("Destroy failed: %v", msg.err)
+			m.destroyed = false // allow manual retry via 'd'
+			m.destroyMsg = fmt.Sprintf("Destroy failed: %v — press d to retry", msg.err)
 		} else {
+			m.destroyed = true
 			m.destroyMsg = "Infrastructure destroyed successfully"
 		}
 	}
@@ -224,7 +235,7 @@ func (m *ResultsModel) View() string {
 	b.WriteString("\n\n")
 
 	// Cleanup / export summary.
-	if m.infra.CleanupPolicy != "" || m.infra.Exported {
+	if m.infra.CleanupPolicy != "" || m.infra.Exported || m.destroyed {
 		summaryStyle := lipgloss.NewStyle().Foreground(core.Steel)
 		var parts []string
 		if m.infra.Reused {
@@ -235,6 +246,11 @@ func (m *ResultsModel) View() string {
 		}
 		if m.infra.Exported {
 			parts = append(parts, "exported: "+m.infra.ExportDir)
+		}
+		if m.destroyed {
+			parts = append(parts, "infra: destroyed")
+		} else if m.infra.DestroyErr != "" && !m.destroying {
+			parts = append(parts, "infra: retained (destroy failed)")
 		}
 		if len(parts) > 0 {
 			b.WriteString("  " + summaryStyle.Render(strings.Join(parts, "  |  ")) + "\n\n")
@@ -299,7 +315,11 @@ func (m *ResultsModel) View() string {
 	}
 
 	b.WriteString("\n\n")
-	helpBar := core.StatusBarStyle.Render(m.help.View(resultsKeys))
+	keys := resultsKeys
+	if m.destroyed {
+		keys.Destroy = key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "destroy infra"), key.WithDisabled())
+	}
+	helpBar := core.StatusBarStyle.Render(m.help.View(keys))
 	b.WriteString(helpBar)
 
 	content := b.String()

--- a/internal/tui/views/nmap/results_test.go
+++ b/internal/tui/views/nmap/results_test.go
@@ -219,6 +219,108 @@ func TestResultsModel_DestroyExecutes(t *testing.T) {
 	}
 }
 
+func TestResultsModel_DestroyFailureAllowsRetry(t *testing.T) {
+	s := testResultsSource()
+	destroyer := &mockDestroyer{err: fmt.Errorf("terraform error")}
+	infra := testInfra()
+	infra.Exported = true
+	infra.ExportDir = "/tmp/out"
+	m := NewResults(infra, s, destroyer)
+	cmd := m.Init()
+	msg := cmd()
+	m.Update(msg)
+
+	_, cmd = m.Update(tea.KeyPressMsg{Code: 'd'})
+	msg = cmd()
+	m.Update(msg)
+
+	if m.destroyed {
+		t.Fatal("expected destroyed=false after failure")
+	}
+	if !strings.Contains(m.destroyMsg, "press d to retry") {
+		t.Fatalf("expected retry hint, got %q", m.destroyMsg)
+	}
+
+	// Retry should work.
+	destroyer.err = nil
+	destroyer.called = false
+	_, cmd = m.Update(tea.KeyPressMsg{Code: 'd'})
+	if cmd == nil {
+		t.Fatal("expected destroy command on retry")
+	}
+	msg = cmd()
+	m.Update(msg)
+
+	if !m.destroyed {
+		t.Fatal("expected destroyed=true after successful retry")
+	}
+}
+
+func TestResultsModel_AutoDestroyedHidesKey(t *testing.T) {
+	s := testResultsSource()
+	infra := testInfra()
+	infra.Destroyed = true
+	infra.Exported = true
+	infra.ExportDir = "/tmp/out"
+	infra.CleanupPolicy = "destroy-after"
+	m := NewResults(infra, s, nil)
+	cmd := m.Init()
+	msg := cmd()
+	m.Update(msg)
+
+	if !m.destroyed {
+		t.Fatal("expected destroyed=true from InfraOutputs")
+	}
+
+	v := m.View()
+	if !strings.Contains(v, "infra: destroyed") {
+		t.Fatal("expected 'infra: destroyed' in summary")
+	}
+
+	// Press d — should be a no-op.
+	_, cmd = m.Update(tea.KeyPressMsg{Code: 'd'})
+	if cmd != nil {
+		t.Fatal("expected no command (already destroyed)")
+	}
+}
+
+func TestResultsModel_AutoDestroyFailureShowsMessage(t *testing.T) {
+	s := testResultsSource()
+	destroyer := &mockDestroyer{}
+	infra := testInfra()
+	infra.DestroyErr = "timeout waiting for resources"
+	infra.Exported = true
+	infra.ExportDir = "/tmp/out"
+	m := NewResults(infra, s, destroyer)
+	cmd := m.Init()
+	msg := cmd()
+	m.Update(msg)
+
+	if !strings.Contains(m.destroyMsg, "Auto-destroy failed") {
+		t.Fatalf("expected auto-destroy failure message, got %q", m.destroyMsg)
+	}
+
+	v := m.View()
+	if !strings.Contains(v, "infra: retained") {
+		t.Fatal("expected 'infra: retained' in summary")
+	}
+
+	// Manual retry via d should work.
+	_, cmd = m.Update(tea.KeyPressMsg{Code: 'd'})
+	if cmd == nil {
+		t.Fatal("expected destroy command (manual retry)")
+	}
+	msg = cmd()
+	m.Update(msg)
+
+	if !destroyer.called {
+		t.Fatal("expected destroyer to be called on retry")
+	}
+	if !m.destroyed {
+		t.Fatal("expected destroyed=true after successful retry")
+	}
+}
+
 func TestResultsModel_DestroyBlockedWithoutExport(t *testing.T) {
 	s := testResultsSource()
 	destroyer := &mockDestroyer{}

--- a/internal/tui/views/nmap/status.go
+++ b/internal/tui/views/nmap/status.go
@@ -28,7 +28,8 @@ const (
 	phaseEnqueuing statusPhase = iota
 	phaseLaunching
 	phaseScanning
-	phaseExporting // exporting results locally before cleanup
+	phaseExporting  // exporting results locally before cleanup
+	phaseDestroying // auto-destroying infrastructure after export
 	phaseComplete
 )
 
@@ -57,6 +58,11 @@ type exportCompleteMsg struct {
 	dir   string
 	count int
 	err   error
+}
+
+// autoDestroyCompleteMsg reports the outcome of auto-destroy in the status view.
+type autoDestroyCompleteMsg struct {
+	err error
 }
 
 // SpotThreshold is the worker count at or above which auto mode selects spot
@@ -146,7 +152,8 @@ type StatusModel struct {
 	submitter  JobSubmitter
 	tracker    ProgressTracker
 	jobTracker *operator.Tracker
-	storage    cloud.Storage // for local export on completion
+	storage    cloud.Storage    // for local export on completion
+	destroyer  core.Destroyer   // for auto-destroy after export (nil = no destroy)
 	infra      core.InfraOutputs
 
 	phase        statusPhase
@@ -179,7 +186,7 @@ type rateSample struct {
 // counter may be nil — falls back to Storage.Count() for progress tracking.
 // When counter is provided and the target count is >= CounterThreshold, the
 // counter is used automatically for O(1) progress polling.
-func NewStatus(infra core.InfraOutputs, q cloud.Queue, s cloud.Storage, c cloud.Compute, counter cloud.ProgressCounter, jt *operator.Tracker) *StatusModel {
+func NewStatus(infra core.InfraOutputs, q cloud.Queue, s cloud.Storage, c cloud.Compute, counter cloud.ProgressCounter, jt *operator.Tracker, destroyer core.Destroyer) *StatusModel {
 	// Pre-count targets to decide tracking strategy.
 	scanner := nmaptool.NewScanner(nil)
 	targets := scanner.ParseTargets(infra.TargetsContent, infra.NmapOptions)
@@ -191,6 +198,7 @@ func NewStatus(infra core.InfraOutputs, q cloud.Queue, s cloud.Storage, c cloud.
 		jt,
 	)
 	m.storage = s
+	m.destroyer = destroyer
 	return m
 }
 
@@ -381,9 +389,26 @@ func (m *StatusModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 	case exportCompleteMsg:
 		if msg.err != nil {
 			m.cleanupWarning = fmt.Sprintf("destroy-after skipped: export failed (%v)", msg.err)
+			m.phase = phaseComplete
+			return m, m.navigateToResults()
+		}
+		m.infra.Exported = true
+		m.infra.ExportDir = msg.dir
+		// Auto-destroy if destroy-after policy and destroyer is available.
+		if m.destroyer != nil {
+			m.phase = phaseDestroying
+			return m, m.runAutoDestroy()
+		}
+		m.cleanupWarning = "destroy-after skipped: no terraform directory"
+		m.phase = phaseComplete
+		return m, m.navigateToResults()
+
+	case autoDestroyCompleteMsg:
+		if msg.err != nil {
+			m.infra.DestroyErr = msg.err.Error()
+			m.cleanupWarning = fmt.Sprintf("destroy failed: %v", msg.err)
 		} else {
-			m.infra.Exported = true
-			m.infra.ExportDir = msg.dir
+			m.infra.Destroyed = true
 		}
 		m.phase = phaseComplete
 		return m, m.navigateToResults()
@@ -447,12 +472,23 @@ func (m *StatusModel) View() string {
 		fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Output:"), m.infra.OutputDir)
 		fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Elapsed:"), elapsed.String())
 
+	case phaseDestroying:
+		b.WriteString(core.SelectedStyle.Render("  Destroying infrastructure...") + "\n\n")
+		fmt.Fprintf(&b, "  %s%d / %d\n", labelStyle.Render("Completed:"), m.completed, m.totalTargets)
+		if m.infra.Exported {
+			fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Exported:"), m.infra.ExportDir)
+		}
+		fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Elapsed:"), elapsed.String())
+
 	case phaseComplete:
 		b.WriteString(core.SuccessStyle.Render("  Scan complete!") + "\n\n")
 		fmt.Fprintf(&b, "  %s%d / %d\n", labelStyle.Render("Completed:"), m.completed, m.totalTargets)
 		fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Elapsed:"), elapsed.String())
 		if m.infra.Exported {
 			fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Exported:"), m.infra.ExportDir)
+		}
+		if m.infra.Destroyed {
+			fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Infra:"), "destroyed")
 		}
 	}
 
@@ -579,6 +615,14 @@ func (m *StatusModel) exportResults() tea.Cmd {
 			return exportCompleteMsg{err: err}
 		}
 		return exportCompleteMsg{dir: result.Dir, count: result.ResultCount + result.ArtifactCount}
+	}
+}
+
+func (m *StatusModel) runAutoDestroy() tea.Cmd {
+	d := m.destroyer
+	return func() tea.Msg {
+		err := d.Destroy(context.Background())
+		return autoDestroyCompleteMsg{err: err}
 	}
 }
 

--- a/internal/tui/views/nmap/status_test.go
+++ b/internal/tui/views/nmap/status_test.go
@@ -536,3 +536,223 @@ func (s *mockExportStorage) Upload(context.Context, string, string, []byte) erro
 func (s *mockExportStorage) Download(context.Context, string, string) ([]byte, error) { return nil, nil }
 func (s *mockExportStorage) List(context.Context, string, string) ([]string, error)   { return nil, nil }
 func (s *mockExportStorage) Count(context.Context, string, string) (int, error)       { return 0, nil }
+
+// --- Track 1 PR 5.12: auto-destroy lifecycle tests ---
+
+func TestStatusModel_ExportSuccess_DestroyAfter_TriggersDestroy(t *testing.T) {
+	infra := testInfra()
+	infra.CleanupPolicy = "destroy-after"
+	infra.OutputDir = "/tmp/export"
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{})
+	m.storage = &mockExportStorage{}
+	m.destroyer = &mockDestroyer{}
+	m.phase = phaseExporting
+
+	_, cmd := m.Update(exportCompleteMsg{dir: "/tmp/export/nmap/job-123", count: 5})
+	if m.phase != phaseDestroying {
+		t.Fatalf("expected phaseDestroying, got %d", m.phase)
+	}
+	if !m.infra.Exported {
+		t.Fatal("expected Exported to be true")
+	}
+	if cmd == nil {
+		t.Fatal("expected destroy command")
+	}
+}
+
+func TestStatusModel_ExportSuccess_ReusePolicySkipsDestroy(t *testing.T) {
+	infra := testInfra()
+	infra.CleanupPolicy = "reuse"
+	infra.OutputDir = "/tmp/export"
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{})
+	m.storage = &mockExportStorage{}
+	m.destroyer = &mockDestroyer{}
+	m.phase = phaseExporting
+
+	// Reuse policy export doesn't happen (shouldExport is false), but if it did,
+	// it would not trigger destroy because the exportCompleteMsg only fires when
+	// cleanup_policy is destroy-after. Simulate export complete for a non-destroy
+	// path — this shouldn't reach phaseDestroying because the code only reaches
+	// phaseExporting when shouldExport() returns true (which requires destroy-after).
+	// Instead, verify the reuse path goes directly to complete.
+	infra2 := testInfra()
+	infra2.CleanupPolicy = "reuse"
+	infra2.OutputDir = "/tmp/export"
+	m2 := NewStatusWithDeps(infra2, &mockSubmitter{}, &mockTracker{})
+	m2.totalTargets = 2
+	m2.phase = phaseScanning
+
+	_, _ = m2.Update(scanProgressMsg{completed: 2})
+	if m2.phase != phaseComplete {
+		t.Fatalf("expected phaseComplete for reuse policy, got %d", m2.phase)
+	}
+}
+
+func TestStatusModel_ExportSuccess_NoDestroyer_ShowsWarning(t *testing.T) {
+	infra := testInfra()
+	infra.CleanupPolicy = "destroy-after"
+	infra.OutputDir = "/tmp/export"
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{})
+	m.storage = &mockExportStorage{}
+	// destroyer is nil
+	m.phase = phaseExporting
+
+	_, cmd := m.Update(exportCompleteMsg{dir: "/tmp/export/nmap/job-123", count: 5})
+	if m.phase != phaseComplete {
+		t.Fatalf("expected phaseComplete when destroyer is nil, got %d", m.phase)
+	}
+	if !strings.Contains(m.cleanupWarning, "no terraform directory") {
+		t.Fatalf("expected terraform warning, got %q", m.cleanupWarning)
+	}
+	if cmd == nil {
+		t.Fatal("expected navigate command")
+	}
+}
+
+func TestStatusModel_DestroySuccess_SetsDestroyed(t *testing.T) {
+	infra := testInfra()
+	infra.CleanupPolicy = "destroy-after"
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{})
+	m.phase = phaseDestroying
+
+	_, cmd := m.Update(autoDestroyCompleteMsg{err: nil})
+	if m.phase != phaseComplete {
+		t.Fatalf("expected phaseComplete, got %d", m.phase)
+	}
+	if !m.infra.Destroyed {
+		t.Fatal("expected Destroyed to be true")
+	}
+	if m.infra.DestroyErr != "" {
+		t.Fatalf("expected no DestroyErr, got %q", m.infra.DestroyErr)
+	}
+	if m.cleanupWarning != "" {
+		t.Fatalf("expected no cleanup warning, got %q", m.cleanupWarning)
+	}
+	if cmd == nil {
+		t.Fatal("expected navigate command")
+	}
+}
+
+func TestStatusModel_DestroyFailure_SetsDestroyErr(t *testing.T) {
+	infra := testInfra()
+	infra.CleanupPolicy = "destroy-after"
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{})
+	m.phase = phaseDestroying
+
+	_, cmd := m.Update(autoDestroyCompleteMsg{err: context.DeadlineExceeded})
+	if m.phase != phaseComplete {
+		t.Fatalf("expected phaseComplete, got %d", m.phase)
+	}
+	if m.infra.Destroyed {
+		t.Fatal("expected Destroyed to remain false")
+	}
+	if m.infra.DestroyErr == "" {
+		t.Fatal("expected DestroyErr to be set")
+	}
+	if !strings.Contains(m.cleanupWarning, "destroy failed") {
+		t.Fatalf("expected destroy failure warning, got %q", m.cleanupWarning)
+	}
+	if cmd == nil {
+		t.Fatal("expected navigate command")
+	}
+}
+
+func TestStatusModel_ViewShowsDestroyingPhase(t *testing.T) {
+	infra := testInfra()
+	infra.CleanupPolicy = "destroy-after"
+	infra.Exported = true
+	infra.ExportDir = "/tmp/export/nmap/job-123"
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{})
+	m.totalTargets = 10
+	m.completed = 10
+	m.phase = phaseDestroying
+
+	v := m.View()
+	if !strings.Contains(v, "Destroying") {
+		t.Fatal("expected 'Destroying' in view during phaseDestroying")
+	}
+	if !strings.Contains(v, "/tmp/export/nmap/job-123") {
+		t.Fatal("expected export dir in view during phaseDestroying")
+	}
+}
+
+func TestStatusModel_ViewShowsDestroyedOnComplete(t *testing.T) {
+	infra := testInfra()
+	infra.Exported = true
+	infra.ExportDir = "/tmp/export/nmap/job-123"
+	infra.Destroyed = true
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{})
+	m.totalTargets = 10
+	m.completed = 10
+	m.phase = phaseComplete
+
+	v := m.View()
+	if !strings.Contains(v, "destroyed") {
+		t.Fatal("expected 'destroyed' label in view")
+	}
+}
+
+func TestStatusModel_AutoDestroyEndToEnd(t *testing.T) {
+	infra := testInfra()
+	infra.CleanupPolicy = "destroy-after"
+	infra.OutputDir = "/tmp/export"
+	destroyer := &mockDestroyer{}
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{})
+	m.storage = &mockExportStorage{}
+	m.destroyer = destroyer
+	m.totalTargets = 2
+	m.phase = phaseScanning
+
+	// Scan complete triggers export.
+	_, cmd := m.Update(scanProgressMsg{completed: 2})
+	if m.phase != phaseExporting {
+		t.Fatalf("expected phaseExporting, got %d", m.phase)
+	}
+
+	// Export succeeds, triggers destroy.
+	_, cmd = m.Update(exportCompleteMsg{dir: "/tmp/export/nmap/job-123", count: 2})
+	if m.phase != phaseDestroying {
+		t.Fatalf("expected phaseDestroying, got %d", m.phase)
+	}
+
+	// Execute the destroy command.
+	msg := cmd()
+	destroyMsg, ok := msg.(autoDestroyCompleteMsg)
+	if !ok {
+		t.Fatalf("expected autoDestroyCompleteMsg, got %T", msg)
+	}
+	if destroyMsg.err != nil {
+		t.Fatalf("expected no destroy error, got %v", destroyMsg.err)
+	}
+	if !destroyer.called {
+		t.Fatal("expected destroyer to be called")
+	}
+
+	// Destroy complete, navigates to results.
+	_, cmd = m.Update(destroyMsg)
+	if m.phase != phaseComplete {
+		t.Fatalf("expected phaseComplete, got %d", m.phase)
+	}
+	if !m.infra.Destroyed {
+		t.Fatal("expected Destroyed to be true")
+	}
+	if cmd == nil {
+		t.Fatal("expected navigate command")
+	}
+	navMsg := cmd()
+	nav, ok := navMsg.(core.NavigateWithDataMsg)
+	if !ok {
+		t.Fatalf("expected NavigateWithDataMsg, got %T", navMsg)
+	}
+	if nav.Target != core.ViewNmapResults {
+		t.Fatalf("expected ViewNmapResults, got %v", nav.Target)
+	}
+	// Verify infra carries the cleanup outcome.
+	navInfra, ok := nav.Data.(core.InfraOutputs)
+	if !ok {
+		t.Fatalf("expected InfraOutputs in nav data, got %T", nav.Data)
+	}
+	if !navInfra.Destroyed {
+		t.Fatal("expected nav data to carry Destroyed=true")
+	}
+}

--- a/internal/tui/views/nmap/status_test.go
+++ b/internal/tui/views/nmap/status_test.go
@@ -704,13 +704,13 @@ func TestStatusModel_AutoDestroyEndToEnd(t *testing.T) {
 	m.phase = phaseScanning
 
 	// Scan complete triggers export.
-	_, cmd := m.Update(scanProgressMsg{completed: 2})
+	_, _ = m.Update(scanProgressMsg{completed: 2})
 	if m.phase != phaseExporting {
 		t.Fatalf("expected phaseExporting, got %d", m.phase)
 	}
 
 	// Export succeeds, triggers destroy.
-	_, cmd = m.Update(exportCompleteMsg{dir: "/tmp/export/nmap/job-123", count: 2})
+	_, cmd := m.Update(exportCompleteMsg{dir: "/tmp/export/nmap/job-123", count: 2})
 	if m.phase != phaseDestroying {
 		t.Fatalf("expected phaseDestroying, got %d", m.phase)
 	}


### PR DESCRIPTION
## Summary                                                
  - Status views (nmap + generic) auto-destroy infrastructure after successful export when    
  `cleanup_policy=destroy-after`, removing the need to manually press `d`                     
  - Adds `phaseDestroying` phase with dedicated UI rendering ("Destroying infrastructure...")
  - `InfraOutputs` gains `Destroyed` and `DestroyErr` fields to carry cleanup outcome from    
  status to results views                                                                     
  - Results views seed destroyed/error state from `InfraOutputs` on construction for immediate
   feedback                                                                                   
  - Summary bar shows `infra: destroyed` or `infra: retained (destroy failed)` in results    
  views                                                                                       
  - `d` keybinding is disabled in help bar after successful destroy; failed destroys allow
  manual retry with `d`                                                                       
  - Extracts `buildDestroyer` helper in `app.go` to share between status and results view
  construction                                                                                
                                                            
  ## Test plan                                                                                
  - [x] Export success + destroy-after triggers auto-destroy (nmap + generic status)
  - [x] Export success + no destroyer shows warning (nmap + generic status)                   
  - [x] Export success + reuse policy skips destroy (nmap status)                             
  - [x] Destroy success sets `Destroyed=true` (nmap + generic status)                         
  - [x] Destroy failure sets `DestroyErr` and warning (nmap + generic status)                 
  - [x] End-to-end: scan → export → destroy → navigate with `Destroyed=true` (nmap + generic  
  status)                                                                                     
  - [x] View renders destroying phase and destroyed label (nmap + generic status)             
  - [x] Auto-destroyed results view hides `d` key, shows "infra: destroyed" (nmap + generic   
  results)                                                                                    
  - [x] Auto-destroy failure shows message and allows manual retry via `d` (nmap + generic    
  results)                                                                                    
  - [x] Manual destroy failure allows retry (nmap + generic results)                         
  - [x] All existing tests pass