### PR TITLE
feat(cloud): VPS-family scan execution via Docker-over-SSH compute

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,18 @@ Heph4estus is a TUI/CLI app that handles cloud infrastructure deployment and dis
 
 **Built-in modules today:** `nmap`, `nuclei`, `ffuf`, `subfinder`, `httpx`, `masscan`, `gobuster`, `feroxbuster`, `dnsx`, `katana`, `gospider`, `massdns`, `dalfox`, `gowitness`. All modules run on the generic worker backend. See `ARCHITECTURE.md`, `PLAN.md`, and `IMPLEMENTATION.md` for the roadmap.
 
+## Cloud Providers
+
+**AWS** (default, fully integrated): SQS + S3 + ECS Fargate / EC2 Spot Fleet. Infrastructure is provisioned and destroyed automatically via Terraform.
+
+**VPS providers** (`manual`, `hetzner`, `linode`, `scaleway`, `vultr`; provider-aware fleet manager planned): NATS JetStream + S3-compatible storage (MinIO) + Docker-over-SSH compute. Scan execution is supported when the operator provides controller endpoints and worker hosts via environment variables. PR 6.2 opens the manual/operator-managed path; `manual` is the expert/escape-hatch mode, not the flagship operator UX. PR 6.3 is the first polished provider-native VPS path via `hetzner`, and Phase 6 follow-on PRs extend the same fleet-manager model to `linode` and `vultr`. The legacy `selfhosted` selector remains accepted as a compatibility alias for `manual`.
+
 ## Requirements
 
 - **Go 1.26+**: For building the application
 - **Docker**: For building container images (managed by heph4estus)
 - **Terraform 1.0+**: For infrastructure provisioning (managed by heph4estus)
-- **AWS CLI**: Configured with appropriate credentials and permissions
+- **AWS CLI**: Configured with appropriate credentials and permissions (AWS path only)
 
 ## Quick Start
 
@@ -94,7 +100,81 @@ Both `heph scan` and `heph nmap` accept these lifecycle flags:
 ./bin/heph scan --tool httpx --file targets.txt --no-deploy
 ```
 
-### 5. Explicit Infrastructure Management
+### 5. VPS Scan Execution (Manual/Operator-Managed Today)
+
+The current VPS-family path is intentionally split in two:
+
+- `manual` is the expert mode and escape hatch for operator-managed environments
+- provider-native UX starts with `hetzner` in PR 6.3, then expands to `linode` and `vultr` in later Phase 6 PRs
+
+Selfhosted scan execution works when the operator has already provisioned:
+
+- A reachable NATS JetStream endpoint (queue)
+- A reachable MinIO or S3-compatible endpoint (storage)
+- Worker hosts with Docker and SSH access
+- A worker image reachable by those hosts
+
+Set the required environment variables:
+
+```bash
+# Controller endpoints
+export NATS_URL="nats://controller:4222"
+export S3_ENDPOINT="http://controller:9000"
+export S3_REGION="us-east-1"
+export S3_ACCESS_KEY="minioadmin"
+export S3_SECRET_KEY="minioadmin"
+export S3_PATH_STYLE="true"
+
+# Scan runtime contract (env-driven)
+export SELFHOSTED_QUEUE_ID="heph-tasks"
+export SELFHOSTED_BUCKET="heph-results"
+
+# Worker compute config
+export SELFHOSTED_WORKER_HOSTS="w1.example.com,w2.example.com"
+export SELFHOSTED_SSH_USER="heph"
+export SELFHOSTED_SSH_KEY_PATH="$HOME/.ssh/id_ed25519"
+export SELFHOSTED_DOCKER_IMAGE="controller:5000/heph-nmap-worker:latest"
+# Optional: export SELFHOSTED_SSH_PORT="22"
+# Optional: export NATS_STREAM="heph-tasks"
+```
+
+Run scans:
+
+```bash
+# Nmap scan on the manual/operator-managed VPS path
+./bin/heph nmap --file targets.txt --cloud manual
+
+# Generic tool scan on a named VPS provider
+./bin/heph scan --tool httpx --file targets.txt --cloud hetzner
+```
+
+Host and network requirements:
+- Treat each worker VM as one source-IP slot when you care about IP diversity. If you run more workers than unique hosts, some workers will share the same public IP.
+- Each worker host should have a stable public IPv4 address. For IPv6 scanning, each host must also have a routable public IPv6 address.
+- Provider firewalls/security groups must allow outbound IPv6 and outbound access to the controller services (NATS, MinIO, registry).
+- The worker container must have a validated IPv6 egress path from inside Docker. In practice that means host networking or a verified Docker IPv6 configuration on the worker VM before relying on `-6`.
+- Each host must be able to pull the worker image, reach the controller endpoints, and accept non-interactive SSH from the operator.
+
+Scheduler rules:
+- The queue is the task scheduler; the host inventory is the source-IP pool.
+- The current selfhosted path is manual: Heph launches workers across `SELFHOSTED_WORKER_HOSTS`, so maximum source-IP diversity today is bounded by the number of unique hosts you supply.
+- For maximum diversity today, keep `--workers` less than or equal to the number of unique worker hosts.
+- The PR 6.3 target is a provider-aware fleet manager that owns host provisioning, health, public IP metadata, IPv6 capability checks, and diversity-aware placement. Its default rule should be one worker container per healthy host/public IP, with multi-worker-per-host reserved for explicit throughput mode.
+
+What success looks like:
+- Tasks enqueue to the NATS queue identified by `SELFHOSTED_QUEUE_ID`
+- Workers launch over SSH on the configured hosts
+- Workers read from NATS and upload results to `SELFHOSTED_BUCKET`
+- `heph status --job-id <id>` can reattach using recorded job metadata
+
+What is not yet supported:
+- `heph infra deploy --cloud hetzner` polished provider-native UX (deferred to PR 6.3)
+- `heph infra deploy --cloud linode` provider adapter and UX (deferred to PR 6.4)
+- `heph infra deploy --cloud vultr` provider adapter and UX (deferred to PR 6.5)
+- `manual` becoming a zero-config mainstream path; it remains expert mode
+- Automatic controller-output consumption by scan paths (scan execution uses the env-driven contract above)
+
+### 6. Explicit Infrastructure Management
 
 `heph infra` is still available as the power-user and CI path for managing infrastructure directly:
 
@@ -106,7 +186,7 @@ Both `heph scan` and `heph nmap` accept these lifecycle flags:
 ./bin/heph infra destroy --tool nmap
 ```
 
-### 6. Clean Up
+### 7. Clean Up
 
 Infrastructure can be destroyed after a run using `--destroy-after`, or manually:
 

--- a/cmd/heph/cloud.go
+++ b/cmd/heph/cloud.go
@@ -17,21 +17,17 @@ func resolveCLICloud(explicit string, cfg *operator.OperatorConfig) (cloud.Kind,
 	return kind, nil
 }
 
-// requireComputeSupport returns an error when the selected cloud does not
-// yet have compute/deploy support. AWS is always supported; selfhosted
-// compute and deploy land in PR 6.2/6.3.
-func requireComputeSupport(kind cloud.Kind) error {
-	if kind == cloud.KindSelfhosted {
-		return fmt.Errorf("selfhosted compute and deploy support land in PR 6.2/6.3 — queue and storage are available but end-to-end scan execution requires compute")
+// requireDeploySupport returns an error when the selected cloud does not
+// yet support infrastructure deploy/destroy.
+func requireDeploySupport(kind cloud.Kind) error {
+	if kind.IsSelfhostedFamily() {
+		return fmt.Errorf("%s infrastructure deploy/destroy lands in PR 6.3", kind.Canonical())
 	}
 	return nil
 }
 
-// requireDeploySupport returns an error when the selected cloud does not
-// yet support infrastructure deploy/destroy.
-func requireDeploySupport(kind cloud.Kind) error {
-	if kind == cloud.KindSelfhosted {
-		return fmt.Errorf("selfhosted infrastructure deploy/destroy lands in PR 6.2/6.3")
-	}
-	return nil
+// ValidateComputeMode delegates to cloud.ValidateComputeMode — the single
+// authority for cloud-specific compute-mode policy.
+func ValidateComputeMode(kind cloud.Kind, mode string) error {
+	return cloud.ValidateComputeMode(kind, mode)
 }

--- a/cmd/heph/cloud_test.go
+++ b/cmd/heph/cloud_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"heph4estus/internal/cloud"
+)
+
+func TestValidateComputeMode_AWS(t *testing.T) {
+	for _, mode := range []string{"", "auto", "fargate", "spot"} {
+		if err := ValidateComputeMode(cloud.KindAWS, mode); err != nil {
+			t.Errorf("AWS mode %q should be valid: %v", mode, err)
+		}
+	}
+}
+
+func TestValidateComputeMode_AWSInvalid(t *testing.T) {
+	if err := ValidateComputeMode(cloud.KindAWS, "gpu"); err == nil {
+		t.Fatal("expected error for invalid AWS compute mode")
+	}
+}
+
+func TestValidateComputeMode_ManualAuto(t *testing.T) {
+	for _, mode := range []string{"", "auto"} {
+		if err := ValidateComputeMode(cloud.KindManual, mode); err != nil {
+			t.Errorf("manual mode %q should be valid: %v", mode, err)
+		}
+	}
+}
+
+func TestValidateComputeMode_ManualFargateRejected(t *testing.T) {
+	err := ValidateComputeMode(cloud.KindManual, "fargate")
+	if err == nil {
+		t.Fatal("expected error for manual + fargate")
+	}
+}
+
+func TestValidateComputeMode_ProviderSpotRejected(t *testing.T) {
+	err := ValidateComputeMode(cloud.KindHetzner, "spot")
+	if err == nil {
+		t.Fatal("expected error for hetzner + spot")
+	}
+}
+
+func TestRequireDeploySupport_ProviderFamilyBlocked(t *testing.T) {
+	err := requireDeploySupport(cloud.KindHetzner)
+	if err == nil {
+		t.Fatal("expected error: VPS deploy should be blocked")
+	}
+	if !strings.Contains(err.Error(), "PR 6.3") {
+		t.Fatalf("error should mention PR 6.3 deferral, got: %v", err)
+	}
+}
+
+func TestRequireDeploySupport_AWSAllowed(t *testing.T) {
+	if err := requireDeploySupport(cloud.KindAWS); err != nil {
+		t.Fatalf("AWS deploy should be allowed: %v", err)
+	}
+}

--- a/cmd/heph/cmd_infra.go
+++ b/cmd/heph/cmd_infra.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"heph4estus/internal/cloud"
 	"heph4estus/internal/infra"
 	"heph4estus/internal/logger"
 	"heph4estus/internal/operator"
@@ -42,7 +43,7 @@ func runInfraDeploy(args []string, log logger.Logger) error {
 	backend := fs.String("backend", "generic", "Infrastructure backend (generic)")
 	autoApprove := fs.Bool("auto-approve", false, "Skip interactive approval prompt")
 	region := fs.String("region", "", "AWS region (default: from AWS_REGION or us-east-1)")
-	cloudFlag := fs.String("cloud", "", "Cloud provider: aws or selfhosted (default: from config or aws)")
+	cloudFlag := fs.String("cloud", "", "Cloud provider: "+cloud.SupportedKindsText()+" (default: from config or aws)")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -86,7 +87,7 @@ func runInfraDestroy(args []string, log logger.Logger) error {
 	tool := fs.String("tool", "", "Tool whose infrastructure to destroy")
 	backend := fs.String("backend", "generic", "Infrastructure backend (generic)")
 	autoApprove := fs.Bool("auto-approve", false, "Skip interactive approval prompt")
-	cloudFlag := fs.String("cloud", "", "Cloud provider: aws or selfhosted (default: from config or aws)")
+	cloudFlag := fs.String("cloud", "", "Cloud provider: "+cloud.SupportedKindsText()+" (default: from config or aws)")
 
 	if err := fs.Parse(args); err != nil {
 		return err

--- a/cmd/heph/cmd_lifecycle_test.go
+++ b/cmd/heph/cmd_lifecycle_test.go
@@ -133,6 +133,7 @@ func TestRunTargetListScanStartedFalseOnLaunchFailure(t *testing.T) {
 		"results-bucket",
 		"queue-url",
 		operator.NoopTracker(),
+		cloud.KindAWS,
 	)
 	if err == nil {
 		t.Fatal("expected error")
@@ -160,6 +161,7 @@ func TestRunTargetListScanStartedTrueOnOutputFailure(t *testing.T) {
 		"results-bucket",
 		"queue-url",
 		operator.NoopTracker(),
+		cloud.KindAWS,
 	)
 	if err == nil {
 		t.Fatal("expected error")
@@ -224,6 +226,75 @@ func TestRunNmapScanWithDepsStartedTrueOnOutputFailure(t *testing.T) {
 	}
 	if !started {
 		t.Fatal("expected started=true after successful worker launch")
+	}
+}
+
+func TestRunNmapScanWithDeps_SelfhostedUsesRunContainer(t *testing.T) {
+	tasks := []nmaptool.ScanTask{{
+		JobID:   "job-sh",
+		Target:  "10.0.0.1",
+		Options: "-sS",
+	}}
+
+	comp := &mockCompute{}
+	started, err := runNmapScanWithDeps(
+		context.Background(),
+		tasks,
+		1,
+		"auto", // auto on VPS providers should NOT use spot
+		0,
+		"text",
+		map[string]string{
+			"sqs_queue_url":  "nats-stream",
+			"s3_bucket_name": "minio-bucket",
+		},
+		&mockQueue{},
+		&mockStorage{count: 1},
+		comp,
+		operator.NoopTracker(),
+		"job-sh",
+		cloud.KindHetzner,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !started {
+		t.Fatal("expected started=true")
+	}
+}
+
+func TestRunNmapScanWithDeps_SelfhostedNeverCallsSpot(t *testing.T) {
+	// Even with 200 workers (above spot threshold), VPS providers should use RunContainer.
+	tasks := []nmaptool.ScanTask{{
+		JobID:   "job-sh",
+		Target:  "10.0.0.1",
+		Options: "-sS",
+	}}
+
+	comp := &mockCompute{runSpotErr: errors.New("spot should not be called")}
+	started, err := runNmapScanWithDeps(
+		context.Background(),
+		tasks,
+		200, // above spot threshold
+		"auto",
+		0,
+		"text",
+		map[string]string{
+			"sqs_queue_url":  "nats-stream",
+			"s3_bucket_name": "minio-bucket",
+		},
+		&mockQueue{},
+		&mockStorage{count: 1},
+		comp,
+		operator.NoopTracker(),
+		"job-sh",
+		cloud.KindManual,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error (spot should not have been called): %v", err)
+	}
+	if !started {
+		t.Fatal("expected started=true")
 	}
 }
 

--- a/cmd/heph/cmd_nmap.go
+++ b/cmd/heph/cmd_nmap.go
@@ -41,7 +41,7 @@ func runNmap(args []string, log logger.Logger) error {
 	jitterMax := fs.Int("jitter-max", 0, "Maximum jitter seconds before each scan (0 = disabled)")
 	noRDNS := fs.Bool("no-rdns", false, "Disable reverse DNS resolution (-n)")
 	format := fs.String("format", "text", "Output format: text or json")
-	cloudFlag := fs.String("cloud", "", "Cloud provider: aws or selfhosted (default: from config or aws)")
+	cloudFlag := fs.String("cloud", "", "Cloud provider: "+cloud.SupportedKindsText()+" (default: from config or aws)")
 
 	outDir := fs.String("out", "", "Download results/artifacts to this directory after completion")
 
@@ -66,15 +66,12 @@ func runNmap(args []string, log logger.Logger) error {
 	if err != nil {
 		return err
 	}
-	if err := requireComputeSupport(cloudKind); err != nil {
+	if err := ValidateComputeMode(cloudKind, *computeMode); err != nil {
 		return err
 	}
 
 	if *inputFile == "" {
 		return fmt.Errorf("--file flag is required")
-	}
-	if *computeMode != "auto" && *computeMode != "fargate" && *computeMode != "spot" {
-		return fmt.Errorf("--compute-mode must be auto, fargate, or spot")
 	}
 	if *format != "text" && *format != "json" {
 		return fmt.Errorf("--format must be text or json")
@@ -129,12 +126,53 @@ func runNmap(args []string, log logger.Logger) error {
 		logStatus("Parsed %d targets from %s [job %s]", len(tasks), *inputFile, jobID)
 	}
 
+	ctx := mainContext()
+
 	// Track the job.
 	tracker := newTracker()
 	cleanupPolicy := "reuse"
 	if *destroyAfter {
 		cleanupPolicy = "destroy-after"
 	}
+
+	var (
+		outputs map[string]string
+		bucket  string
+		reused  bool
+		toolCfg *infra.ToolConfig
+	)
+
+	if cloudKind.IsSelfhostedFamily() {
+		// Selfhosted: no Terraform/deploy — read queue ID and bucket from config.
+		shCfg := factory.SelfhostedConfigFromEnv()
+		if shCfg.QueueID == "" || shCfg.Bucket == "" {
+			return fmt.Errorf("%s requires SELFHOSTED_QUEUE_ID and SELFHOSTED_BUCKET environment variables", cloudKind.Canonical())
+		}
+		bucket = shCfg.Bucket
+		outputs = map[string]string{
+			"sqs_queue_url":  shCfg.QueueID,
+			"s3_bucket_name": shCfg.Bucket,
+		}
+	} else {
+		// AWS: resolve tool config and ensure infrastructure.
+		toolCfg, err = infra.ResolveToolConfig("nmap")
+		if err != nil {
+			return err
+		}
+		region := infra.AWSRegion()
+		ensureResult, ensureErr := infra.EnsureInfra(ctx, toolCfg, infra.LifecyclePolicy{
+			NoDeploy:     *noDeploy,
+			AutoApprove:  *autoApprove,
+			DestroyAfter: *destroyAfter,
+		}, region, os.Stderr, deployPrompt, log)
+		if ensureErr != nil {
+			return ensureErr
+		}
+		outputs = ensureResult.Outputs
+		reused = ensureResult.Reused
+		bucket = outputs["s3_bucket_name"]
+	}
+
 	_ = tracker.Create(&operator.JobRecord{
 		JobID:         jobID,
 		ToolName:      "nmap",
@@ -144,34 +182,8 @@ func runNmap(args []string, log logger.Logger) error {
 		ComputeMode:   *computeMode,
 		Cloud:         string(cloudKind),
 		CleanupPolicy: cleanupPolicy,
+		Bucket:        bucket,
 	})
-
-	// Resolve tool config and ensure infrastructure.
-	cfg, err := infra.ResolveToolConfig("nmap")
-	if err != nil {
-		return err
-	}
-
-	ctx := mainContext()
-	region := infra.AWSRegion()
-
-	ensureResult, err := infra.EnsureInfra(ctx, cfg, infra.LifecyclePolicy{
-		NoDeploy:     *noDeploy,
-		AutoApprove:  *autoApprove,
-		DestroyAfter: *destroyAfter,
-	}, region, os.Stderr, deployPrompt, log)
-	if err != nil {
-		return err
-	}
-	outputs := ensureResult.Outputs
-
-	// Update job record with infra outputs.
-	if store := tracker.Store(); store != nil {
-		if rec, loadErr := store.Load(jobID); loadErr == nil {
-			rec.Bucket = outputs["s3_bucket_name"]
-			_ = store.Update(rec)
-		}
-	}
 
 	// Run the scan.
 	started, scanErr := runNmapScan(ctx, tasks, *workers, *computeMode, *jitterMax, *format, outputs, log, tracker, jobID, cloudKind)
@@ -185,7 +197,6 @@ func runNmap(args []string, log logger.Logger) error {
 	// Export results locally before any cleanup.
 	var exportDir string
 	if *outDir != "" && scanErr == nil && started {
-		bucket := outputs["s3_bucket_name"]
 		logStatus("Exporting results to %s...", *outDir)
 
 		exportProvider, provErr := factory.BuildForKind(ctx, cloudKind, log)
@@ -212,18 +223,22 @@ func runNmap(args []string, log logger.Logger) error {
 
 	// Destroy only after execution has actually started and export is done.
 	if *destroyAfter && started {
-		logStatus("Destroying infrastructure (--destroy-after)...")
-		if destroyErr := infra.RunDestroy(ctx, cfg, os.Stderr, log); destroyErr != nil {
-			if scanErr != nil {
-				return fmt.Errorf("scan failed: %w; additionally, destroy failed: %v", scanErr, destroyErr)
+		if cloudKind.IsSelfhostedFamily() {
+			logStatus("Skipping destroy: %s does not support auto-destroy", cloudKind.Canonical())
+		} else {
+			logStatus("Destroying infrastructure (--destroy-after)...")
+			if destroyErr := infra.RunDestroy(ctx, toolCfg, os.Stderr, log); destroyErr != nil {
+				if scanErr != nil {
+					return fmt.Errorf("scan failed: %w; additionally, destroy failed: %v", scanErr, destroyErr)
+				}
+				return fmt.Errorf("scan completed but destroy failed: %w", destroyErr)
 			}
-			return fmt.Errorf("scan completed but destroy failed: %w", destroyErr)
 		}
 	}
 
 	// Print run summary.
 	if started {
-		printRunSummary(jobID, "nmap", ensureResult.Reused, cleanupPolicy, exportDir)
+		printRunSummary(jobID, "nmap", reused, cleanupPolicy, exportDir)
 	}
 
 	return scanErr
@@ -240,10 +255,10 @@ func runNmapScan(ctx context.Context, tasks []nmap.ScanTask, workers int, comput
 	if err != nil {
 		return false, fmt.Errorf("building cloud provider: %w", err)
 	}
-	return runNmapScanWithDeps(ctx, tasks, workers, computeMode, jitterMax, format, outputs, provider.Queue(), provider.Storage(), provider.Compute(), tracker, jobID)
+	return runNmapScanWithDeps(ctx, tasks, workers, computeMode, jitterMax, format, outputs, provider.Queue(), provider.Storage(), provider.Compute(), tracker, jobID, cloudKind)
 }
 
-func runNmapScanWithDeps(ctx context.Context, tasks []nmap.ScanTask, workers int, computeMode string, jitterMax int, format string, outputs map[string]string, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, tracker *operator.Tracker, jobID string) (bool, error) {
+func runNmapScanWithDeps(ctx context.Context, tasks []nmap.ScanTask, workers int, computeMode string, jitterMax int, format string, outputs map[string]string, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, tracker *operator.Tracker, jobID string, cloudKind ...cloud.Kind) (bool, error) {
 	queueURL := outputs["sqs_queue_url"]
 	bucket := outputs["s3_bucket_name"]
 	if queueURL == "" || bucket == "" {
@@ -296,7 +311,9 @@ func runNmapScanWithDeps(ctx context.Context, tasks []nmap.ScanTask, workers int
 		"TOOL_NAME":          "nmap",
 	}
 
-	useSpot := resolveComputeMode(computeMode, workers)
+	// Selfhosted only supports RunContainer (no spot instances).
+	isSelfhosted := len(cloudKind) > 0 && cloudKind[0].IsSelfhostedFamily()
+	useSpot := !isSelfhosted && resolveComputeMode(computeMode, workers)
 	if useSpot {
 		ecrURL := outputs["ecr_repo_url"]
 		userData := awscloud.GenerateUserData(awscloud.UserDataOpts{
@@ -332,9 +349,9 @@ func runNmapScanWithDeps(ctx context.Context, tasks []nmap.ScanTask, workers int
 			Count:          workers,
 		})
 		if err != nil {
-			return false, fmt.Errorf("launching Fargate tasks: %w", err)
+			return false, fmt.Errorf("launching workers: %w", err)
 		}
-		logStatus("Launched %d Fargate tasks", workers)
+		logStatus("Launched %d workers", workers)
 	}
 
 	_ = tracker.UpdatePhase(jobID, operator.PhaseScanning)

--- a/cmd/heph/cmd_scan.go
+++ b/cmd/heph/cmd_scan.go
@@ -37,7 +37,7 @@ func runScan(args []string, log logger.Logger) error {
 	noDeploy := fs.Bool("no-deploy", false, "Fail instead of deploying or redeploying infrastructure")
 	autoApprove := fs.Bool("auto-approve", false, "Skip deploy confirmation prompts when lifecycle requires deploy")
 	destroyAfter := fs.Bool("destroy-after", false, "Destroy infrastructure after the run completes")
-	cloudFlag := fs.String("cloud", "", "Cloud provider: aws or selfhosted (default: from config or aws)")
+	cloudFlag := fs.String("cloud", "", "Cloud provider: "+cloud.SupportedKindsText()+" (default: from config or aws)")
 
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -55,7 +55,7 @@ func runScan(args []string, log logger.Logger) error {
 	if err != nil {
 		return err
 	}
-	if err := requireComputeSupport(cloudKind); err != nil {
+	if err := ValidateComputeMode(cloudKind, *computeMode); err != nil {
 		return err
 	}
 
@@ -64,9 +64,6 @@ func runScan(args []string, log logger.Logger) error {
 	}
 	if *format != "text" && *format != "json" {
 		return fmt.Errorf("--format must be text or json")
-	}
-	if *computeMode != "auto" && *computeMode != "fargate" && *computeMode != "spot" {
-		return fmt.Errorf("--compute-mode must be auto, fargate, or spot")
 	}
 	if *workers <= 0 {
 		return fmt.Errorf("--workers must be positive")
@@ -127,31 +124,49 @@ func runScan(args []string, log logger.Logger) error {
 		}
 	}
 
-	// Resolve tool config and ensure infrastructure.
-	cfg, err := infra.ResolveToolConfig(*tool)
-	if err != nil {
-		return err
-	}
-
 	ctx := mainContext()
-	region := infra.AWSRegion()
 
-	ensureResult, err := infra.EnsureInfra(ctx, cfg, infra.LifecyclePolicy{
-		NoDeploy:     *noDeploy,
-		AutoApprove:  *autoApprove,
-		DestroyAfter: *destroyAfter,
-	}, region, os.Stderr, deployPrompt, log)
-	if err != nil {
-		return err
+	var (
+		queueURL string
+		bucket   string
+		outputs  map[string]string
+		reused   bool
+		toolCfg  *infra.ToolConfig
+	)
+
+	if cloudKind.IsSelfhostedFamily() {
+		// Selfhosted: no Terraform/deploy — read queue ID and bucket from config.
+		shCfg := factory.SelfhostedConfigFromEnv()
+		queueURL = shCfg.QueueID
+		bucket = shCfg.Bucket
+		if queueURL == "" || bucket == "" {
+			return fmt.Errorf("%s requires SELFHOSTED_QUEUE_ID and SELFHOSTED_BUCKET environment variables", cloudKind.Canonical())
+		}
+	} else {
+		// AWS: resolve tool config and ensure infrastructure.
+		toolCfg, err = infra.ResolveToolConfig(*tool)
+		if err != nil {
+			return err
+		}
+		region := infra.AWSRegion()
+		ensureResult, ensureErr := infra.EnsureInfra(ctx, toolCfg, infra.LifecyclePolicy{
+			NoDeploy:     *noDeploy,
+			AutoApprove:  *autoApprove,
+			DestroyAfter: *destroyAfter,
+		}, region, os.Stderr, deployPrompt, log)
+		if ensureErr != nil {
+			return ensureErr
+		}
+		outputs = ensureResult.Outputs
+		reused = ensureResult.Reused
+		queueURL = outputs["sqs_queue_url"]
+		bucket = outputs["s3_bucket_name"]
+		if queueURL == "" || bucket == "" {
+			return fmt.Errorf("terraform outputs missing sqs_queue_url or s3_bucket_name")
+		}
 	}
-	outputs := ensureResult.Outputs
 
-	queueURL := outputs["sqs_queue_url"]
-	bucket := outputs["s3_bucket_name"]
-	if queueURL == "" || bucket == "" {
-		return fmt.Errorf("terraform outputs missing sqs_queue_url or s3_bucket_name")
-	}
-
+	// Build the cloud provider.
 	provider, err := factory.BuildForKind(ctx, cloudKind, log)
 	if err != nil {
 		return fmt.Errorf("building cloud provider: %w", err)
@@ -184,9 +199,9 @@ func runScan(args []string, log logger.Logger) error {
 		started bool
 	)
 	if mod.InputType == modules.InputTypeWordlist {
-		started, scanErr = runWordlistScan(ctx, *tool, jobID, *wordlistFile, wordlistContent, *runtimeTarget, *options, *chunks, *workers, *computeMode, *format, queue, storage, compute, outputs, bucket, queueURL, tracker)
+		started, scanErr = runWordlistScan(ctx, *tool, jobID, *wordlistFile, wordlistContent, *runtimeTarget, *options, *chunks, *workers, *computeMode, *format, queue, storage, compute, outputs, bucket, queueURL, tracker, cloudKind)
 	} else {
-		started, scanErr = runTargetListScan(ctx, *tool, jobID, *inputFile, targetContent, *options, *workers, *computeMode, *format, queue, storage, compute, outputs, bucket, queueURL, tracker)
+		started, scanErr = runTargetListScan(ctx, *tool, jobID, *inputFile, targetContent, *options, *workers, *computeMode, *format, queue, storage, compute, outputs, bucket, queueURL, tracker, cloudKind)
 	}
 
 	if scanErr != nil {
@@ -217,24 +232,28 @@ func runScan(args []string, log logger.Logger) error {
 
 	// Destroy only after execution has actually started and export is done.
 	if *destroyAfter && started {
-		logStatus("Destroying infrastructure (--destroy-after)...")
-		if destroyErr := infra.RunDestroy(ctx, cfg, os.Stderr, log); destroyErr != nil {
-			if scanErr != nil {
-				return fmt.Errorf("scan failed: %w; additionally, destroy failed: %v", scanErr, destroyErr)
+		if cloudKind.IsSelfhostedFamily() {
+			logStatus("Skipping destroy: %s does not support auto-destroy", cloudKind.Canonical())
+		} else {
+			logStatus("Destroying infrastructure (--destroy-after)...")
+			if destroyErr := infra.RunDestroy(ctx, toolCfg, os.Stderr, log); destroyErr != nil {
+				if scanErr != nil {
+					return fmt.Errorf("scan failed: %w; additionally, destroy failed: %v", scanErr, destroyErr)
+				}
+				return fmt.Errorf("scan completed but destroy failed: %w", destroyErr)
 			}
-			return fmt.Errorf("scan completed but destroy failed: %w", destroyErr)
 		}
 	}
 
 	// Print run summary.
 	if started {
-		printRunSummary(jobID, *tool, ensureResult.Reused, cleanupPolicy, exportDir)
+		printRunSummary(jobID, *tool, reused, cleanupPolicy, exportDir)
 	}
 
 	return scanErr
 }
 
-func runTargetListScan(ctx context.Context, tool, jobID, inputFile, content, options string, workers int, computeMode, format string, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, outputs map[string]string, bucket, queueURL string, tracker *operator.Tracker) (bool, error) {
+func runTargetListScan(ctx context.Context, tool, jobID, inputFile, content, options string, workers int, computeMode, format string, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, outputs map[string]string, bucket, queueURL string, tracker *operator.Tracker, cloudKind cloud.Kind) (bool, error) {
 	targets := parseTargetLines(content)
 	if len(targets) == 0 {
 		return false, fmt.Errorf("no targets found in %s", inputFile)
@@ -281,7 +300,7 @@ func runTargetListScan(ctx context.Context, tool, jobID, inputFile, content, opt
 	_ = tracker.UpdatePhase(jobID, operator.PhaseLaunching)
 
 	// Launch workers.
-	if err := launchGenericWorkers(ctx, tool, workers, computeMode, compute, outputs, queueURL, bucket); err != nil {
+	if err := launchGenericWorkers(ctx, tool, workers, computeMode, compute, outputs, queueURL, bucket, cloudKind); err != nil {
 		return false, err
 	}
 
@@ -291,7 +310,7 @@ func runTargetListScan(ctx context.Context, tool, jobID, inputFile, content, opt
 	return true, pollAndOutput(ctx, storage, bucket, tool, jobID, len(tasks), "targets", format)
 }
 
-func runWordlistScan(ctx context.Context, tool, jobID, wordlistFile, content, runtimeTarget, options string, chunks, workers int, computeMode, format string, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, outputs map[string]string, bucket, queueURL string, tracker *operator.Tracker) (bool, error) {
+func runWordlistScan(ctx context.Context, tool, jobID, wordlistFile, content, runtimeTarget, options string, chunks, workers int, computeMode, format string, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, outputs map[string]string, bucket, queueURL string, tracker *operator.Tracker, cloudKind cloud.Kind) (bool, error) {
 	if chunks <= 0 {
 		chunks = workers
 	}
@@ -347,7 +366,7 @@ func runWordlistScan(ctx context.Context, tool, jobID, wordlistFile, content, ru
 	_ = tracker.UpdatePhase(jobID, operator.PhaseLaunching)
 
 	// Launch workers.
-	if err := launchGenericWorkers(ctx, tool, workers, computeMode, compute, outputs, queueURL, bucket); err != nil {
+	if err := launchGenericWorkers(ctx, tool, workers, computeMode, compute, outputs, queueURL, bucket, cloudKind); err != nil {
 		return false, err
 	}
 
@@ -382,7 +401,7 @@ func preflightWordlistFile(tool, path, runtimeTarget, options string, chunks, wo
 	return string(content), nil
 }
 
-func launchGenericWorkers(ctx context.Context, tool string, workers int, computeMode string, compute cloud.Compute, outputs map[string]string, queueURL, bucket string) error {
+func launchGenericWorkers(ctx context.Context, tool string, workers int, computeMode string, compute cloud.Compute, outputs map[string]string, queueURL, bucket string, cloudKind cloud.Kind) error {
 	logStatus("Launching %d workers (mode: %s)...", workers, computeMode)
 	launchCtx, launchCancel := context.WithTimeout(ctx, launchTimeout)
 	defer launchCancel()
@@ -394,7 +413,8 @@ func launchGenericWorkers(ctx context.Context, tool string, workers int, compute
 		"TOOL_NAME": tool,
 	}
 
-	useSpot := resolveComputeMode(computeMode, workers)
+	// Selfhosted only supports RunContainer (no spot instances).
+	useSpot := !cloudKind.IsSelfhostedFamily() && resolveComputeMode(computeMode, workers)
 	if useSpot {
 		ecrURL := outputs["ecr_repo_url"]
 		userData := awscloud.GenerateUserData(awscloud.UserDataOpts{
@@ -430,9 +450,9 @@ func launchGenericWorkers(ctx context.Context, tool string, workers int, compute
 			Count:          workers,
 		})
 		if err != nil {
-			return fmt.Errorf("launching Fargate tasks: %w", err)
+			return fmt.Errorf("launching workers: %w", err)
 		}
-		logStatus("Launched %d Fargate tasks", workers)
+		logStatus("Launched %d workers", workers)
 	}
 	return nil
 }

--- a/cmd/heph/main_test.go
+++ b/cmd/heph/main_test.go
@@ -69,7 +69,7 @@ func TestNmapInvalidComputeMode(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid compute mode")
 	}
-	if !strings.Contains(err.Error(), "--compute-mode must be") {
+	if !strings.Contains(err.Error(), "compute-mode must be") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -194,7 +194,7 @@ func TestScanInvalidComputeMode(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid compute mode")
 	}
-	if !strings.Contains(err.Error(), "--compute-mode must be") {
+	if !strings.Contains(err.Error(), "compute-mode must be") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -331,12 +331,19 @@ func TestNmapCloudInvalidValue(t *testing.T) {
 	}
 }
 
-func TestNmapCloudSelfhostedRejected(t *testing.T) {
-	err := run([]string{"nmap", "--file", "targets.txt", "--cloud", "selfhosted"}, testLogger())
+func TestNmapCloudProviderRequiresEnv(t *testing.T) {
+	t.Setenv("SELFHOSTED_QUEUE_ID", "")
+	t.Setenv("SELFHOSTED_BUCKET", "")
+
+	dir := t.TempDir()
+	f := dir + "/targets.txt"
+	_ = os.WriteFile(f, []byte("1.1.1.1\n"), 0o644)
+
+	err := run([]string{"nmap", "--file", f, "--cloud", "manual"}, testLogger())
 	if err == nil {
-		t.Fatal("expected error for selfhosted cloud (compute not supported)")
+		t.Fatal("expected error for manual without env config")
 	}
-	if !strings.Contains(err.Error(), "selfhosted compute") {
+	if !strings.Contains(err.Error(), "manual requires SELFHOSTED_QUEUE_ID") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -351,46 +358,73 @@ func TestScanCloudInvalidValue(t *testing.T) {
 	}
 }
 
-func TestScanCloudSelfhostedRejected(t *testing.T) {
-	err := run([]string{"scan", "--tool", "httpx", "--file", "targets.txt", "--cloud", "selfhosted"}, testLogger())
+func TestScanCloudProviderRequiresEnv(t *testing.T) {
+	t.Setenv("SELFHOSTED_QUEUE_ID", "")
+	t.Setenv("SELFHOSTED_BUCKET", "")
+
+	dir := t.TempDir()
+	f := dir + "/targets.txt"
+	_ = os.WriteFile(f, []byte("example.com\n"), 0o644)
+
+	err := run([]string{"scan", "--tool", "httpx", "--file", f, "--cloud", "hetzner"}, testLogger())
 	if err == nil {
-		t.Fatal("expected error for selfhosted cloud")
+		t.Fatal("expected error for provider without env config")
 	}
-	if !strings.Contains(err.Error(), "selfhosted compute") {
+	if !strings.Contains(err.Error(), "hetzner requires SELFHOSTED_QUEUE_ID") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestInfraDeployCloudSelfhostedRejected(t *testing.T) {
-	err := run([]string{"infra", "deploy", "--tool", "nmap", "--cloud", "selfhosted"}, testLogger())
+func TestNmapCloudManualRejectsFargate(t *testing.T) {
+	err := run([]string{"nmap", "--file", "targets.txt", "--cloud", "manual", "--compute-mode", "fargate"}, testLogger())
 	if err == nil {
-		t.Fatal("expected error for selfhosted cloud")
+		t.Fatal("expected error for manual + fargate")
 	}
-	if !strings.Contains(err.Error(), "selfhosted infrastructure deploy") {
+	if !strings.Contains(err.Error(), `provider "manual" only supports`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestInfraDestroyCloudSelfhostedRejected(t *testing.T) {
-	err := run([]string{"infra", "destroy", "--tool", "nmap", "--auto-approve", "--cloud", "selfhosted"}, testLogger())
+func TestScanCloudProviderRejectsSpot(t *testing.T) {
+	err := run([]string{"scan", "--tool", "httpx", "--file", "targets.txt", "--cloud", "linode", "--compute-mode", "spot"}, testLogger())
 	if err == nil {
-		t.Fatal("expected error for selfhosted cloud")
+		t.Fatal("expected error for VPS provider + spot")
 	}
-	if !strings.Contains(err.Error(), "selfhosted infrastructure deploy") {
+	if !strings.Contains(err.Error(), `provider "linode" only supports`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestStatusCloudSelfhostedAccepted(t *testing.T) {
-	// status --cloud selfhosted should not be rejected at the cloud validation
-	// layer — only compute/deploy paths reject selfhosted. status needs a
+func TestInfraDeployCloudProviderRejected(t *testing.T) {
+	err := run([]string{"infra", "deploy", "--tool", "nmap", "--cloud", "hetzner"}, testLogger())
+	if err == nil {
+		t.Fatal("expected error for VPS provider")
+	}
+	if !strings.Contains(err.Error(), "hetzner infrastructure deploy/destroy lands in PR 6.3") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestInfraDestroyCloudProviderRejected(t *testing.T) {
+	err := run([]string{"infra", "destroy", "--tool", "nmap", "--auto-approve", "--cloud", "manual"}, testLogger())
+	if err == nil {
+		t.Fatal("expected error for manual cloud")
+	}
+	if !strings.Contains(err.Error(), "manual infrastructure deploy/destroy lands in PR 6.3") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestStatusCloudProviderAccepted(t *testing.T) {
+	// status --cloud manual should not be rejected at the cloud validation
+	// layer — only compute/deploy paths reject VPS providers. status needs a
 	// valid job record to proceed, so it will fail on that instead.
-	err := run([]string{"status", "--job-id", "nonexistent-job", "--cloud", "selfhosted"}, testLogger())
+	err := run([]string{"status", "--job-id", "nonexistent-job", "--cloud", "manual"}, testLogger())
 	if err == nil {
 		t.Fatal("expected error (job not found)")
 	}
-	if strings.Contains(err.Error(), "selfhosted") && strings.Contains(err.Error(), "compute") {
-		t.Fatalf("status should not reject selfhosted cloud: %v", err)
+	if strings.Contains(err.Error(), "manual") && strings.Contains(err.Error(), "compute") {
+		t.Fatalf("status should not reject manual cloud: %v", err)
 	}
 }
 
@@ -412,6 +446,39 @@ func TestScanCloudAWSExplicitAccepted(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "unsupported cloud") || strings.Contains(err.Error(), "selfhosted") {
 		t.Fatalf("--cloud aws should be accepted: %v", err)
+	}
+}
+
+func TestNmapCloudProviderAutoAccepted(t *testing.T) {
+	// manual + auto (default) should pass cloud/compute validation
+	// and proceed to file read. It fails there because the file doesn't exist.
+	err := run([]string{"nmap", "--file", "/nonexistent/targets.txt", "--cloud", "manual"}, testLogger())
+	if err == nil {
+		t.Fatal("expected error (file not found)")
+	}
+	// Should NOT fail on cloud or compute-mode validation.
+	if strings.Contains(err.Error(), "unsupported cloud") || strings.Contains(err.Error(), `provider "manual" only supports`) {
+		t.Fatalf("manual + auto should pass validation: %v", err)
+	}
+}
+
+func TestScanCloudNamedProviderAutoAccepted(t *testing.T) {
+	err := run([]string{"scan", "--tool", "httpx", "--file", "/nonexistent/targets.txt", "--cloud", "hetzner"}, testLogger())
+	if err == nil {
+		t.Fatal("expected error (file not found)")
+	}
+	if strings.Contains(err.Error(), "unsupported cloud") || strings.Contains(err.Error(), `provider "hetzner" only supports`) {
+		t.Fatalf("hetzner + auto should pass validation: %v", err)
+	}
+}
+
+func TestNmapCloudProviderRejectsSpot(t *testing.T) {
+	err := run([]string{"nmap", "--file", "targets.txt", "--cloud", "vultr", "--compute-mode", "spot"}, testLogger())
+	if err == nil {
+		t.Fatal("expected error for VPS provider + spot")
+	}
+	if !strings.Contains(err.Error(), `provider "vultr" only supports`) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/deployments/selfhosted/controller/main.tf
+++ b/deployments/selfhosted/controller/main.tf
@@ -1,0 +1,40 @@
+# Selfhosted controller module — generates cloud-init bootstrap and credentials
+# for a controller VM running NATS JetStream, MinIO, and a Docker registry.
+#
+# This module does NOT provision the VM itself. Provider-specific modules
+# (e.g. deployments/hetzner/) compose this module and pass its cloud_init
+# output as the VM's user_data. This keeps the controller logic portable
+# across any VPS provider that supports cloud-init.
+#
+# PR 6.3 will add the first provider-specific composition (Hetzner).
+
+terraform {
+  required_version = ">= 1.3"
+}
+
+# --- Credential generation ---
+
+resource "random_password" "minio_secret_key" {
+  length  = 40
+  special = false
+}
+
+resource "random_id" "minio_access_key" {
+  byte_length = 10
+}
+
+# --- Cloud-init rendering ---
+
+locals {
+  cloud_init = templatefile("${path.module}/templates/cloud-init.yaml", {
+    minio_access_key   = random_id.minio_access_key.hex
+    minio_secret_key   = random_password.minio_secret_key.result
+    minio_bucket       = var.minio_bucket
+    minio_port         = var.minio_port
+    minio_console_port = var.minio_console_port
+    nats_port          = var.nats_port
+    nats_monitor_port  = var.nats_monitor_port
+    nats_stream_name   = var.nats_stream_name
+    registry_port      = var.registry_port
+  })
+}

--- a/deployments/selfhosted/controller/outputs.tf
+++ b/deployments/selfhosted/controller/outputs.tf
@@ -1,0 +1,63 @@
+# Output names map onto the selfhosted env family so that future PR 6.3
+# deploy UX can wire these directly into the operator's environment.
+#
+# Sensitive outputs are marked so Terraform does not display them in plan
+# or apply output. The infra.RedactOutputs helper provides a second layer
+# when reading outputs programmatically.
+
+output "tool_name" {
+  description = "Tool name (passed through for lifecycle mismatch detection)."
+  value       = var.tool_name
+}
+
+output "nats_url" {
+  description = "NATS client URL for workers and the operator CLI."
+  value       = "nats://${var.controller_ip}:${var.nats_port}"
+}
+
+output "nats_stream" {
+  description = "NATS JetStream stream name."
+  value       = var.nats_stream_name
+}
+
+output "s3_endpoint" {
+  description = "MinIO S3-compatible endpoint URL."
+  value       = "http://${var.controller_ip}:${var.minio_port}"
+}
+
+output "s3_region" {
+  description = "S3 region (MinIO ignores this but clients require it)."
+  value       = "us-east-1"
+}
+
+output "s3_access_key" {
+  description = "MinIO root access key."
+  value       = random_id.minio_access_key.hex
+  sensitive   = true
+}
+
+output "s3_secret_key" {
+  description = "MinIO root secret key."
+  value       = random_password.minio_secret_key.result
+  sensitive   = true
+}
+
+output "s3_path_style" {
+  description = "Whether to use path-style S3 access (always true for MinIO)."
+  value       = "true"
+}
+
+output "s3_bucket_name" {
+  description = "Default storage bucket name."
+  value       = var.minio_bucket
+}
+
+output "registry_url" {
+  description = "Docker registry URL for worker image distribution."
+  value       = "${var.controller_ip}:${var.registry_port}"
+}
+
+output "cloud_init" {
+  description = "Rendered cloud-init content for the controller VM. Pass this as user_data to the provider-specific VM resource."
+  value       = local.cloud_init
+}

--- a/deployments/selfhosted/controller/templates/cloud-init.yaml
+++ b/deployments/selfhosted/controller/templates/cloud-init.yaml
@@ -1,0 +1,116 @@
+#cloud-config
+# Selfhosted controller bootstrap — installs Docker and starts NATS JetStream,
+# MinIO, and a Docker registry as systemd-managed containers.
+#
+# This template is rendered by the controller Terraform module with credentials
+# and port variables injected at plan time.
+
+package_update: true
+
+packages:
+  - docker.io
+  - jq
+
+write_files:
+  # --- NATS JetStream ---
+  - path: /etc/systemd/system/nats.service
+    content: |
+      [Unit]
+      Description=NATS JetStream
+      After=docker.service
+      Requires=docker.service
+
+      [Service]
+      Restart=always
+      RestartSec=5
+      ExecStartPre=-/usr/bin/docker rm -f nats
+      ExecStart=/usr/bin/docker run --name nats \
+        -p ${nats_port}:4222 \
+        -p ${nats_monitor_port}:8222 \
+        -v /data/nats:/data \
+        nats:latest -js -sd /data
+      ExecStop=/usr/bin/docker stop nats
+
+      [Install]
+      WantedBy=multi-user.target
+
+  # --- MinIO ---
+  - path: /etc/systemd/system/minio.service
+    content: |
+      [Unit]
+      Description=MinIO Object Storage
+      After=docker.service
+      Requires=docker.service
+
+      [Service]
+      Restart=always
+      RestartSec=5
+      ExecStartPre=-/usr/bin/docker rm -f minio
+      ExecStart=/usr/bin/docker run --name minio \
+        -p ${minio_port}:9000 \
+        -p ${minio_console_port}:9001 \
+        -v /data/minio:/data \
+        -e MINIO_ROOT_USER=${minio_access_key} \
+        -e MINIO_ROOT_PASSWORD=${minio_secret_key} \
+        minio/minio server /data --console-address :9001
+      ExecStop=/usr/bin/docker stop minio
+
+      [Install]
+      WantedBy=multi-user.target
+
+  # --- Docker Registry ---
+  - path: /etc/systemd/system/registry.service
+    content: |
+      [Unit]
+      Description=Docker Registry
+      After=docker.service
+      Requires=docker.service
+
+      [Service]
+      Restart=always
+      RestartSec=5
+      ExecStartPre=-/usr/bin/docker rm -f registry
+      ExecStart=/usr/bin/docker run --name registry \
+        -p ${registry_port}:5000 \
+        -v /data/registry:/var/lib/registry \
+        registry:2
+      ExecStop=/usr/bin/docker stop registry
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  - mkdir -p /data/nats /data/minio /data/registry
+  - systemctl daemon-reload
+  - systemctl enable --now docker
+  - systemctl enable --now nats
+  - systemctl enable --now minio
+  - systemctl enable --now registry
+
+  # Bootstrap MinIO bucket — retry until MinIO is healthy.
+  - |
+    for i in $(seq 1 30); do
+      docker run --rm --entrypoint sh minio/mc -c "
+        mc alias set local http://localhost:${minio_port} ${minio_access_key} ${minio_secret_key} &&
+        mc mb --ignore-existing local/${minio_bucket}
+      " && break
+      sleep 2
+    done
+
+  # Bootstrap NATS JetStream stream — retry until NATS is healthy.
+  # Retention=WorkQueue ensures each message is delivered to exactly one worker.
+  # max-deliver=3 acts as a dead-letter threshold (matches SQS DLQ semantics).
+  # ack-wait=5m matches SQS visibility timeout for long-running scans.
+  - |
+    for i in $(seq 1 30); do
+      docker run --rm natsio/nats-box nats -s nats://host.docker.internal:${nats_port} \
+        stream add ${nats_stream_name} \
+        --subjects="${nats_stream_name}.*" \
+        --retention=work \
+        --max-deliver=3 \
+        --ack-wait=5m \
+        --discard=old \
+        --storage=file \
+        --defaults && break
+      sleep 2
+    done

--- a/deployments/selfhosted/controller/variables.tf
+++ b/deployments/selfhosted/controller/variables.tf
@@ -1,0 +1,51 @@
+variable "controller_ip" {
+  description = "Public IP address of the controller VM. Used to construct service endpoint URLs in outputs."
+  type        = string
+}
+
+variable "tool_name" {
+  description = "Tool name for lifecycle mismatch detection (passed through to outputs)."
+  type        = string
+}
+
+variable "minio_bucket" {
+  description = "Default MinIO bucket name, created during cloud-init bootstrap."
+  type        = string
+  default     = "heph-results"
+}
+
+variable "nats_port" {
+  description = "NATS client port."
+  type        = number
+  default     = 4222
+}
+
+variable "nats_monitor_port" {
+  description = "NATS HTTP monitoring port."
+  type        = number
+  default     = 8222
+}
+
+variable "nats_stream_name" {
+  description = "NATS JetStream stream name for task distribution."
+  type        = string
+  default     = "heph-tasks"
+}
+
+variable "minio_port" {
+  description = "MinIO S3 API port."
+  type        = number
+  default     = 9000
+}
+
+variable "minio_console_port" {
+  description = "MinIO web console port."
+  type        = number
+  default     = 9001
+}
+
+variable "registry_port" {
+  description = "Docker registry port."
+  type        = number
+  default     = 5000
+}

--- a/internal/cloud/factory/factory.go
+++ b/internal/cloud/factory/factory.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 
 	"heph4estus/internal/cloud"
 	awscloud "heph4estus/internal/cloud/aws"
@@ -25,8 +27,8 @@ type AWSConfig struct {
 }
 
 // SelfhostedConfig describes the explicit endpoints and credentials needed
-// for the selfhosted provider. PR 6.1 Track 0 only persists the shape; later
-// tracks attach the actual NATS and S3-compatible client code.
+// for the selfhosted provider (NATS JetStream, S3-compatible storage,
+// Docker-over-SSH compute).
 type SelfhostedConfig struct {
 	// NATS JetStream queue settings.
 	NATSURL        string
@@ -41,6 +43,17 @@ type SelfhostedConfig struct {
 	S3AccessKey string
 	S3Secret    string
 	S3PathStyle bool
+
+	// Scan runtime settings — queue identifier and bucket for scan execution.
+	QueueID string // Queue identifier (SQS URL or NATS subject)
+	Bucket  string // Storage bucket name
+
+	// Compute settings for SSH/Docker workers.
+	WorkerHosts []string // SSH-reachable worker addresses
+	SSHUser     string   // SSH login user
+	SSHKeyPath  string   // path to private key
+	SSHPort     int      // SSH port (0 means default 22)
+	DockerImage string   // Docker image reference for the worker container
 }
 
 // Config is the input to Build. Exactly one of AWS or Selfhosted should be
@@ -59,15 +72,15 @@ func Build(cfg Config) (cloud.Provider, error) {
 	if cfg.Logger == nil {
 		return nil, fmt.Errorf("factory: logger is required")
 	}
-	switch cfg.Kind {
+	switch cfg.Kind.RuntimeFamily() {
 	case cloud.KindAWS, "":
 		if cfg.AWS == nil {
 			return nil, fmt.Errorf("factory: AWS config is required for cloud %q", cloud.KindAWS)
 		}
 		return awscloud.NewProvider(cfg.AWS.SDKConfig, cfg.Logger), nil
-	case cloud.KindSelfhosted:
+	case cloud.KindManual:
 		if cfg.Selfhosted == nil {
-			return nil, fmt.Errorf("factory: selfhosted config is required for cloud %q", cloud.KindSelfhosted)
+			return nil, fmt.Errorf("factory: selfhosted config is required for cloud %q", cfg.Kind.Canonical())
 		}
 		pcfg := selfhosted.ProviderConfig{
 			Storage: selfhosted.StorageConfig{
@@ -87,6 +100,15 @@ func Build(cfg Config) (cloud.Provider, error) {
 				MaxDeliver:     cfg.Selfhosted.MaxDeliver,
 			}
 		}
+		if len(cfg.Selfhosted.WorkerHosts) > 0 {
+			pcfg.Compute = &selfhosted.ComputeConfig{
+				WorkerHosts: cfg.Selfhosted.WorkerHosts,
+				SSHUser:     cfg.Selfhosted.SSHUser,
+				SSHKeyPath:  cfg.Selfhosted.SSHKeyPath,
+				SSHPort:     cfg.Selfhosted.SSHPort,
+				DockerImage: cfg.Selfhosted.DockerImage,
+			}
+		}
 		return selfhosted.NewProvider(pcfg, cfg.Logger)
 	default:
 		return nil, fmt.Errorf("factory: unsupported cloud %q", cfg.Kind)
@@ -97,7 +119,7 @@ func Build(cfg Config) (cloud.Provider, error) {
 // environment variables. CLI, TUI, and worker paths use this so endpoint
 // configuration is centralised in one place.
 func SelfhostedConfigFromEnv() *SelfhostedConfig {
-	return &SelfhostedConfig{
+	cfg := &SelfhostedConfig{
 		NATSURL:     os.Getenv("NATS_URL"),
 		StreamName:  os.Getenv("NATS_STREAM"),
 		S3Endpoint:  os.Getenv("S3_ENDPOINT"),
@@ -105,7 +127,25 @@ func SelfhostedConfigFromEnv() *SelfhostedConfig {
 		S3AccessKey: os.Getenv("S3_ACCESS_KEY"),
 		S3Secret:    os.Getenv("S3_SECRET_KEY"),
 		S3PathStyle: os.Getenv("S3_PATH_STYLE") == "true",
+
+		// Scan runtime settings.
+		QueueID: os.Getenv("SELFHOSTED_QUEUE_ID"),
+		Bucket:  os.Getenv("SELFHOSTED_BUCKET"),
+
+		// Compute settings.
+		SSHUser:     os.Getenv("SELFHOSTED_SSH_USER"),
+		SSHKeyPath:  os.Getenv("SELFHOSTED_SSH_KEY_PATH"),
+		DockerImage: os.Getenv("SELFHOSTED_DOCKER_IMAGE"),
 	}
+	if hosts := os.Getenv("SELFHOSTED_WORKER_HOSTS"); hosts != "" {
+		cfg.WorkerHosts = splitCommaList(hosts)
+	}
+	if port := os.Getenv("SELFHOSTED_SSH_PORT"); port != "" {
+		if p, err := strconv.Atoi(port); err == nil && p > 0 {
+			cfg.SSHPort = p
+		}
+	}
+	return cfg
 }
 
 // BuildForKind constructs a provider for the given kind, loading
@@ -113,7 +153,7 @@ func SelfhostedConfigFromEnv() *SelfhostedConfig {
 // default SDK credential chain; for selfhosted it reads NATS_URL,
 // S3_ENDPOINT, and related env vars via SelfhostedConfigFromEnv.
 func BuildForKind(ctx context.Context, kind cloud.Kind, log logger.Logger) (cloud.Provider, error) {
-	switch kind {
+	switch kind.RuntimeFamily() {
 	case cloud.KindAWS, "":
 		sdkCfg, err := awscfg.LoadDefaultConfig(ctx)
 		if err != nil {
@@ -124,9 +164,9 @@ func BuildForKind(ctx context.Context, kind cloud.Kind, log logger.Logger) (clou
 			AWS:    &AWSConfig{SDKConfig: sdkCfg},
 			Logger: log,
 		})
-	case cloud.KindSelfhosted:
+	case cloud.KindManual:
 		return Build(Config{
-			Kind:       cloud.KindSelfhosted,
+			Kind:       kind.Canonical(),
 			Selfhosted: SelfhostedConfigFromEnv(),
 			Logger:     log,
 		})
@@ -140,4 +180,16 @@ func envOr(key, fallback string) string {
 		return v
 	}
 	return fallback
+}
+
+// splitCommaList splits a comma-separated string into trimmed, non-empty parts.
+func splitCommaList(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/internal/cloud/factory/factory_test.go
+++ b/internal/cloud/factory/factory_test.go
@@ -136,7 +136,10 @@ func TestSelfhostedConfigFromEnv(t *testing.T) {
 }
 
 func TestSelfhostedConfigFromEnv_Defaults(t *testing.T) {
-	for _, k := range []string{"NATS_URL", "NATS_STREAM", "S3_ENDPOINT", "S3_REGION", "S3_ACCESS_KEY", "S3_SECRET_KEY", "S3_PATH_STYLE"} {
+	for _, k := range []string{
+		"NATS_URL", "NATS_STREAM", "S3_ENDPOINT", "S3_REGION", "S3_ACCESS_KEY", "S3_SECRET_KEY", "S3_PATH_STYLE",
+		"SELFHOSTED_WORKER_HOSTS", "SELFHOSTED_SSH_USER", "SELFHOSTED_SSH_KEY_PATH", "SELFHOSTED_SSH_PORT", "SELFHOSTED_DOCKER_IMAGE",
+	} {
 		t.Setenv(k, "")
 	}
 
@@ -150,5 +153,178 @@ func TestSelfhostedConfigFromEnv_Defaults(t *testing.T) {
 	}
 	if cfg.S3PathStyle {
 		t.Error("S3PathStyle should default to false")
+	}
+	if len(cfg.WorkerHosts) != 0 {
+		t.Errorf("WorkerHosts should be empty, got %v", cfg.WorkerHosts)
+	}
+	if cfg.SSHUser != "" {
+		t.Errorf("SSHUser should be empty, got %q", cfg.SSHUser)
+	}
+	if cfg.SSHKeyPath != "" {
+		t.Errorf("SSHKeyPath should be empty, got %q", cfg.SSHKeyPath)
+	}
+	if cfg.SSHPort != 0 {
+		t.Errorf("SSHPort should be 0, got %d", cfg.SSHPort)
+	}
+	if cfg.DockerImage != "" {
+		t.Errorf("DockerImage should be empty, got %q", cfg.DockerImage)
+	}
+}
+
+func TestSelfhostedConfigFromEnv_ComputeFields(t *testing.T) {
+	t.Setenv("SELFHOSTED_WORKER_HOSTS", "10.0.0.1, 10.0.0.2, 10.0.0.3")
+	t.Setenv("SELFHOSTED_SSH_USER", "heph")
+	t.Setenv("SELFHOSTED_SSH_KEY_PATH", "/home/heph/.ssh/id_ed25519")
+	t.Setenv("SELFHOSTED_SSH_PORT", "2222")
+	t.Setenv("SELFHOSTED_DOCKER_IMAGE", "ghcr.io/heph/worker:latest")
+
+	// Clear storage/queue vars to isolate the test.
+	for _, k := range []string{"NATS_URL", "NATS_STREAM", "S3_ENDPOINT", "S3_REGION", "S3_ACCESS_KEY", "S3_SECRET_KEY", "S3_PATH_STYLE"} {
+		t.Setenv(k, "")
+	}
+
+	cfg := SelfhostedConfigFromEnv()
+
+	if len(cfg.WorkerHosts) != 3 {
+		t.Fatalf("WorkerHosts = %v, want 3 entries", cfg.WorkerHosts)
+	}
+	if cfg.WorkerHosts[0] != "10.0.0.1" || cfg.WorkerHosts[1] != "10.0.0.2" || cfg.WorkerHosts[2] != "10.0.0.3" {
+		t.Errorf("WorkerHosts = %v", cfg.WorkerHosts)
+	}
+	if cfg.SSHUser != "heph" {
+		t.Errorf("SSHUser = %q", cfg.SSHUser)
+	}
+	if cfg.SSHKeyPath != "/home/heph/.ssh/id_ed25519" {
+		t.Errorf("SSHKeyPath = %q", cfg.SSHKeyPath)
+	}
+	if cfg.SSHPort != 2222 {
+		t.Errorf("SSHPort = %d", cfg.SSHPort)
+	}
+	if cfg.DockerImage != "ghcr.io/heph/worker:latest" {
+		t.Errorf("DockerImage = %q", cfg.DockerImage)
+	}
+}
+
+func TestSelfhostedConfigFromEnv_QueueAndBucket(t *testing.T) {
+	t.Setenv("SELFHOSTED_QUEUE_ID", "scan-stream")
+	t.Setenv("SELFHOSTED_BUCKET", "results-bucket")
+	// Clear other vars.
+	for _, k := range []string{"NATS_URL", "NATS_STREAM", "S3_ENDPOINT", "S3_REGION", "S3_ACCESS_KEY", "S3_SECRET_KEY", "S3_PATH_STYLE",
+		"SELFHOSTED_WORKER_HOSTS", "SELFHOSTED_SSH_USER", "SELFHOSTED_SSH_KEY_PATH", "SELFHOSTED_SSH_PORT", "SELFHOSTED_DOCKER_IMAGE"} {
+		t.Setenv(k, "")
+	}
+
+	cfg := SelfhostedConfigFromEnv()
+	if cfg.QueueID != "scan-stream" {
+		t.Errorf("QueueID = %q, want scan-stream", cfg.QueueID)
+	}
+	if cfg.Bucket != "results-bucket" {
+		t.Errorf("Bucket = %q, want results-bucket", cfg.Bucket)
+	}
+}
+
+func TestSelfhostedConfigFromEnv_SingleWorkerHost(t *testing.T) {
+	t.Setenv("SELFHOSTED_WORKER_HOSTS", "worker.example.com")
+	for _, k := range []string{"NATS_URL", "NATS_STREAM", "S3_ENDPOINT", "S3_REGION", "S3_ACCESS_KEY", "S3_SECRET_KEY", "S3_PATH_STYLE",
+		"SELFHOSTED_SSH_USER", "SELFHOSTED_SSH_KEY_PATH", "SELFHOSTED_SSH_PORT", "SELFHOSTED_DOCKER_IMAGE"} {
+		t.Setenv(k, "")
+	}
+
+	cfg := SelfhostedConfigFromEnv()
+	if len(cfg.WorkerHosts) != 1 || cfg.WorkerHosts[0] != "worker.example.com" {
+		t.Errorf("WorkerHosts = %v, want [worker.example.com]", cfg.WorkerHosts)
+	}
+}
+
+func TestSelfhostedConfigFromEnv_FullScanRuntime(t *testing.T) {
+	// Prove the full selfhosted scan runtime env contract is parsed correctly.
+	t.Setenv("NATS_URL", "nats://ctrl:4222")
+	t.Setenv("NATS_STREAM", "heph-tasks")
+	t.Setenv("S3_ENDPOINT", "http://ctrl:9000")
+	t.Setenv("S3_REGION", "us-east-1")
+	t.Setenv("S3_ACCESS_KEY", "minioadmin")
+	t.Setenv("S3_SECRET_KEY", "minioadmin")
+	t.Setenv("S3_PATH_STYLE", "true")
+	t.Setenv("SELFHOSTED_QUEUE_ID", "heph-tasks")
+	t.Setenv("SELFHOSTED_BUCKET", "heph-results")
+	t.Setenv("SELFHOSTED_WORKER_HOSTS", "w1.example.com,w2.example.com")
+	t.Setenv("SELFHOSTED_SSH_USER", "heph")
+	t.Setenv("SELFHOSTED_SSH_KEY_PATH", "/home/heph/.ssh/id_ed25519")
+	t.Setenv("SELFHOSTED_SSH_PORT", "22")
+	t.Setenv("SELFHOSTED_DOCKER_IMAGE", "ctrl:5000/heph-nmap-worker:latest")
+
+	cfg := SelfhostedConfigFromEnv()
+
+	// Queue/bucket (scan runtime contract).
+	if cfg.QueueID != "heph-tasks" {
+		t.Errorf("QueueID = %q", cfg.QueueID)
+	}
+	if cfg.Bucket != "heph-results" {
+		t.Errorf("Bucket = %q", cfg.Bucket)
+	}
+
+	// Transport endpoints.
+	if cfg.NATSURL != "nats://ctrl:4222" {
+		t.Errorf("NATSURL = %q", cfg.NATSURL)
+	}
+	if cfg.S3Endpoint != "http://ctrl:9000" {
+		t.Errorf("S3Endpoint = %q", cfg.S3Endpoint)
+	}
+
+	// Compute.
+	if len(cfg.WorkerHosts) != 2 {
+		t.Fatalf("WorkerHosts = %v", cfg.WorkerHosts)
+	}
+	if cfg.SSHUser != "heph" {
+		t.Errorf("SSHUser = %q", cfg.SSHUser)
+	}
+	if cfg.SSHPort != 22 {
+		t.Errorf("SSHPort = %d", cfg.SSHPort)
+	}
+	if cfg.DockerImage != "ctrl:5000/heph-nmap-worker:latest" {
+		t.Errorf("DockerImage = %q", cfg.DockerImage)
+	}
+}
+
+func TestSelfhostedConfigFromEnv_InvalidSSHPortIgnored(t *testing.T) {
+	t.Setenv("SELFHOSTED_SSH_PORT", "not-a-number")
+	for _, k := range []string{"NATS_URL", "S3_ENDPOINT", "S3_REGION", "S3_ACCESS_KEY", "S3_SECRET_KEY", "S3_PATH_STYLE",
+		"SELFHOSTED_WORKER_HOSTS", "SELFHOSTED_SSH_USER", "SELFHOSTED_SSH_KEY_PATH", "SELFHOSTED_DOCKER_IMAGE",
+		"SELFHOSTED_QUEUE_ID", "SELFHOSTED_BUCKET", "NATS_STREAM"} {
+		t.Setenv(k, "")
+	}
+
+	cfg := SelfhostedConfigFromEnv()
+	if cfg.SSHPort != 0 {
+		t.Errorf("expected SSHPort 0 for invalid input, got %d", cfg.SSHPort)
+	}
+}
+
+func TestBuildSelfhostedWithComputeConfig(t *testing.T) {
+	p, err := Build(Config{
+		Kind: cloud.KindSelfhosted,
+		Selfhosted: &SelfhostedConfig{
+			S3Endpoint:  "https://minio.example:9000",
+			S3Region:    "us-east-1",
+			S3AccessKey: "ak",
+			S3Secret:    "sk",
+			S3PathStyle: true,
+			WorkerHosts: []string{"10.0.0.1", "10.0.0.2"},
+			SSHUser:     "heph",
+			SSHKeyPath:  "/tmp/key",
+			SSHPort:     2222,
+			DockerImage: "ghcr.io/heph/worker:latest",
+		},
+		Logger: logger.NewSimpleLogger(),
+	})
+	if err != nil {
+		t.Fatalf("Build selfhosted with compute: %v", err)
+	}
+	if p == nil || p.Storage() == nil {
+		t.Fatal("expected selfhosted provider with storage")
+	}
+	// Compute is backed by real DockerCompute when config is present.
+	if p.Compute() == nil {
+		t.Fatal("expected compute surface")
 	}
 }

--- a/internal/cloud/kind.go
+++ b/internal/cloud/kind.go
@@ -12,10 +12,17 @@ type Kind string
 const (
 	// KindAWS selects the AWS provider (SQS + S3 + ECS/EC2).
 	KindAWS Kind = "aws"
-	// KindSelfhosted selects the selfhosted provider (NATS JetStream + S3-compatible).
-	// The full data plane lands in PR 6.1 Track 1/2; PR 6.1 Track 0 only adds the
-	// identity and config plumbing.
-	KindSelfhosted Kind = "selfhosted"
+	// KindManual selects the manual/operator-managed VPS path.
+	KindManual Kind = "manual"
+	// KindSelfhosted is a deprecated alias for KindManual, kept for backwards
+	// compatibility with older configs and CLI usage.
+	KindSelfhosted Kind = "manual"
+	// VPS/provider selectors. Today they share the same selfhosted runtime
+	// family; later PRs can attach provider-aware fleet managers to them.
+	KindHetzner  Kind = "hetzner"
+	KindLinode   Kind = "linode"
+	KindScaleway Kind = "scaleway"
+	KindVultr    Kind = "vultr"
 )
 
 // DefaultKind is the cloud used when nothing else is specified.
@@ -23,11 +30,56 @@ const DefaultKind = KindAWS
 
 // SupportedKinds returns the canonical list of cloud kinds.
 func SupportedKinds() []Kind {
-	return []Kind{KindAWS, KindSelfhosted}
+	return []Kind{KindAWS, KindManual, KindHetzner, KindLinode, KindScaleway, KindVultr}
 }
 
 // String returns the canonical string form of the kind.
 func (k Kind) String() string { return string(k) }
+
+// Canonical returns the canonical display/storage form of the kind.
+func (k Kind) Canonical() Kind {
+	switch strings.ToLower(strings.TrimSpace(string(k))) {
+	case "selfhosted", "manual":
+		return KindManual
+	case "aws":
+		return KindAWS
+	case "hetzner":
+		return KindHetzner
+	case "linode":
+		return KindLinode
+	case "scaleway":
+		return KindScaleway
+	case "vultr":
+		return KindVultr
+	default:
+		return k
+	}
+}
+
+// IsSelfhostedFamily reports whether the kind belongs to the VPS/selfhosted
+// runtime family.
+func (k Kind) IsSelfhostedFamily() bool {
+	switch k.Canonical() {
+	case KindManual, KindHetzner, KindLinode, KindScaleway, KindVultr:
+		return true
+	default:
+		return false
+	}
+}
+
+// RuntimeFamily collapses provider-specific selectors onto the shared
+// execution family used by the implementation.
+func (k Kind) RuntimeFamily() Kind {
+	if k.IsSelfhostedFamily() {
+		return KindManual
+	}
+	return KindAWS
+}
+
+// SupportedKindsText returns the canonical user-facing list for help text.
+func SupportedKindsText() string {
+	return joinKinds(SupportedKinds())
+}
 
 // ParseKind validates and normalizes a cloud kind string. An empty input
 // returns DefaultKind so callers can pass through unset config values.
@@ -36,12 +88,39 @@ func ParseKind(s string) (Kind, error) {
 	if trimmed == "" {
 		return DefaultKind, nil
 	}
+	if trimmed == "selfhosted" {
+		return KindManual, nil
+	}
 	for _, k := range SupportedKinds() {
 		if trimmed == string(k) {
 			return k, nil
 		}
 	}
-	return "", fmt.Errorf("unsupported cloud %q (expected one of: %s)", s, joinKinds(SupportedKinds()))
+	return "", fmt.Errorf("unsupported cloud %q (expected one of: %s)", s, SupportedKindsText())
+}
+
+// ValidateComputeMode checks whether the given compute mode is allowed for
+// the selected cloud provider. This is the single authority for cloud-specific
+// mode policy so callers (CLI and TUI) do not duplicate the check.
+//
+// Policy:
+//   - AWS: auto, fargate, spot (and empty, which resolves to auto).
+//   - Selfhosted: auto only (fargate and spot are AWS-specific concepts).
+func ValidateComputeMode(kind Kind, mode string) error {
+	switch {
+	case kind.IsSelfhostedFamily():
+		if mode != "" && mode != "auto" {
+			return fmt.Errorf("provider %q only supports compute-mode \"auto\", got %q (fargate and spot are AWS-specific)", kind.Canonical(), mode)
+		}
+	default: // AWS
+		switch mode {
+		case "", "auto", "fargate", "spot":
+			// all valid
+		default:
+			return fmt.Errorf("compute-mode must be auto, fargate, or spot, got %q", mode)
+		}
+	}
+	return nil
 }
 
 func joinKinds(ks []Kind) string {

--- a/internal/cloud/kind_test.go
+++ b/internal/cloud/kind_test.go
@@ -13,7 +13,12 @@ func TestParseKind(t *testing.T) {
 		{"aws lowercase", "aws", KindAWS, false},
 		{"aws mixed case", "AWS", KindAWS, false},
 		{"aws with whitespace", "  aws  ", KindAWS, false},
-		{"selfhosted", "selfhosted", KindSelfhosted, false},
+		{"manual", "manual", KindManual, false},
+		{"legacy selfhosted alias", "selfhosted", KindManual, false},
+		{"hetzner", "hetzner", KindHetzner, false},
+		{"linode", "linode", KindLinode, false},
+		{"scaleway", "scaleway", KindScaleway, false},
+		{"vultr", "vultr", KindVultr, false},
 		{"unknown", "gcp", "", true},
 	}
 	for _, tt := range tests {
@@ -29,15 +34,69 @@ func TestParseKind(t *testing.T) {
 	}
 }
 
-func TestSupportedKindsContainsAWSAndSelfhosted(t *testing.T) {
-	got := SupportedKinds()
-	want := map[Kind]bool{KindAWS: false, KindSelfhosted: false}
-	for _, k := range got {
-		want[k] = true
+func TestValidateComputeMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		kind    Kind
+		mode    string
+		wantErr bool
+	}{
+		{"aws auto", KindAWS, "auto", false},
+		{"aws empty", KindAWS, "", false},
+		{"aws fargate", KindAWS, "fargate", false},
+		{"aws spot", KindAWS, "spot", false},
+		{"aws invalid", KindAWS, "gpu", true},
+		{"manual auto", KindManual, "auto", false},
+		{"manual empty", KindManual, "", false},
+		{"manual fargate rejected", KindManual, "fargate", true},
+		{"hetzner spot rejected", KindHetzner, "spot", true},
 	}
-	for k, present := range want {
-		if !present {
-			t.Errorf("SupportedKinds missing %q", k)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateComputeMode(tt.kind, tt.mode)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ValidateComputeMode(%q, %q) error = %v, wantErr %v", tt.kind, tt.mode, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSupportedKindsReturnsCanonicalUserFacingKinds(t *testing.T) {
+	got := SupportedKinds()
+	want := []Kind{KindAWS, KindManual, KindHetzner, KindLinode, KindScaleway, KindVultr}
+	if len(got) != len(want) {
+		t.Fatalf("SupportedKinds() len = %d, want %d", len(got), len(want))
+	}
+	for i, kind := range want {
+		if got[i] != kind {
+			t.Fatalf("SupportedKinds()[%d] = %q, want %q", i, got[i], kind)
+		}
+	}
+}
+
+func TestSelfhostedFamilyHelpers(t *testing.T) {
+	tests := []struct {
+		kind          Kind
+		wantFamily    bool
+		wantRuntime   Kind
+		wantCanonical Kind
+	}{
+		{KindAWS, false, KindAWS, KindAWS},
+		{KindManual, true, KindManual, KindManual},
+		{KindSelfhosted, true, KindManual, KindManual},
+		{Kind("selfhosted"), true, KindManual, KindManual},
+		{KindHetzner, true, KindManual, KindHetzner},
+		{KindLinode, true, KindManual, KindLinode},
+	}
+	for _, tt := range tests {
+		if got := tt.kind.IsSelfhostedFamily(); got != tt.wantFamily {
+			t.Errorf("%q IsSelfhostedFamily() = %v, want %v", tt.kind, got, tt.wantFamily)
+		}
+		if got := tt.kind.RuntimeFamily(); got != tt.wantRuntime {
+			t.Errorf("%q RuntimeFamily() = %q, want %q", tt.kind, got, tt.wantRuntime)
+		}
+		if got := tt.kind.Canonical(); got != tt.wantCanonical {
+			t.Errorf("%q Canonical() = %q, want %q", tt.kind, got, tt.wantCanonical)
 		}
 	}
 }

--- a/internal/cloud/selfhosted/docker.go
+++ b/internal/cloud/selfhosted/docker.go
@@ -1,0 +1,202 @@
+package selfhosted
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"heph4estus/internal/cloud"
+	"heph4estus/internal/logger"
+)
+
+var (
+	errComputeNotConfigured = errors.New("selfhosted: compute is not configured")
+	errSpotUnsupported      = fmt.Errorf("selfhosted: spot instances are not supported: %w", cloud.ErrNotImplemented)
+)
+
+var (
+	_ cloud.Compute = (*DockerCompute)(nil)
+	_ cloud.Compute = configErrorCompute{}
+)
+
+// CommandRunner executes a command on a remote host. The real implementation
+// shells out to the ssh binary; tests inject a recorder.
+type CommandRunner interface {
+	Run(ctx context.Context, host string, remoteCmd string) error
+}
+
+type sshRunner struct {
+	user    string
+	keyPath string
+	port    int
+}
+
+func (r *sshRunner) Run(ctx context.Context, host string, remoteCmd string) error {
+	port := r.port
+	if port == 0 {
+		port = 22
+	}
+	args := []string{
+		"-i", r.keyPath,
+		"-p", strconv.Itoa(port),
+		"-o", "StrictHostKeyChecking=no",
+		"-o", "BatchMode=yes",
+		fmt.Sprintf("%s@%s", r.user, host),
+		remoteCmd,
+	}
+	cmd := exec.CommandContext(ctx, "ssh", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ssh %s: %w: %s", host, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// DockerCompute implements cloud.Compute by running Docker containers on
+// remote hosts over SSH.
+type DockerCompute struct {
+	hosts        []string
+	image        string
+	transportEnv map[string]string
+	runner       CommandRunner
+	logger       logger.Logger
+}
+
+func newDockerCompute(cfg ComputeConfig, transportEnv map[string]string, runner CommandRunner, log logger.Logger) *DockerCompute {
+	return &DockerCompute{
+		hosts:        cfg.WorkerHosts,
+		image:        cfg.DockerImage,
+		transportEnv: transportEnv,
+		runner:       runner,
+		logger:       log,
+	}
+}
+
+// RunContainer launches detached Docker containers on remote worker hosts
+// over SSH, round-robining across the configured host list.
+func (c *DockerCompute) RunContainer(ctx context.Context, opts cloud.ContainerOpts) (string, error) {
+	count := opts.Count
+	if count <= 0 {
+		count = 1
+	}
+
+	image := c.image
+	if opts.Image != "" {
+		image = opts.Image
+	}
+
+	env := c.buildEnv(opts.Env)
+
+	var launched []string
+	for i := 0; i < count; i++ {
+		host := c.hosts[i%len(c.hosts)]
+		name := containerName(opts.ContainerName, i, count)
+
+		c.logger.Info("Pulling %s on %s", image, host)
+		if err := c.runner.Run(ctx, host, "docker pull "+image); err != nil {
+			return strings.Join(launched, ","), fmt.Errorf("docker pull on %s: %w", host, err)
+		}
+
+		c.logger.Info("Starting container %s on %s", name, host)
+		if err := c.runner.Run(ctx, host, buildDockerRun(name, env, image)); err != nil {
+			return strings.Join(launched, ","), fmt.Errorf("docker run on %s: %w", host, err)
+		}
+
+		launched = append(launched, host+":"+name)
+	}
+
+	return strings.Join(launched, ","), nil
+}
+
+func (c *DockerCompute) RunSpotInstances(_ context.Context, _ cloud.SpotOpts) ([]string, error) {
+	return nil, errSpotUnsupported
+}
+
+func (c *DockerCompute) GetSpotStatus(_ context.Context, _ []string) ([]cloud.SpotStatus, error) {
+	return nil, errSpotUnsupported
+}
+
+// buildEnv merges caller env, transport env, and forces CLOUD=selfhosted.
+// Precedence: opts.Env < transportEnv < CLOUD=selfhosted.
+func (c *DockerCompute) buildEnv(optsEnv map[string]string) map[string]string {
+	env := make(map[string]string, len(optsEnv)+len(c.transportEnv)+1)
+	for k, v := range optsEnv {
+		env[k] = v
+	}
+	for k, v := range c.transportEnv {
+		if v != "" {
+			env[k] = v
+		}
+	}
+	env["CLOUD"] = "selfhosted"
+	return env
+}
+
+func buildDockerRun(name string, env map[string]string, image string) string {
+	parts := []string{"docker", "run", "-d", "--name", name}
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		parts = append(parts, "-e", k+"="+env[k])
+	}
+	parts = append(parts, image)
+	return strings.Join(parts, " ")
+}
+
+var nameRe = regexp.MustCompile(`[^a-zA-Z0-9_.-]`)
+
+func containerName(base string, index, total int) string {
+	if base == "" {
+		base = "heph-worker"
+	}
+	name := nameRe.ReplaceAllString(base, "-")
+	if total > 1 {
+		name = fmt.Sprintf("%s-%d", name, index)
+	}
+	return name
+}
+
+func validateComputeConfig(cfg *ComputeConfig) error {
+	if cfg == nil {
+		return errComputeNotConfigured
+	}
+	if len(cfg.WorkerHosts) == 0 {
+		return fmt.Errorf("%w: no worker hosts configured", errComputeNotConfigured)
+	}
+	if cfg.SSHUser == "" {
+		return fmt.Errorf("%w: no SSH user configured", errComputeNotConfigured)
+	}
+	if cfg.SSHKeyPath == "" {
+		return fmt.Errorf("%w: no SSH key path configured", errComputeNotConfigured)
+	}
+	if cfg.DockerImage == "" {
+		return fmt.Errorf("%w: no Docker image configured", errComputeNotConfigured)
+	}
+	return nil
+}
+
+// configErrorCompute implements cloud.Compute by returning a configuration
+// error for all operations. Used when compute config is absent or incomplete.
+type configErrorCompute struct {
+	err error
+}
+
+func (c configErrorCompute) RunContainer(_ context.Context, _ cloud.ContainerOpts) (string, error) {
+	return "", c.err
+}
+
+func (c configErrorCompute) RunSpotInstances(_ context.Context, _ cloud.SpotOpts) ([]string, error) {
+	return nil, c.err
+}
+
+func (c configErrorCompute) GetSpotStatus(_ context.Context, _ []string) ([]cloud.SpotStatus, error) {
+	return nil, c.err
+}

--- a/internal/cloud/selfhosted/docker_test.go
+++ b/internal/cloud/selfhosted/docker_test.go
@@ -1,0 +1,349 @@
+package selfhosted
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"heph4estus/internal/cloud"
+	"heph4estus/internal/logger"
+)
+
+// runCall records one invocation of a CommandRunner.
+type runCall struct {
+	Host string
+	Cmd  string
+}
+
+// recordingRunner captures every Run call for later assertion.
+type recordingRunner struct {
+	calls []runCall
+	err   error // if non-nil, every call returns this
+}
+
+func (r *recordingRunner) Run(_ context.Context, host, cmd string) error {
+	r.calls = append(r.calls, runCall{Host: host, Cmd: cmd})
+	return r.err
+}
+
+func testCompute(hosts []string, image string, transportEnv map[string]string, runner CommandRunner) *DockerCompute {
+	return &DockerCompute{
+		hosts:        hosts,
+		image:        image,
+		transportEnv: transportEnv,
+		runner:       runner,
+		logger:       logger.NewSimpleLogger(),
+	}
+}
+
+// --- Single-container launch ---
+
+func TestDockerCompute_SingleContainer(t *testing.T) {
+	rec := &recordingRunner{}
+	dc := testCompute(
+		[]string{"10.0.0.1"},
+		"ghcr.io/heph/worker:latest",
+		map[string]string{
+			"S3_ENDPOINT":   "https://minio:9000",
+			"S3_REGION":     "us-east-1",
+			"S3_ACCESS_KEY": "ak",
+			"S3_SECRET_KEY": "sk",
+			"S3_PATH_STYLE": "true",
+			"NATS_URL":      "nats://nats:4222",
+		},
+		rec,
+	)
+
+	result, err := dc.RunContainer(context.Background(), cloud.ContainerOpts{
+		ContainerName: "test-worker",
+		Count:         1,
+	})
+	if err != nil {
+		t.Fatalf("RunContainer: %v", err)
+	}
+
+	if len(rec.calls) != 2 {
+		t.Fatalf("expected 2 calls (pull + run), got %d", len(rec.calls))
+	}
+
+	// Both target the single host.
+	for i, c := range rec.calls {
+		if c.Host != "10.0.0.1" {
+			t.Errorf("call[%d] host = %q, want 10.0.0.1", i, c.Host)
+		}
+	}
+
+	// Pull command.
+	if rec.calls[0].Cmd != "docker pull ghcr.io/heph/worker:latest" {
+		t.Errorf("pull cmd = %q", rec.calls[0].Cmd)
+	}
+
+	// Run command: verify name and required env.
+	runCmd := rec.calls[1].Cmd
+	if !strings.Contains(runCmd, "--name test-worker") {
+		t.Errorf("run cmd missing --name: %q", runCmd)
+	}
+	for _, want := range []string{
+		"-e CLOUD=selfhosted",
+		"-e S3_ENDPOINT=https://minio:9000",
+		"-e S3_REGION=us-east-1",
+		"-e S3_ACCESS_KEY=ak",
+		"-e S3_SECRET_KEY=sk",
+		"-e S3_PATH_STYLE=true",
+		"-e NATS_URL=nats://nats:4222",
+	} {
+		if !strings.Contains(runCmd, want) {
+			t.Errorf("run cmd missing %q: %q", want, runCmd)
+		}
+	}
+
+	if result != "10.0.0.1:test-worker" {
+		t.Errorf("result = %q, want 10.0.0.1:test-worker", result)
+	}
+}
+
+// --- Multi-container with round-robin ---
+
+func TestDockerCompute_MultiContainer_RoundRobin(t *testing.T) {
+	rec := &recordingRunner{}
+	dc := testCompute([]string{"h1", "h2"}, "worker:latest", map[string]string{}, rec)
+
+	result, err := dc.RunContainer(context.Background(), cloud.ContainerOpts{
+		ContainerName: "scan",
+		Count:         5,
+	})
+	if err != nil {
+		t.Fatalf("RunContainer: %v", err)
+	}
+
+	// 5 containers x 2 calls each = 10 calls.
+	if len(rec.calls) != 10 {
+		t.Fatalf("expected 10 calls, got %d", len(rec.calls))
+	}
+
+	// Round-robin: h1, h2, h1, h2, h1.
+	wantHosts := []string{"h1", "h2", "h1", "h2", "h1"}
+	for i, want := range wantHosts {
+		pullHost := rec.calls[i*2].Host
+		runHost := rec.calls[i*2+1].Host
+		if pullHost != want {
+			t.Errorf("container %d pull host = %q, want %q", i, pullHost, want)
+		}
+		if runHost != want {
+			t.Errorf("container %d run host = %q, want %q", i, runHost, want)
+		}
+	}
+
+	// Container names: scan-0 through scan-4.
+	for i := 0; i < 5; i++ {
+		wantName := fmt.Sprintf("--name scan-%d", i)
+		if !strings.Contains(rec.calls[i*2+1].Cmd, wantName) {
+			t.Errorf("container %d: cmd missing %q: %q", i, wantName, rec.calls[i*2+1].Cmd)
+		}
+	}
+
+	// Deterministic result.
+	parts := strings.Split(result, ",")
+	want := []string{"h1:scan-0", "h2:scan-1", "h1:scan-2", "h2:scan-3", "h1:scan-4"}
+	if len(parts) != len(want) {
+		t.Fatalf("result parts = %d, want %d", len(parts), len(want))
+	}
+	for i := range want {
+		if parts[i] != want[i] {
+			t.Errorf("result[%d] = %q, want %q", i, parts[i], want[i])
+		}
+	}
+}
+
+// --- Zero count treated as 1 ---
+
+func TestDockerCompute_ZeroCount(t *testing.T) {
+	rec := &recordingRunner{}
+	dc := testCompute([]string{"h1"}, "img", map[string]string{}, rec)
+
+	result, err := dc.RunContainer(context.Background(), cloud.ContainerOpts{Count: 0})
+	if err != nil {
+		t.Fatalf("RunContainer: %v", err)
+	}
+	if len(rec.calls) != 2 {
+		t.Fatalf("expected 2 calls (1 container), got %d", len(rec.calls))
+	}
+	if result != "h1:heph-worker" {
+		t.Errorf("result = %q, want h1:heph-worker", result)
+	}
+}
+
+// --- Image override ---
+
+func TestDockerCompute_ImageOverride(t *testing.T) {
+	rec := &recordingRunner{}
+	dc := testCompute([]string{"h1"}, "default:latest", map[string]string{}, rec)
+
+	_, err := dc.RunContainer(context.Background(), cloud.ContainerOpts{
+		Image: "override:v2",
+		Count: 1,
+	})
+	if err != nil {
+		t.Fatalf("RunContainer: %v", err)
+	}
+	if !strings.Contains(rec.calls[0].Cmd, "override:v2") {
+		t.Errorf("pull should use override image: %q", rec.calls[0].Cmd)
+	}
+	if !strings.Contains(rec.calls[1].Cmd, "override:v2") {
+		t.Errorf("run should use override image: %q", rec.calls[1].Cmd)
+	}
+}
+
+// --- Runner error propagates ---
+
+func TestDockerCompute_RunnerError(t *testing.T) {
+	rec := &recordingRunner{err: fmt.Errorf("connection refused")}
+	dc := testCompute([]string{"h1"}, "img", map[string]string{}, rec)
+
+	_, err := dc.RunContainer(context.Background(), cloud.ContainerOpts{Count: 1})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "docker pull on h1") {
+		t.Errorf("error = %q, want docker pull context", err.Error())
+	}
+}
+
+// --- Env precedence ---
+
+func TestBuildEnv(t *testing.T) {
+	dc := &DockerCompute{
+		transportEnv: map[string]string{
+			"S3_ENDPOINT": "https://minio:9000",
+			"NATS_URL":    "nats://nats:4222",
+		},
+	}
+
+	env := dc.buildEnv(map[string]string{
+		"CUSTOM":   "val",
+		"CLOUD":    "aws",
+		"NATS_URL": "nats://should-be-overridden",
+	})
+
+	if env["CLOUD"] != "selfhosted" {
+		t.Errorf("CLOUD = %q, want selfhosted (must be forced)", env["CLOUD"])
+	}
+	if env["NATS_URL"] != "nats://nats:4222" {
+		t.Errorf("NATS_URL = %q, transport should override caller", env["NATS_URL"])
+	}
+	if env["S3_ENDPOINT"] != "https://minio:9000" {
+		t.Errorf("S3_ENDPOINT = %q", env["S3_ENDPOINT"])
+	}
+	if env["CUSTOM"] != "val" {
+		t.Errorf("CUSTOM = %q, caller env should pass through", env["CUSTOM"])
+	}
+}
+
+// --- Container naming ---
+
+func TestContainerName(t *testing.T) {
+	tests := []struct {
+		base  string
+		index int
+		total int
+		want  string
+	}{
+		{"worker", 0, 1, "worker"},
+		{"worker", 0, 3, "worker-0"},
+		{"worker", 2, 3, "worker-2"},
+		{"", 0, 1, "heph-worker"},
+		{"", 1, 2, "heph-worker-1"},
+		{"my/scan@host", 0, 1, "my-scan-host"},
+		{"valid.name_ok", 0, 1, "valid.name_ok"},
+	}
+	for _, tt := range tests {
+		got := containerName(tt.base, tt.index, tt.total)
+		if got != tt.want {
+			t.Errorf("containerName(%q, %d, %d) = %q, want %q", tt.base, tt.index, tt.total, got, tt.want)
+		}
+	}
+}
+
+// --- Spot methods ---
+
+func TestDockerCompute_SpotUnsupported(t *testing.T) {
+	dc := testCompute([]string{"h1"}, "img", map[string]string{}, &recordingRunner{})
+	ctx := context.Background()
+
+	_, err := dc.RunSpotInstances(ctx, cloud.SpotOpts{})
+	if !errors.Is(err, errSpotUnsupported) {
+		t.Errorf("RunSpotInstances = %v, want errSpotUnsupported", err)
+	}
+	if !errors.Is(err, cloud.ErrNotImplemented) {
+		t.Error("RunSpotInstances should wrap cloud.ErrNotImplemented")
+	}
+
+	_, err = dc.GetSpotStatus(ctx, nil)
+	if !errors.Is(err, errSpotUnsupported) {
+		t.Errorf("GetSpotStatus = %v, want errSpotUnsupported", err)
+	}
+	if !errors.Is(err, cloud.ErrNotImplemented) {
+		t.Error("GetSpotStatus should wrap cloud.ErrNotImplemented")
+	}
+}
+
+// --- Config validation ---
+
+func TestValidateComputeConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *ComputeConfig
+		wantSub string
+	}{
+		{"nil config", nil, "compute is not configured"},
+		{"no hosts", &ComputeConfig{SSHUser: "u", SSHKeyPath: "/k", DockerImage: "img"}, "no worker hosts"},
+		{"no user", &ComputeConfig{WorkerHosts: []string{"h"}, SSHKeyPath: "/k", DockerImage: "img"}, "no SSH user"},
+		{"no key", &ComputeConfig{WorkerHosts: []string{"h"}, SSHUser: "u", DockerImage: "img"}, "no SSH key path"},
+		{"no image", &ComputeConfig{WorkerHosts: []string{"h"}, SSHUser: "u", SSHKeyPath: "/k"}, "no Docker image"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateComputeConfig(tt.cfg)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("error = %q, want substring %q", err, tt.wantSub)
+			}
+			if !errors.Is(err, errComputeNotConfigured) {
+				t.Error("error should wrap errComputeNotConfigured")
+			}
+		})
+	}
+}
+
+func TestValidateComputeConfig_Valid(t *testing.T) {
+	err := validateComputeConfig(&ComputeConfig{
+		WorkerHosts: []string{"h"},
+		SSHUser:     "u",
+		SSHKeyPath:  "/k",
+		DockerImage: "img",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// --- configErrorCompute ---
+
+func TestConfigErrorCompute(t *testing.T) {
+	c := configErrorCompute{err: errComputeNotConfigured}
+	ctx := context.Background()
+
+	if _, err := c.RunContainer(ctx, cloud.ContainerOpts{}); !errors.Is(err, errComputeNotConfigured) {
+		t.Errorf("RunContainer = %v", err)
+	}
+	if _, err := c.RunSpotInstances(ctx, cloud.SpotOpts{}); !errors.Is(err, errComputeNotConfigured) {
+		t.Errorf("RunSpotInstances = %v", err)
+	}
+	if _, err := c.GetSpotStatus(ctx, nil); !errors.Is(err, errComputeNotConfigured) {
+		t.Errorf("GetSpotStatus = %v", err)
+	}
+}

--- a/internal/cloud/selfhosted/provider.go
+++ b/internal/cloud/selfhosted/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"heph4estus/internal/cloud"
 	"heph4estus/internal/logger"
@@ -14,25 +15,33 @@ import (
 // JetStream-backed queue.
 var errQueueNotConfigured = errors.New("selfhosted: queue is not configured — provide NATS_URL to enable queue support")
 
-// errComputeNotImplemented is returned by the stub compute surface.
-// Selfhosted compute (docker run over SSH) lands in PR 6.2.
-var errComputeNotImplemented = errors.New("selfhosted: compute is not implemented (PR 6.2)")
-
 // Compile-time interface check.
 var _ cloud.Provider = (*Provider)(nil)
 
-// Provider is the selfhosted cloud.Provider backed by S3-compatible storage
-// and NATS JetStream queuing. Compute remains a stub until PR 6.2.
+// Provider is the selfhosted cloud.Provider backed by S3-compatible storage,
+// NATS JetStream queuing, and Docker-over-SSH compute.
 type Provider struct {
 	storage *Storage
 	queue   cloud.Queue
 	compute cloud.Compute
 }
 
+// ComputeConfig describes the SSH/Docker compute settings for selfhosted
+// workers. The DockerCompute implementation in docker.go uses these to
+// launch containers on remote hosts over SSH.
+type ComputeConfig struct {
+	WorkerHosts []string // SSH-reachable worker addresses
+	SSHUser     string   // SSH login user
+	SSHKeyPath  string   // path to private key
+	SSHPort     int      // SSH port (0 means default 22)
+	DockerImage string   // Docker image reference for the worker container
+}
+
 // ProviderConfig is the input to NewProvider.
 type ProviderConfig struct {
 	Storage StorageConfig
 	Queue   *QueueConfig
+	Compute *ComputeConfig
 }
 
 // NewProvider builds a selfhosted Provider from explicit configuration.
@@ -51,10 +60,22 @@ func NewProvider(cfg ProviderConfig, log logger.Logger) (*Provider, error) {
 		}
 		q = nq
 	}
+	var comp cloud.Compute
+	if err := validateComputeConfig(cfg.Compute); err != nil {
+		comp = configErrorCompute{err: err}
+	} else {
+		transportEnv := buildTransportEnv(cfg)
+		runner := &sshRunner{
+			user:    cfg.Compute.SSHUser,
+			keyPath: cfg.Compute.SSHKeyPath,
+			port:    cfg.Compute.SSHPort,
+		}
+		comp = newDockerCompute(*cfg.Compute, transportEnv, runner, log)
+	}
 	return &Provider{
 		storage: storage,
 		queue:   q,
-		compute: stubCompute{},
+		compute: comp,
 	}, nil
 }
 
@@ -64,7 +85,8 @@ func (p *Provider) Storage() cloud.Storage { return p.storage }
 // Queue returns the NATS JetStream queue, or a stub if no NATS URL was configured.
 func (p *Provider) Queue() cloud.Queue { return p.queue }
 
-// Compute returns a placeholder compute surface until PR 6.2 lands.
+// Compute returns the Docker-over-SSH compute surface when compute config is
+// present, or a config-error surface otherwise.
 func (p *Provider) Compute() cloud.Compute { return p.compute }
 
 type stubQueue struct{}
@@ -76,14 +98,23 @@ func (stubQueue) Receive(context.Context, string) (*cloud.Message, error) {
 }
 func (stubQueue) Delete(context.Context, string, string) error { return errQueueNotConfigured }
 
-type stubCompute struct{}
-
-func (stubCompute) RunContainer(context.Context, cloud.ContainerOpts) (string, error) {
-	return "", errComputeNotImplemented
-}
-func (stubCompute) RunSpotInstances(context.Context, cloud.SpotOpts) ([]string, error) {
-	return nil, errComputeNotImplemented
-}
-func (stubCompute) GetSpotStatus(context.Context, []string) ([]cloud.SpotStatus, error) {
-	return nil, errComputeNotImplemented
+func buildTransportEnv(cfg ProviderConfig) map[string]string {
+	region := cfg.Storage.Region
+	if region == "" {
+		region = "us-east-1"
+	}
+	env := map[string]string{
+		"S3_ENDPOINT":   cfg.Storage.Endpoint,
+		"S3_REGION":     region,
+		"S3_ACCESS_KEY": cfg.Storage.AccessKey,
+		"S3_SECRET_KEY": cfg.Storage.Secret,
+		"S3_PATH_STYLE": strconv.FormatBool(cfg.Storage.PathStyle),
+	}
+	if cfg.Queue != nil {
+		env["NATS_URL"] = cfg.Queue.URL
+		if cfg.Queue.StreamName != "" {
+			env["NATS_STREAM"] = cfg.Queue.StreamName
+		}
+	}
+	return env
 }

--- a/internal/cloud/selfhosted/provider_test.go
+++ b/internal/cloud/selfhosted/provider_test.go
@@ -62,7 +62,7 @@ func TestStubQueueReturnsError(t *testing.T) {
 	}
 }
 
-func TestStubComputeReturnsError(t *testing.T) {
+func TestComputeNotConfiguredReturnsError(t *testing.T) {
 	p, err := NewProvider(ProviderConfig{
 		Storage: StorageConfig{
 			Endpoint:  "https://minio.local:9000",
@@ -77,14 +77,47 @@ func TestStubComputeReturnsError(t *testing.T) {
 	ctx := context.Background()
 	c := p.Compute()
 
-	if _, err := c.RunContainer(ctx, cloud.ContainerOpts{}); !errors.Is(err, errComputeNotImplemented) {
-		t.Errorf("RunContainer = %v, want errComputeNotImplemented", err)
+	if _, err := c.RunContainer(ctx, cloud.ContainerOpts{}); !errors.Is(err, errComputeNotConfigured) {
+		t.Errorf("RunContainer = %v, want errComputeNotConfigured", err)
 	}
-	if _, err := c.RunSpotInstances(ctx, cloud.SpotOpts{}); !errors.Is(err, errComputeNotImplemented) {
-		t.Errorf("RunSpotInstances = %v, want errComputeNotImplemented", err)
+	if _, err := c.RunSpotInstances(ctx, cloud.SpotOpts{}); !errors.Is(err, errComputeNotConfigured) {
+		t.Errorf("RunSpotInstances = %v, want errComputeNotConfigured", err)
 	}
-	if _, err := c.GetSpotStatus(ctx, nil); !errors.Is(err, errComputeNotImplemented) {
-		t.Errorf("GetSpotStatus = %v, want errComputeNotImplemented", err)
+	if _, err := c.GetSpotStatus(ctx, nil); !errors.Is(err, errComputeNotConfigured) {
+		t.Errorf("GetSpotStatus = %v, want errComputeNotConfigured", err)
+	}
+}
+
+func TestProviderWithComputeConfig(t *testing.T) {
+	p, err := NewProvider(ProviderConfig{
+		Storage: StorageConfig{
+			Endpoint:  "https://minio.local:9000",
+			AccessKey: "ak",
+			Secret:    "sk",
+		},
+		Compute: &ComputeConfig{
+			WorkerHosts: []string{"10.0.0.1"},
+			SSHUser:     "heph",
+			SSHKeyPath:  "/tmp/key",
+			DockerImage: "worker:latest",
+		},
+	}, logger.NewSimpleLogger())
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+
+	if p.Compute() == nil {
+		t.Fatal("expected non-nil compute")
+	}
+
+	// Real DockerCompute returns errSpotUnsupported, not errComputeNotConfigured.
+	ctx := context.Background()
+	_, err = p.Compute().RunSpotInstances(ctx, cloud.SpotOpts{})
+	if !errors.Is(err, errSpotUnsupported) {
+		t.Errorf("RunSpotInstances = %v, want errSpotUnsupported", err)
+	}
+	if errors.Is(err, errComputeNotConfigured) {
+		t.Error("real compute should not return errComputeNotConfigured")
 	}
 }
 

--- a/internal/cloud/selfhosted/s3compat.go
+++ b/internal/cloud/selfhosted/s3compat.go
@@ -2,8 +2,7 @@
 // operator-owned infrastructure (MinIO for object storage, NATS JetStream
 // for queuing) instead of AWS managed services.
 //
-// Storage and queue are fully implemented. Compute remains a stub until
-// PR 6.2 lands selfhosted compute (docker run over SSH).
+// Storage, queue, and Docker-over-SSH compute are fully implemented.
 package selfhosted
 
 import (

--- a/internal/config/worker_config_test.go
+++ b/internal/config/worker_config_test.go
@@ -51,6 +51,59 @@ func TestNewWorkerConfig_ProviderNeutralFieldNames(t *testing.T) {
 	}
 }
 
+func TestNewWorkerConfig_JitterParsing(t *testing.T) {
+	t.Setenv("QUEUE_URL", "q")
+	t.Setenv("S3_BUCKET", "b")
+	t.Setenv("TOOL_NAME", "nmap")
+	t.Setenv("JITTER_MAX_SECONDS", "30")
+
+	cfg, err := NewWorkerConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.JitterMaxSeconds != 30 {
+		t.Errorf("JitterMaxSeconds = %d, want 30", cfg.JitterMaxSeconds)
+	}
+}
+
+func TestNewWorkerConfig_JitterInvalidIgnored(t *testing.T) {
+	t.Setenv("QUEUE_URL", "q")
+	t.Setenv("S3_BUCKET", "b")
+	t.Setenv("TOOL_NAME", "nmap")
+	t.Setenv("JITTER_MAX_SECONDS", "abc")
+
+	cfg, err := NewWorkerConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.JitterMaxSeconds != 0 {
+		t.Errorf("JitterMaxSeconds = %d, want 0 for invalid input", cfg.JitterMaxSeconds)
+	}
+}
+
+func TestNewWorkerConfig_SelfhostedScanRuntime(t *testing.T) {
+	// Prove a selfhosted worker reads env-driven queue/bucket exactly like AWS.
+	t.Setenv("QUEUE_URL", "nats-subject")
+	t.Setenv("S3_BUCKET", "minio-bucket")
+	t.Setenv("TOOL_NAME", "httpx")
+	t.Setenv("CLOUD", "selfhosted")
+	t.Setenv("JITTER_MAX_SECONDS", "")
+
+	cfg, err := NewWorkerConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Cloud != "selfhosted" {
+		t.Errorf("Cloud = %q, want selfhosted", cfg.Cloud)
+	}
+	if cfg.QueueID != "nats-subject" {
+		t.Errorf("QueueID = %q, want nats-subject", cfg.QueueID)
+	}
+	if cfg.Bucket != "minio-bucket" {
+		t.Errorf("Bucket = %q, want minio-bucket", cfg.Bucket)
+	}
+}
+
 func TestNewWorkerConfig_MissingRequired(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/infra/docker.go
+++ b/internal/infra/docker.go
@@ -60,6 +60,17 @@ func (d *DockerClient) Tag(ctx context.Context, source, target string) error {
 	return nil
 }
 
+// Login authenticates Docker to a registry with the given credentials.
+func (d *DockerClient) Login(ctx context.Context, registry, username, password string) error {
+	d.logger.Info("Logging into registry %s", registry)
+	result, err := d.runCmd(ctx, "", nil, "docker", "login", "--username", username, "--password", password, registry)
+	if err != nil {
+		d.logger.Error("docker login failed: %s", string(result.Stderr))
+		return fmt.Errorf("docker login: %w", err)
+	}
+	return nil
+}
+
 // Push pushes a Docker image to a registry.
 func (d *DockerClient) Push(ctx context.Context, tag string, stream io.Writer) error {
 	d.logger.Info("Pushing Docker image %s", tag)

--- a/internal/infra/lifecycle.go
+++ b/internal/infra/lifecycle.go
@@ -3,6 +3,8 @@ package infra
 import (
 	"context"
 	"fmt"
+
+	"heph4estus/internal/cloud"
 )
 
 // InfraStatus classifies the current state of deployed infrastructure.
@@ -47,9 +49,11 @@ type ProbeResult struct {
 	Err          error             // the underlying error when Status is Error
 }
 
-// Probe inspects existing Terraform outputs and classifies the infrastructure state
-// relative to the requested tool.
-func Probe(ctx context.Context, tf *TerraformClient, terraformDir, requestedTool string) ProbeResult {
+// Probe inspects existing Terraform outputs and classifies the infrastructure
+// state relative to the requested tool. The kind parameter selects the
+// required-output set so that AWS and selfhosted infrastructure are evaluated
+// against the correct contract.
+func Probe(ctx context.Context, tf *TerraformClient, kind cloud.Kind, terraformDir, requestedTool string) ProbeResult {
 	outputs, err := tf.ReadOutputs(ctx, terraformDir)
 	if err != nil {
 		// Distinguish "no state" from real Terraform failures.
@@ -78,7 +82,7 @@ func Probe(ctx context.Context, tf *TerraformClient, terraformDir, requestedTool
 
 	// Check for missing required keys.
 	var missing []string
-	for _, key := range RequiredOutputKeys {
+	for _, key := range RequiredOutputKeysForCloud(kind) {
 		if outputs[key] == "" {
 			missing = append(missing, key)
 		}

--- a/internal/infra/lifecycle_test.go
+++ b/internal/infra/lifecycle_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"heph4estus/internal/cloud"
 )
 
 // fullOutputs returns a complete set of terraform outputs for testing.
@@ -40,7 +42,7 @@ func TestProbe_Ready(t *testing.T) {
 		logger: nopLogger{},
 	}
 
-	result := Probe(context.Background(), tc, "/work", "nmap")
+	result := Probe(context.Background(), tc, cloud.KindAWS, "/work", "nmap")
 	if result.Status != StatusReady {
 		t.Fatalf("expected StatusReady, got %s", result.Status)
 	}
@@ -55,7 +57,7 @@ func TestProbe_Missing(t *testing.T) {
 		logger: nopLogger{},
 	}
 
-	result := Probe(context.Background(), tc, "/work", "nmap")
+	result := Probe(context.Background(), tc, cloud.KindAWS, "/work", "nmap")
 	if result.Status != StatusMissing {
 		t.Fatalf("expected StatusMissing, got %s", result.Status)
 	}
@@ -79,7 +81,7 @@ func TestProbe_Mismatch(t *testing.T) {
 		logger: nopLogger{},
 	}
 
-	result := Probe(context.Background(), tc, "/work", "nmap")
+	result := Probe(context.Background(), tc, cloud.KindAWS, "/work", "nmap")
 	if result.Status != StatusMismatch {
 		t.Fatalf("expected StatusMismatch, got %s", result.Status)
 	}
@@ -98,7 +100,7 @@ func TestProbe_Stale(t *testing.T) {
 		logger: nopLogger{},
 	}
 
-	result := Probe(context.Background(), tc, "/work", "nmap")
+	result := Probe(context.Background(), tc, cloud.KindAWS, "/work", "nmap")
 	if result.Status != StatusStale {
 		t.Fatalf("expected StatusStale, got %s", result.Status)
 	}
@@ -125,7 +127,7 @@ func TestProbe_LegacyNoToolName(t *testing.T) {
 		logger: nopLogger{},
 	}
 
-	result := Probe(context.Background(), tc, "/work", "nmap")
+	result := Probe(context.Background(), tc, cloud.KindAWS, "/work", "nmap")
 	if result.Status != StatusStale {
 		t.Fatalf("expected StatusStale for legacy state without tool_name, got %s", result.Status)
 	}
@@ -158,7 +160,7 @@ func TestProbe_MissingSpotOutputs(t *testing.T) {
 		logger: nopLogger{},
 	}
 
-	result := Probe(context.Background(), tc, "/work", "nmap")
+	result := Probe(context.Background(), tc, cloud.KindAWS, "/work", "nmap")
 	if result.Status != StatusStale {
 		t.Fatalf("expected StatusStale for missing spot outputs, got %s", result.Status)
 	}
@@ -170,7 +172,7 @@ func TestProbe_Error(t *testing.T) {
 		logger: nopLogger{},
 	}
 
-	result := Probe(context.Background(), tc, "/work", "nmap")
+	result := Probe(context.Background(), tc, cloud.KindAWS, "/work", "nmap")
 	if result.Status != StatusError {
 		t.Fatalf("expected StatusError, got %s", result.Status)
 	}
@@ -277,5 +279,80 @@ func TestDecide_ErrorAlwaysBlocks(t *testing.T) {
 	}
 	if result.Reason != ReasonProbeError {
 		t.Fatalf("expected ReasonProbeError, got %s", result.Reason)
+	}
+}
+
+// --- Provider-aware required output tests ---
+
+func TestRequiredOutputKeysForCloud_AWS(t *testing.T) {
+	keys := RequiredOutputKeysForCloud(cloud.KindAWS)
+	if len(keys) != len(AWSRequiredOutputKeys) {
+		t.Fatalf("AWS keys length = %d, want %d", len(keys), len(AWSRequiredOutputKeys))
+	}
+	// Spot check a few AWS-specific keys.
+	want := map[string]bool{
+		"sqs_queue_url":        true,
+		"ecr_repo_url":         true,
+		"ecs_cluster_name":     true,
+		"ami_id":               true,
+		"instance_profile_arn": true,
+	}
+	for _, k := range keys {
+		delete(want, k)
+	}
+	if len(want) > 0 {
+		t.Fatalf("missing expected AWS keys: %v", want)
+	}
+}
+
+func TestRequiredOutputKeysForCloud_Selfhosted(t *testing.T) {
+	keys := RequiredOutputKeysForCloud(cloud.KindSelfhosted)
+	if len(keys) != len(SelfhostedRequiredOutputKeys) {
+		t.Fatalf("selfhosted keys length = %d, want %d", len(keys), len(SelfhostedRequiredOutputKeys))
+	}
+	// Selfhosted should only require tool_name for mismatch detection.
+	if keys[0] != "tool_name" {
+		t.Fatalf("expected tool_name, got %q", keys[0])
+	}
+	// AWS-specific keys must NOT appear in selfhosted set.
+	for _, k := range keys {
+		if k == "sqs_queue_url" || k == "ecr_repo_url" || k == "ecs_cluster_name" {
+			t.Fatalf("selfhosted should not require AWS key %q", k)
+		}
+	}
+}
+
+func TestRequiredOutputKeysForCloud_UnknownFallsToAWS(t *testing.T) {
+	keys := RequiredOutputKeysForCloud("")
+	if len(keys) != len(AWSRequiredOutputKeys) {
+		t.Fatalf("empty kind should fall back to AWS, got %d keys", len(keys))
+	}
+}
+
+func TestProbe_SelfhostedReadyWithToolName(t *testing.T) {
+	// Selfhosted only requires tool_name — outputs with just tool_name should be ready.
+	outputJSON := `{"tool_name":{"value":"nmap"}}`
+	tc := &TerraformClient{
+		runCmd: newMockExecutor(outputJSON, "", 0, nil),
+		logger: nopLogger{},
+	}
+
+	result := Probe(context.Background(), tc, cloud.KindSelfhosted, "/work", "nmap")
+	if result.Status != StatusReady {
+		t.Fatalf("expected StatusReady for selfhosted with tool_name, got %s (missing: %v)", result.Status, result.MissingKeys)
+	}
+}
+
+func TestProbe_SelfhostedMissingToolName(t *testing.T) {
+	// Selfhosted outputs missing tool_name should be stale.
+	outputJSON := `{"some_key":{"value":"val"}}`
+	tc := &TerraformClient{
+		runCmd: newMockExecutor(outputJSON, "", 0, nil),
+		logger: nopLogger{},
+	}
+
+	result := Probe(context.Background(), tc, cloud.KindSelfhosted, "/work", "nmap")
+	if result.Status != StatusStale {
+		t.Fatalf("expected StatusStale for selfhosted without tool_name, got %s", result.Status)
 	}
 }

--- a/internal/infra/pipeline.go
+++ b/internal/infra/pipeline.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"heph4estus/internal/cloud"
 	"heph4estus/internal/logger"
 )
 
@@ -16,6 +17,7 @@ type DeployResult struct {
 // DeployOpts configures a deploy pipeline run.
 type DeployOpts struct {
 	ToolConfig  *ToolConfig
+	Cloud       cloud.Kind // Provider family (empty defaults to AWS)
 	Region      string
 	AutoApprove bool
 	Stream      io.Writer // where to write progress (typically os.Stderr)
@@ -69,7 +71,7 @@ func RunDeploy(ctx context.Context, opts DeployOpts, log logger.Logger) (*Deploy
 		return nil, err
 	}
 
-	// 5. Read outputs
+	// 5. Read outputs (redact sensitive values for display)
 	if err := writeLine(opts.Stream, "==> Reading outputs"); err != nil {
 		return nil, err
 	}
@@ -78,7 +80,7 @@ func RunDeploy(ctx context.Context, opts DeployOpts, log logger.Logger) (*Deploy
 		return nil, err
 	}
 	for k, v := range outputs {
-		if err := writef(opts.Stream, "    %s = %s\n", k, v); err != nil {
+		if err := writef(opts.Stream, "    %s = %s\n", k, RedactOutputValue(k, v)); err != nil {
 			return nil, err
 		}
 	}
@@ -97,28 +99,20 @@ func RunDeploy(ctx context.Context, opts DeployOpts, log logger.Logger) (*Deploy
 		}
 	}
 
-	// 7. ECR auth
-	if err := writeLine(opts.Stream, "==> ECR authenticate"); err != nil {
+	// 7. Registry auth (provider-aware: ECR for AWS, docker login for selfhosted)
+	if err := writeLine(opts.Stream, "==> Registry auth"); err != nil {
 		return nil, err
 	}
-	if err := ecr.Authenticate(ctx, opts.Region); err != nil {
+	publisher := NewPublisher(opts.Cloud, docker, ecr, outputs, opts.Region)
+	if err := publisher.Authenticate(ctx); err != nil {
 		return nil, err
 	}
 
-	// 8. Docker tag + push
-	ecrURL := outputs["ecr_repo_url"]
-	if ecrURL == "" {
-		return nil, fmt.Errorf("terraform output missing ecr_repo_url")
-	}
-	remoteTag := ecrURL + ":latest"
-
-	if err := writeLine(opts.Stream, "==> Docker push"); err != nil {
+	// 8. Image publish (provider-aware: tag+push to ECR or selfhosted registry)
+	if err := writeLine(opts.Stream, "==> Image publish"); err != nil {
 		return nil, err
 	}
-	if err := docker.Tag(ctx, cfg.DockerTag, remoteTag); err != nil {
-		return nil, err
-	}
-	if err := docker.Push(ctx, remoteTag, opts.Stream); err != nil {
+	if _, err := publisher.Publish(ctx, cfg.DockerTag, opts.Stream); err != nil {
 		return nil, err
 	}
 
@@ -160,7 +154,10 @@ func EnsureInfra(ctx context.Context, cfg *ToolConfig, policy LifecyclePolicy, r
 	tf := NewTerraformClient(log)
 
 	// Probe current state.
-	probe := Probe(ctx, tf, cfg.TerraformDir, cfg.ToolName)
+	// EnsureInfra is currently only called from AWS paths (selfhosted
+	// compute is blocked). Default to AWS required outputs. Track 2 will
+	// thread cloud.Kind through ToolConfig when selfhosted scan paths open.
+	probe := Probe(ctx, tf, cloud.DefaultKind, cfg.TerraformDir, cfg.ToolName)
 	decision := Decide(probe, policy)
 
 	if err := writef(stream, "==> Lifecycle: %s\n", decision.Message); err != nil {

--- a/internal/infra/publish.go
+++ b/internal/infra/publish.go
@@ -1,0 +1,101 @@
+package infra
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"heph4estus/internal/cloud"
+)
+
+// ImagePublisher handles registry authentication and image publication.
+// Implementations exist for AWS ECR and selfhosted Docker registries.
+type ImagePublisher interface {
+	// Authenticate logs Docker into the target registry. For ECR this runs
+	// the three-step AWS auth flow; for a selfhosted registry it runs
+	// docker login with the controller credentials (or no-ops when no
+	// credentials are configured).
+	Authenticate(ctx context.Context) error
+
+	// Publish tags the local image and pushes it to the remote registry.
+	// Returns the remote image reference (e.g. "123.dkr.ecr.../nmap:latest"
+	// or "10.0.1.5:5000/heph-nmap-worker:latest").
+	Publish(ctx context.Context, localTag string, stream io.Writer) (remoteRef string, err error)
+}
+
+// ECRPublisher publishes images to AWS Elastic Container Registry.
+type ECRPublisher struct {
+	ECR     *ECRClient
+	Docker  *DockerClient
+	Region  string
+	RepoURL string // ecr_repo_url from terraform outputs
+}
+
+func (p *ECRPublisher) Authenticate(ctx context.Context) error {
+	return p.ECR.Authenticate(ctx, p.Region)
+}
+
+func (p *ECRPublisher) Publish(ctx context.Context, localTag string, stream io.Writer) (string, error) {
+	if p.RepoURL == "" {
+		return "", fmt.Errorf("ecr_repo_url is required for AWS image publish")
+	}
+	remoteTag := p.RepoURL + ":latest"
+	if err := p.Docker.Tag(ctx, localTag, remoteTag); err != nil {
+		return "", err
+	}
+	if err := p.Docker.Push(ctx, remoteTag, stream); err != nil {
+		return "", err
+	}
+	return remoteTag, nil
+}
+
+// RegistryPublisher publishes images to a generic Docker registry
+// (typically the controller-hosted registry for selfhosted deployments).
+type RegistryPublisher struct {
+	Docker      *DockerClient
+	RegistryURL string // e.g. "10.0.1.5:5000"
+	Username    string // optional — empty means no auth
+	Password    string // optional
+}
+
+func (p *RegistryPublisher) Authenticate(ctx context.Context) error {
+	if p.Username == "" || p.Password == "" {
+		// No credentials — assume insecure registry or pre-authenticated.
+		return nil
+	}
+	return p.Docker.Login(ctx, p.RegistryURL, p.Username, p.Password)
+}
+
+func (p *RegistryPublisher) Publish(ctx context.Context, localTag string, stream io.Writer) (string, error) {
+	if p.RegistryURL == "" {
+		return "", fmt.Errorf("registry_url is required for selfhosted image publish")
+	}
+	remoteTag := p.RegistryURL + "/" + localTag
+	if err := p.Docker.Tag(ctx, localTag, remoteTag); err != nil {
+		return "", err
+	}
+	if err := p.Docker.Push(ctx, remoteTag, stream); err != nil {
+		return "", err
+	}
+	return remoteTag, nil
+}
+
+// NewPublisher constructs the appropriate ImagePublisher for the given cloud
+// provider. For AWS it returns an ECRPublisher; for selfhosted/VPS providers
+// it returns a RegistryPublisher that targets the controller-hosted Docker registry.
+func NewPublisher(kind cloud.Kind, docker *DockerClient, ecr *ECRClient, outputs map[string]string, region string) ImagePublisher {
+	if kind.IsSelfhostedFamily() {
+		return &RegistryPublisher{
+			Docker:      docker,
+			RegistryURL: outputs["registry_url"],
+			Username:    outputs["registry_username"],
+			Password:    outputs["registry_password"],
+		}
+	}
+	return &ECRPublisher{
+		ECR:     ecr,
+		Docker:  docker,
+		Region:  region,
+		RepoURL: outputs["ecr_repo_url"],
+	}
+}

--- a/internal/infra/publish_test.go
+++ b/internal/infra/publish_test.go
@@ -1,0 +1,199 @@
+package infra
+
+import (
+	"context"
+	"testing"
+
+	"heph4estus/internal/cloud"
+)
+
+func TestECRPublisher_Authenticate(t *testing.T) {
+	// ECR auth requires 3 sequential calls: get-login-password, get-caller-identity, docker login.
+	ecr := &ECRClient{
+		runCmd: newSequentialMockExecutor([]mockCall{
+			{stdout: "token"},
+			{stdout: "123456789012"},
+			{stdout: "Login Succeeded"},
+		}),
+		logger: nopLogger{},
+	}
+	pub := &ECRPublisher{
+		ECR:     ecr,
+		Docker:  &DockerClient{runCmd: newMockExecutor("", "", 0, nil), logger: nopLogger{}},
+		Region:  "us-east-1",
+		RepoURL: "123.dkr.ecr.us-east-1.amazonaws.com/nmap",
+	}
+	if err := pub.Authenticate(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestECRPublisher_Publish(t *testing.T) {
+	cap, exec := newCapturingExecutor("")
+	docker := &DockerClient{runCmd: exec, logger: nopLogger{}}
+	pub := &ECRPublisher{
+		Docker:  docker,
+		RepoURL: "123.dkr.ecr.us-east-1.amazonaws.com/nmap",
+	}
+
+	ref, err := pub.Publish(context.Background(), "heph-nmap-worker:latest", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "123.dkr.ecr.us-east-1.amazonaws.com/nmap:latest"
+	if ref != expected {
+		t.Fatalf("expected ref %q, got %q", expected, ref)
+	}
+	// Should have called docker tag then docker push.
+	if len(cap.calls) != 2 {
+		t.Fatalf("expected 2 docker calls, got %d", len(cap.calls))
+	}
+	assertContains(t, cap.calls[0], "tag")
+	assertContains(t, cap.calls[1], "push")
+}
+
+func TestECRPublisher_Publish_MissingRepoURL(t *testing.T) {
+	pub := &ECRPublisher{
+		Docker: &DockerClient{runCmd: newMockExecutor("", "", 0, nil), logger: nopLogger{}},
+	}
+	_, err := pub.Publish(context.Background(), "img:latest", nil)
+	if err == nil {
+		t.Fatal("expected error for missing ecr_repo_url")
+	}
+}
+
+func TestRegistryPublisher_AuthenticateWithCredentials(t *testing.T) {
+	cap, exec := newCapturingExecutor("")
+	docker := &DockerClient{runCmd: exec, logger: nopLogger{}}
+	pub := &RegistryPublisher{
+		Docker:      docker,
+		RegistryURL: "10.0.1.5:5000",
+		Username:    "admin",
+		Password:    "secret123",
+	}
+
+	if err := pub.Authenticate(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cap.calls) != 1 {
+		t.Fatalf("expected 1 call (docker login), got %d", len(cap.calls))
+	}
+	assertContains(t, cap.calls[0], "docker")
+	assertContains(t, cap.calls[0], "login")
+	assertContains(t, cap.calls[0], "--username")
+	assertContains(t, cap.calls[0], "admin")
+	assertContains(t, cap.calls[0], "10.0.1.5:5000")
+}
+
+func TestRegistryPublisher_AuthenticateNoCredentials(t *testing.T) {
+	// No credentials — should be a no-op (no docker login call).
+	cap, exec := newCapturingExecutor("")
+	docker := &DockerClient{runCmd: exec, logger: nopLogger{}}
+	pub := &RegistryPublisher{
+		Docker:      docker,
+		RegistryURL: "10.0.1.5:5000",
+	}
+
+	if err := pub.Authenticate(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cap.calls) != 0 {
+		t.Fatalf("expected 0 calls for no-credential auth, got %d", len(cap.calls))
+	}
+}
+
+func TestRegistryPublisher_Publish(t *testing.T) {
+	cap, exec := newCapturingExecutor("")
+	docker := &DockerClient{runCmd: exec, logger: nopLogger{}}
+	pub := &RegistryPublisher{
+		Docker:      docker,
+		RegistryURL: "10.0.1.5:5000",
+	}
+
+	ref, err := pub.Publish(context.Background(), "heph-nmap-worker:latest", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "10.0.1.5:5000/heph-nmap-worker:latest"
+	if ref != expected {
+		t.Fatalf("expected ref %q, got %q", expected, ref)
+	}
+	if len(cap.calls) != 2 {
+		t.Fatalf("expected 2 docker calls, got %d", len(cap.calls))
+	}
+	assertContains(t, cap.calls[0], "tag")
+	assertContains(t, cap.calls[1], "push")
+}
+
+func TestRegistryPublisher_Publish_MissingRegistryURL(t *testing.T) {
+	pub := &RegistryPublisher{
+		Docker: &DockerClient{runCmd: newMockExecutor("", "", 0, nil), logger: nopLogger{}},
+	}
+	_, err := pub.Publish(context.Background(), "img:latest", nil)
+	if err == nil {
+		t.Fatal("expected error for missing registry_url")
+	}
+}
+
+func TestNewPublisher_AWS(t *testing.T) {
+	outputs := map[string]string{"ecr_repo_url": "123.dkr.ecr.us-east-1.amazonaws.com/nmap"}
+	docker := &DockerClient{runCmd: newMockExecutor("", "", 0, nil), logger: nopLogger{}}
+	ecr := &ECRClient{runCmd: newMockExecutor("", "", 0, nil), logger: nopLogger{}}
+
+	pub := NewPublisher(cloud.KindAWS, docker, ecr, outputs, "us-east-1")
+	if _, ok := pub.(*ECRPublisher); !ok {
+		t.Fatalf("expected *ECRPublisher, got %T", pub)
+	}
+}
+
+func TestNewPublisher_Selfhosted(t *testing.T) {
+	outputs := map[string]string{
+		"registry_url":      "10.0.1.5:5000",
+		"registry_username": "admin",
+		"registry_password": "secret",
+	}
+	docker := &DockerClient{runCmd: newMockExecutor("", "", 0, nil), logger: nopLogger{}}
+	ecr := &ECRClient{runCmd: newMockExecutor("", "", 0, nil), logger: nopLogger{}}
+
+	pub := NewPublisher(cloud.KindSelfhosted, docker, ecr, outputs, "")
+	rp, ok := pub.(*RegistryPublisher)
+	if !ok {
+		t.Fatalf("expected *RegistryPublisher, got %T", pub)
+	}
+	if rp.RegistryURL != "10.0.1.5:5000" {
+		t.Fatalf("expected registry URL 10.0.1.5:5000, got %q", rp.RegistryURL)
+	}
+	if rp.Username != "admin" {
+		t.Fatalf("expected username admin, got %q", rp.Username)
+	}
+}
+
+func TestNewPublisher_EmptyKindDefaultsToAWS(t *testing.T) {
+	outputs := map[string]string{"ecr_repo_url": "123.dkr.ecr.us-east-1.amazonaws.com/nmap"}
+	docker := &DockerClient{runCmd: newMockExecutor("", "", 0, nil), logger: nopLogger{}}
+	ecr := &ECRClient{runCmd: newMockExecutor("", "", 0, nil), logger: nopLogger{}}
+
+	pub := NewPublisher("", docker, ecr, outputs, "us-east-1")
+	if _, ok := pub.(*ECRPublisher); !ok {
+		t.Fatalf("empty kind should default to ECRPublisher, got %T", pub)
+	}
+}
+
+func TestDockerLogin(t *testing.T) {
+	cap, exec := newCapturingExecutor("")
+	dc := &DockerClient{runCmd: exec, logger: nopLogger{}}
+
+	if err := dc.Login(context.Background(), "registry.example.com", "user", "pass"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cap.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(cap.calls))
+	}
+	assertContains(t, cap.calls[0], "docker")
+	assertContains(t, cap.calls[0], "login")
+	assertContains(t, cap.calls[0], "--username")
+	assertContains(t, cap.calls[0], "user")
+	assertContains(t, cap.calls[0], "--password")
+	assertContains(t, cap.calls[0], "pass")
+	assertContains(t, cap.calls[0], "registry.example.com")
+}

--- a/internal/infra/redact.go
+++ b/internal/infra/redact.go
@@ -1,0 +1,46 @@
+package infra
+
+import "strings"
+
+// sensitivePatterns is the list of substrings that mark a Terraform output key
+// as sensitive. Matching is case-insensitive against the key name.
+var sensitivePatterns = []string{
+	"secret",
+	"password",
+	"token",
+	"credential",
+	"access_key",
+}
+
+const redactedPlaceholder = "***"
+
+// IsSensitiveOutput returns true when the output key name matches any of the
+// known sensitive patterns. Use this to decide whether a value should be
+// redacted before logging or displaying it to the operator.
+func IsSensitiveOutput(key string) bool {
+	lower := strings.ToLower(key)
+	for _, p := range sensitivePatterns {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// RedactOutputValue returns the original value when the key is safe, or a
+// redaction placeholder when it matches a sensitive pattern.
+func RedactOutputValue(key, value string) string {
+	if IsSensitiveOutput(key) {
+		return redactedPlaceholder
+	}
+	return value
+}
+
+// RedactOutputs returns a copy of the outputs map with sensitive values masked.
+func RedactOutputs(outputs map[string]string) map[string]string {
+	redacted := make(map[string]string, len(outputs))
+	for k, v := range outputs {
+		redacted[k] = RedactOutputValue(k, v)
+	}
+	return redacted
+}

--- a/internal/infra/redact_test.go
+++ b/internal/infra/redact_test.go
@@ -1,0 +1,114 @@
+package infra
+
+import "testing"
+
+func TestIsSensitiveOutput(t *testing.T) {
+	tests := []struct {
+		key  string
+		want bool
+	}{
+		// Should be sensitive.
+		{"s3_secret_key", true},
+		{"s3_access_key", true},
+		{"registry_password", true},
+		{"minio_root_password", true},
+		{"auth_token", true},
+		{"api_credential", true},
+		{"S3_SECRET_KEY", true}, // case insensitive
+
+		// Should NOT be sensitive.
+		{"tool_name", false},
+		{"nats_url", false},
+		{"s3_endpoint", false},
+		{"s3_region", false},
+		{"s3_path_style", false},
+		{"registry_url", false},
+		{"sqs_queue_url", false},
+		{"ecr_repo_url", false},
+		{"s3_bucket_name", false},
+		{"ecs_cluster_name", false},
+	}
+
+	for _, tt := range tests {
+		got := IsSensitiveOutput(tt.key)
+		if got != tt.want {
+			t.Errorf("IsSensitiveOutput(%q) = %v, want %v", tt.key, got, tt.want)
+		}
+	}
+}
+
+func TestRedactOutputValue(t *testing.T) {
+	if got := RedactOutputValue("s3_secret_key", "my-secret"); got != redactedPlaceholder {
+		t.Errorf("expected redacted, got %q", got)
+	}
+	if got := RedactOutputValue("tool_name", "nmap"); got != "nmap" {
+		t.Errorf("expected nmap, got %q", got)
+	}
+}
+
+func TestRedactOutputValue_SelfhostedOutputs(t *testing.T) {
+	// Prove selfhosted controller outputs are redacted when sensitive.
+	sensitiveKeys := []string{
+		"minio_root_password",
+		"registry_password",
+		"s3_secret_key",
+		"s3_access_key",
+	}
+	for _, key := range sensitiveKeys {
+		got := RedactOutputValue(key, "real-value")
+		if got != redactedPlaceholder {
+			t.Errorf("RedactOutputValue(%q) = %q, expected redacted", key, got)
+		}
+	}
+
+	// Non-sensitive selfhosted outputs should pass through.
+	safeKeys := map[string]string{
+		"nats_url":         "nats://10.0.1.5:4222",
+		"s3_endpoint":      "http://10.0.1.5:9000",
+		"registry_url":     "10.0.1.5:5000",
+		"s3_region":        "us-east-1",
+		"s3_path_style":    "true",
+		"controller_ip":    "10.0.1.5",
+	}
+	for key, val := range safeKeys {
+		got := RedactOutputValue(key, val)
+		if got != val {
+			t.Errorf("RedactOutputValue(%q) = %q, expected pass-through %q", key, got, val)
+		}
+	}
+}
+
+func TestRedactOutputs(t *testing.T) {
+	outputs := map[string]string{
+		"tool_name":     "nmap",
+		"s3_access_key": "AKIAIOSFODNN7EXAMPLE",
+		"s3_secret_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		"s3_endpoint":   "http://10.0.1.5:9000",
+		"registry_url":  "10.0.1.5:5000",
+	}
+	redacted := RedactOutputs(outputs)
+
+	// Safe values pass through.
+	if redacted["tool_name"] != "nmap" {
+		t.Errorf("tool_name = %q, want nmap", redacted["tool_name"])
+	}
+	if redacted["s3_endpoint"] != "http://10.0.1.5:9000" {
+		t.Errorf("s3_endpoint = %q, want http://10.0.1.5:9000", redacted["s3_endpoint"])
+	}
+	if redacted["registry_url"] != "10.0.1.5:5000" {
+		t.Errorf("registry_url = %q, want 10.0.1.5:5000", redacted["registry_url"])
+	}
+
+	// Sensitive values are masked.
+	if redacted["s3_access_key"] != redactedPlaceholder {
+		t.Errorf("s3_access_key = %q, want %q", redacted["s3_access_key"], redactedPlaceholder)
+	}
+	if redacted["s3_secret_key"] != redactedPlaceholder {
+		t.Errorf("s3_secret_key = %q, want %q", redacted["s3_secret_key"], redactedPlaceholder)
+	}
+
+	// Original map is not modified.
+	if outputs["s3_access_key"] == redactedPlaceholder {
+		t.Error("original map was modified")
+	}
+}

--- a/internal/infra/runtime.go
+++ b/internal/infra/runtime.go
@@ -1,0 +1,39 @@
+package infra
+
+import "heph4estus/internal/cloud"
+
+// AWSRequiredOutputKeys lists the Terraform output keys that must be present
+// for an AWS scan to proceed. This includes spot-mode keys (ami_id,
+// instance_profile_arn) because the generic Terraform module always outputs
+// them, and their absence indicates stale or partial infrastructure.
+// tool_name is required to detect mismatches.
+var AWSRequiredOutputKeys = []string{
+	"tool_name",
+	"sqs_queue_url",
+	"s3_bucket_name",
+	"ecr_repo_url",
+	"ecs_cluster_name",
+	"task_definition_arn",
+	"subnet_ids",
+	"security_group_id",
+	"ami_id",
+	"instance_profile_arn",
+}
+
+// SelfhostedRequiredOutputKeys lists the output keys for selfhosted
+// infrastructure. Selfhosted does not use Terraform for provisioning so this
+// is intentionally minimal — only tool_name is required to enable lifecycle
+// mismatch detection. Later tracks may extend this if selfhosted gains its
+// own state-file contract.
+var SelfhostedRequiredOutputKeys = []string{
+	"tool_name",
+}
+
+// RequiredOutputKeysForCloud returns the required output keys for the given
+// cloud provider family. Unknown kinds fall back to the AWS set.
+func RequiredOutputKeysForCloud(kind cloud.Kind) []string {
+	if kind.IsSelfhostedFamily() {
+		return SelfhostedRequiredOutputKeys
+	}
+	return AWSRequiredOutputKeys
+}

--- a/internal/infra/toolconfig.go
+++ b/internal/infra/toolconfig.go
@@ -5,12 +5,14 @@ import (
 	"os"
 	"strings"
 
+	"heph4estus/internal/cloud"
 	"heph4estus/internal/modules"
 )
 
 // ToolConfig holds all deploy metadata derived from a module definition.
 // This is the single source of truth used by CLI, TUI, and lifecycle logic.
 type ToolConfig struct {
+	Cloud         cloud.Kind // Provider family (empty defaults to AWS)
 	ToolName      string
 	TerraformDir  string
 	Dockerfile    string
@@ -73,19 +75,8 @@ func AWSRegion() string {
 	return "us-east-1"
 }
 
-// RequiredOutputKeys lists the Terraform output keys that must be present for a scan to proceed.
-// This includes spot-mode keys (ami_id, instance_profile_arn) because the generic terraform
-// module always outputs them, and their absence indicates stale or partial infrastructure.
-// tool_name is required to detect mismatches — without it, legacy state cannot be classified.
-var RequiredOutputKeys = []string{
-	"tool_name",
-	"sqs_queue_url",
-	"s3_bucket_name",
-	"ecr_repo_url",
-	"ecs_cluster_name",
-	"task_definition_arn",
-	"subnet_ids",
-	"security_group_id",
-	"ami_id",
-	"instance_profile_arn",
-}
+// RequiredOutputKeys is the legacy AWS-only required-output list. New code
+// should call RequiredOutputKeysForCloud(kind) instead, which returns the
+// correct set for any cloud.Kind. This alias is kept so existing callers
+// outside this package continue to compile without churn.
+var RequiredOutputKeys = AWSRequiredOutputKeys

--- a/internal/operator/config.go
+++ b/internal/operator/config.go
@@ -19,8 +19,8 @@ type OperatorConfig struct {
 	ComputeMode   string `json:"compute_mode,omitempty"`
 	CleanupPolicy string `json:"cleanup_policy,omitempty"` // "reuse" or "destroy-after"
 	OutputDir     string `json:"output_dir,omitempty"`
-	// Cloud is the persisted default cloud kind ("aws" or "selfhosted").
-	// Empty means "use the built-in default" (AWS).
+	// Cloud is the persisted default cloud kind ("aws", "manual", "hetzner",
+	// etc.). Empty means "use the built-in default" (AWS).
 	Cloud string `json:"cloud,omitempty"`
 }
 

--- a/internal/operator/config_test.go
+++ b/internal/operator/config_test.go
@@ -302,9 +302,10 @@ func TestResolveCloud(t *testing.T) {
 		want     cloud.Kind
 		wantErr  bool
 	}{
-		{"explicit aws wins", "aws", &OperatorConfig{Cloud: "selfhosted"}, cloud.KindAWS, false},
-		{"explicit selfhosted wins", "selfhosted", &OperatorConfig{Cloud: "aws"}, cloud.KindSelfhosted, false},
-		{"config used when explicit empty", "", &OperatorConfig{Cloud: "selfhosted"}, cloud.KindSelfhosted, false},
+		{"explicit aws wins", "aws", &OperatorConfig{Cloud: "manual"}, cloud.KindAWS, false},
+		{"explicit provider wins", "hetzner", &OperatorConfig{Cloud: "aws"}, cloud.KindHetzner, false},
+		{"config used when explicit empty", "", &OperatorConfig{Cloud: "manual"}, cloud.KindManual, false},
+		{"legacy persisted alias still parses", "", &OperatorConfig{Cloud: "selfhosted"}, cloud.KindManual, false},
 		{"defaults to aws when both empty", "", &OperatorConfig{}, cloud.KindAWS, false},
 		{"nil config defaults to aws", "", nil, cloud.KindAWS, false},
 		{"invalid explicit errors", "gcp", &OperatorConfig{}, "", true},
@@ -326,7 +327,7 @@ func TestResolveCloud(t *testing.T) {
 func TestSaveAndLoadConfig_Cloud(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
-	cfg := &OperatorConfig{Cloud: "selfhosted"}
+	cfg := &OperatorConfig{Cloud: "hetzner"}
 	if err := SaveConfigTo(cfg, path); err != nil {
 		t.Fatalf("save: %v", err)
 	}
@@ -334,8 +335,8 @@ func TestSaveAndLoadConfig_Cloud(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if loaded.Cloud != "selfhosted" {
-		t.Errorf("cloud = %q, want selfhosted", loaded.Cloud)
+	if loaded.Cloud != "hetzner" {
+		t.Errorf("cloud = %q, want hetzner", loaded.Cloud)
 	}
 }
 

--- a/internal/tui/core/types.go
+++ b/internal/tui/core/types.go
@@ -86,11 +86,21 @@ type DeployConfig struct {
 	OutputDir     string // local export directory
 }
 
+// SelfhostedRuntime carries VPS/selfhosted-family launch data for future
+// Track 1 / Track 2 consumption. Nil in AWS flows.
+type SelfhostedRuntime struct {
+	WorkerHosts []string // SSH-reachable worker addresses
+	SSHUser     string   // SSH login user
+	DockerImage string   // Docker image reference for the worker container
+}
+
 // InfraOutputs holds terraform outputs needed by downstream views.
 type InfraOutputs struct {
 	// Cloud is the provider family these outputs belong to. Empty means
 	// cloud.DefaultKind so existing AWS-only call sites stay valid.
 	Cloud cloud.Kind
+
+	// --- AWS runtime fields (unchanged for backward compat) ---
 
 	SQSQueueURL       string
 	ECRRepoURL        string
@@ -139,6 +149,12 @@ type InfraOutputs struct {
 	// Cleanup outcome — set by status view after auto-destroy attempt.
 	Destroyed  bool   // true if infra was automatically destroyed after export
 	DestroyErr string // non-empty if auto-destroy was attempted but failed
+
+	// --- Selfhosted-family runtime data (populated for manual/VPS providers) ---
+
+	// Selfhosted carries selfhosted-specific launch data. Nil for AWS flows.
+	// Track 1 populates this with worker host and Docker image info.
+	Selfhosted *SelfhostedRuntime
 }
 
 // LifecycleCheckMsg carries the result of a lifecycle probe back to the deploy view.

--- a/internal/tui/views/deploy/deployer.go
+++ b/internal/tui/views/deploy/deployer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 
+	"heph4estus/internal/cloud"
 	"heph4estus/internal/infra"
 	"heph4estus/internal/logger"
 )
@@ -16,9 +17,17 @@ type Deployer interface {
 	TerraformReadOutputs(ctx context.Context, workDir string) (map[string]string, error)
 	DockerBuild(ctx context.Context, dockerfile, buildCtx, tag string, stream io.Writer) error
 	DockerBuildWithArgs(ctx context.Context, dockerfile, buildCtx, tag string, buildArgs map[string]string, stream io.Writer) error
-	ECRAuthenticate(ctx context.Context, region string) error
-	DockerTag(ctx context.Context, source, target string) error
-	DockerPush(ctx context.Context, tag string, stream io.Writer) error
+
+	// RegistryAuth authenticates Docker to the appropriate image registry.
+	// For AWS this does the three-step ECR auth flow; for selfhosted it runs
+	// docker login to the controller registry (or no-ops when no credentials
+	// are configured).
+	RegistryAuth(ctx context.Context, kind cloud.Kind, region string, outputs map[string]string) error
+
+	// ImagePublish tags a local image and pushes it to the provider's registry.
+	// For AWS this pushes to ECR; for selfhosted it pushes to the controller registry.
+	ImagePublish(ctx context.Context, kind cloud.Kind, localTag string, outputs map[string]string, stream io.Writer) error
+
 	TerraformDestroy(ctx context.Context, workDir string, stream io.Writer) error
 }
 
@@ -62,16 +71,15 @@ func (d *RealDeployer) DockerBuildWithArgs(ctx context.Context, dockerfile, buil
 	return d.docker.BuildWithArgs(ctx, dockerfile, buildCtx, tag, buildArgs, stream)
 }
 
-func (d *RealDeployer) ECRAuthenticate(ctx context.Context, region string) error {
-	return d.ecr.Authenticate(ctx, region)
+func (d *RealDeployer) RegistryAuth(ctx context.Context, kind cloud.Kind, region string, outputs map[string]string) error {
+	pub := infra.NewPublisher(kind, d.docker, d.ecr, outputs, region)
+	return pub.Authenticate(ctx)
 }
 
-func (d *RealDeployer) DockerTag(ctx context.Context, source, target string) error {
-	return d.docker.Tag(ctx, source, target)
-}
-
-func (d *RealDeployer) DockerPush(ctx context.Context, tag string, stream io.Writer) error {
-	return d.docker.Push(ctx, tag, stream)
+func (d *RealDeployer) ImagePublish(ctx context.Context, kind cloud.Kind, localTag string, outputs map[string]string, stream io.Writer) error {
+	pub := infra.NewPublisher(kind, d.docker, d.ecr, outputs, "")
+	_, err := pub.Publish(ctx, localTag, stream)
+	return err
 }
 
 func (d *RealDeployer) TerraformDestroy(ctx context.Context, workDir string, stream io.Writer) error {

--- a/internal/tui/views/deploy/model.go
+++ b/internal/tui/views/deploy/model.go
@@ -24,8 +24,8 @@ const (
 	stageTerraformApply = "terraform-apply"
 	stageReadOutputs    = "read-outputs"
 	stageDockerBuild    = "docker-build"
-	stageECRAuth        = "ecr-auth"
-	stageDockerTagPush  = "docker-tag-push"
+	stageRegistryAuth   = "registry-auth"
+	stageImagePublish   = "image-publish"
 	stageComplete       = "complete"
 	stageFailed         = "failed"
 	stageRejected       = "rejected"
@@ -111,7 +111,7 @@ func (m *Model) runLifecycleCheck() tea.Cmd {
 		}
 
 		tf := infra.NewTerraformClient(simpleLogger{})
-		probe := infra.Probe(ctx, tf, cfg.TerraformDir, toolName)
+		probe := infra.Probe(ctx, tf, cfg.Cloud, cfg.TerraformDir, toolName)
 		decision := infra.Decide(probe, infra.LifecyclePolicy{})
 
 		switch decision.Decision {
@@ -233,8 +233,8 @@ func (m *Model) View() string {
 		{stageTerraformApply, "Terraform Apply"},
 		{stageReadOutputs, "Read Outputs"},
 		{stageDockerBuild, "Docker Build"},
-		{stageECRAuth, "ECR Auth"},
-		{stageDockerTagPush, "Docker Push"},
+		{stageRegistryAuth, "Registry Auth"},
+		{stageImagePublish, "Image Publish"},
 	}
 
 	currentIdx := -1
@@ -275,7 +275,7 @@ func (m *Model) View() string {
 		b.WriteString("  " + m.planSummary + "\n\n")
 		b.WriteString("  " + core.SelectedStyle.Render("Apply these changes? (y/enter = yes, n/esc = no)") + "\n")
 
-	case stageTerraformApply, stageDockerBuild, stageDockerTagPush:
+	case stageTerraformApply, stageDockerBuild, stageImagePublish:
 		b.WriteString(m.viewport.View())
 		b.WriteString("\n")
 
@@ -359,20 +359,16 @@ func (m *Model) runStage(stage string) tea.Cmd {
 			tickCmd(),
 		)
 
-	case stageECRAuth:
+	case stageRegistryAuth:
 		return func() tea.Msg {
-			err := deployer.ECRAuthenticate(ctx, cfg.AWSRegion)
+			err := deployer.RegistryAuth(ctx, cfg.Cloud, cfg.AWSRegion, m.outputs)
 			return core.StageCompleteMsg{Stage: stage, Error: err}
 		}
 
-	case stageDockerTagPush:
-		ecrURL := m.outputs["ecr_repo_url"]
+	case stageImagePublish:
 		return tea.Batch(
 			func() tea.Msg {
-				if err := deployer.DockerTag(ctx, cfg.DockerTag, ecrURL+":latest"); err != nil {
-					return core.StageCompleteMsg{Stage: stage, Error: err}
-				}
-				err := deployer.DockerPush(ctx, ecrURL+":latest", sw)
+				err := deployer.ImagePublish(ctx, cfg.Cloud, cfg.DockerTag, m.outputs, sw)
 				return core.StageCompleteMsg{Stage: stage, Error: err}
 			},
 			tickCmd(),
@@ -404,14 +400,14 @@ func (m *Model) advanceStage(completed string) tea.Cmd {
 
 	case stageDockerBuild:
 		m.streamLog = ""
-		m.stage = stageECRAuth
-		return m.runStage(stageECRAuth)
+		m.stage = stageRegistryAuth
+		return m.runStage(stageRegistryAuth)
 
-	case stageECRAuth:
-		m.stage = stageDockerTagPush
-		return m.runStage(stageDockerTagPush)
+	case stageRegistryAuth:
+		m.stage = stageImagePublish
+		return m.runStage(stageImagePublish)
 
-	case stageDockerTagPush:
+	case stageImagePublish:
 		m.stage = stageComplete
 		return m.emitNavigateToStatus()
 	}
@@ -487,7 +483,7 @@ func tickCmd() tea.Cmd {
 }
 
 func isStreamingStage(stage string) bool {
-	return stage == stageTerraformApply || stage == stageDockerBuild || stage == stageDockerTagPush
+	return stage == stageTerraformApply || stage == stageDockerBuild || stage == stageImagePublish
 }
 
 func mergeOutputs(existing, new map[string]string) map[string]string {

--- a/internal/tui/views/deploy/model_test.go
+++ b/internal/tui/views/deploy/model_test.go
@@ -8,21 +8,21 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"heph4estus/internal/cloud"
 	"heph4estus/internal/tui/core"
 )
 
 // mockDeployer records calls and returns configured results.
 type mockDeployer struct {
-	initErr       error
-	planSummary   string
-	planErr       error
-	applyErr      error
-	readOutputs   map[string]string
-	readOutputErr error
-	buildErr      error
-	ecrAuthErr    error
-	tagErr        error
-	pushErr       error
+	initErr         error
+	planSummary     string
+	planErr         error
+	applyErr        error
+	readOutputs     map[string]string
+	readOutputErr   error
+	buildErr        error
+	registryAuthErr error
+	imagePublishErr error
 }
 
 func (d *mockDeployer) TerraformInit(context.Context, string) error {
@@ -49,16 +49,12 @@ func (d *mockDeployer) DockerBuildWithArgs(_ context.Context, _, _, _ string, _ 
 	return d.buildErr
 }
 
-func (d *mockDeployer) ECRAuthenticate(context.Context, string) error {
-	return d.ecrAuthErr
+func (d *mockDeployer) RegistryAuth(_ context.Context, _ cloud.Kind, _ string, _ map[string]string) error {
+	return d.registryAuthErr
 }
 
-func (d *mockDeployer) DockerTag(_ context.Context, _, _ string) error {
-	return d.tagErr
-}
-
-func (d *mockDeployer) DockerPush(_ context.Context, _ string, _ io.Writer) error {
-	return d.pushErr
+func (d *mockDeployer) ImagePublish(_ context.Context, _ cloud.Kind, _ string, _ map[string]string, _ io.Writer) error {
+	return d.imagePublishErr
 }
 
 func (d *mockDeployer) TerraformDestroy(_ context.Context, _ string, _ io.Writer) error {
@@ -235,13 +231,13 @@ func TestDeployModel_FullPipeline(t *testing.T) {
 		}
 	}
 
-	// ECR auth
+	// Registry auth
 	if cmd != nil {
 		msg = cmd()
 		_, cmd = m.Update(msg)
 	}
 
-	// Docker tag+push
+	// Image publish
 	if cmd != nil {
 		msgs = drainBatch(cmd)
 		for _, msg := range msgs {
@@ -303,6 +299,22 @@ func TestDeployModel_ViewContainsTitle(t *testing.T) {
 	}
 }
 
+func TestDeployModel_ViewShowsGenericStageLabels(t *testing.T) {
+	m := NewWithDeployer(core.DeployConfig{}, &mockDeployer{})
+	v := m.View()
+	// Provider-generic stage labels should appear.
+	if !strings.Contains(v, "Registry Auth") {
+		t.Fatal("expected 'Registry Auth' in view, stage names should be provider-generic")
+	}
+	if !strings.Contains(v, "Image Publish") {
+		t.Fatal("expected 'Image Publish' in view, stage names should be provider-generic")
+	}
+	// Old ECR-specific names should NOT appear.
+	if strings.Contains(v, "ECR Auth") {
+		t.Fatal("view should not contain 'ECR Auth' — stage names should be provider-generic")
+	}
+}
+
 func TestDeployModel_GenericPostDeployNavigation(t *testing.T) {
 	d := &mockDeployer{
 		planSummary: "Plan: 1 to add",
@@ -346,9 +358,9 @@ func TestDeployModel_GenericPostDeployNavigation(t *testing.T) {
 	if cmd != nil { msg = cmd(); _, cmd = m.Update(msg) }
 	// Docker build
 	if cmd != nil { msgs = drainBatch(cmd); for _, msg := range msgs { if sc, ok := msg.(core.StageCompleteMsg); ok { _, cmd = m.Update(sc); break } } }
-	// ECR auth
+	// Registry auth
 	if cmd != nil { msg = cmd(); _, cmd = m.Update(msg) }
-	// Docker tag+push
+	// Image publish
 	if cmd != nil { msgs = drainBatch(cmd); for _, msg := range msgs { if sc, ok := msg.(core.StageCompleteMsg); ok { _, cmd = m.Update(sc); break } } }
 
 	if m.stage != stageComplete {
@@ -540,8 +552,8 @@ func TestDeployModel_FreshDeployCarriesCleanupFields(t *testing.T) {
 	for _, msg := range msgs { if sc, ok := msg.(core.StageCompleteMsg); ok { _, cmd = m.Update(sc); break } }
 	if cmd != nil { msg = cmd(); _, cmd = m.Update(msg) } // read outputs
 	if cmd != nil { msgs = drainBatch(cmd); for _, msg := range msgs { if sc, ok := msg.(core.StageCompleteMsg); ok { _, cmd = m.Update(sc); break } } } // docker build
-	if cmd != nil { msg = cmd(); _, cmd = m.Update(msg) } // ecr auth
-	if cmd != nil { msgs = drainBatch(cmd); for _, msg := range msgs { if sc, ok := msg.(core.StageCompleteMsg); ok { _, cmd = m.Update(sc); break } } } // docker push
+	if cmd != nil { msg = cmd(); _, cmd = m.Update(msg) } // registry auth
+	if cmd != nil { msgs = drainBatch(cmd); for _, msg := range msgs { if sc, ok := msg.(core.StageCompleteMsg); ok { _, cmd = m.Update(sc); break } } } // image publish
 
 	if cmd == nil {
 		t.Fatal("expected navigate command")
@@ -560,6 +572,36 @@ func TestDeployModel_FreshDeployCarriesCleanupFields(t *testing.T) {
 	}
 	if infraOut.OutputDir != "/data/out" {
 		t.Errorf("OutputDir = %q, want /data/out", infraOut.OutputDir)
+	}
+}
+
+func TestDeployModel_ReuseCarriesCloudKind(t *testing.T) {
+	outputs := map[string]string{
+		"sqs_queue_url":       "https://sqs.example.com/q",
+		"ecr_repo_url":        "123.dkr.ecr.us-east-1.amazonaws.com/nmap",
+		"s3_bucket_name":      "bucket",
+		"ecs_cluster_name":    "cluster",
+		"task_definition_arn": "arn:aws:ecs:td",
+		"subnet_ids":          "[subnet-a]",
+		"security_group_id":   "sg-123",
+	}
+	cfg := core.DeployConfig{
+		Cloud:          "aws",
+		TargetsContent: "1.1.1.1\n",
+		WorkerCount:    5,
+	}
+	m := NewWithDeployer(cfg, &mockDeployer{})
+
+	_, cmd := simulateLifecycleReuse(m, outputs)
+	if cmd == nil {
+		t.Fatal("expected navigate command")
+	}
+	msg := cmd()
+	nav := msg.(core.NavigateWithDataMsg)
+	infraOut := nav.Data.(core.InfraOutputs)
+	// Cloud kind should not be selfhosted when config says AWS.
+	if infraOut.Cloud == "selfhosted" {
+		t.Fatal("AWS deploy should not produce selfhosted InfraOutputs")
 	}
 }
 

--- a/internal/tui/views/generic/config.go
+++ b/internal/tui/views/generic/config.go
@@ -12,6 +12,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"heph4estus/internal/cloud"
+	"heph4estus/internal/cloud/factory"
 	"heph4estus/internal/infra"
 	"heph4estus/internal/modules"
 	"heph4estus/internal/operator"
@@ -119,7 +120,7 @@ func NewConfig(toolName string) *ConfigModel {
 	computeMode := operator.ResolveComputeMode("", cfg)
 	savedCloud := ""
 	if cfg != nil {
-		savedCloud = cfg.Cloud
+		savedCloud = normalizeCloudValue(cfg.Cloud)
 	}
 
 	m := &ConfigModel{
@@ -284,18 +285,50 @@ func (m *ConfigModel) handleTargetListFileRead(msg fileReadMsg) tea.Cmd {
 	if computeMode == "" {
 		computeMode = "auto"
 	}
-	if computeMode != "auto" && computeMode != "fargate" && computeMode != "spot" {
-		m.errMsg = "Compute mode must be auto, fargate, or spot"
-		return nil
-	}
 	cloudKind, cloudErr := cloud.ParseKind(strings.TrimSpace(m.inputs[cfgFieldCloud].Value()))
 	if cloudErr != nil {
 		m.errMsg = fmt.Sprintf("Invalid cloud: %v", cloudErr)
 		return nil
 	}
-	if cloudKind == cloud.KindSelfhosted {
-		m.errMsg = "Selfhosted compute/deploy support lands in PR 6.2/6.3"
+	if err := cloud.ValidateComputeMode(cloudKind, computeMode); err != nil {
+		m.errMsg = err.Error()
 		return nil
+	}
+
+	opCfg, _ := operator.LoadConfig()
+	cleanupPolicy := operator.ResolveCleanupPolicy("", opCfg)
+	outputDir := operator.ResolveOutputDir("", opCfg)
+	toolOptions := strings.TrimSpace(m.inputs[cfgFieldOptions].Value())
+
+	if cloudKind.IsSelfhostedFamily() {
+		// Selfhosted: bypass deploy view, go directly to status.
+		shCfg := factory.SelfhostedConfigFromEnv()
+		if shCfg.QueueID == "" || shCfg.Bucket == "" {
+			m.errMsg = fmt.Sprintf("%s requires SELFHOSTED_QUEUE_ID and SELFHOSTED_BUCKET environment variables", cloudKind.Canonical())
+			return nil
+		}
+		return func() tea.Msg {
+			return core.NavigateWithDataMsg{
+				Target: core.ViewGenericStatus,
+				Data: core.InfraOutputs{
+					Cloud:          cloudKind,
+					SQSQueueURL:    shCfg.QueueID,
+					S3BucketName:   shCfg.Bucket,
+					TargetsContent: msg.content,
+					WorkerCount:    workerCount,
+					ComputeMode:    computeMode,
+					ToolName:       m.toolName,
+					ToolOptions:    toolOptions,
+					CleanupPolicy:  cleanupPolicy,
+					OutputDir:      outputDir,
+					Selfhosted: &core.SelfhostedRuntime{
+						WorkerHosts: shCfg.WorkerHosts,
+						SSHUser:     shCfg.SSHUser,
+						DockerImage: shCfg.DockerImage,
+					},
+				},
+			}
+		}
 	}
 
 	tc, err := infra.ResolveToolConfig(m.toolName)
@@ -303,9 +336,6 @@ func (m *ConfigModel) handleTargetListFileRead(msg fileReadMsg) tea.Cmd {
 		m.errMsg = fmt.Sprintf("Error resolving tool config: %v", err)
 		return nil
 	}
-	opCfg, _ := operator.LoadConfig()
-	cleanupPolicy := operator.ResolveCleanupPolicy("", opCfg)
-	outputDir := operator.ResolveOutputDir("", opCfg)
 	return func() tea.Msg {
 		return core.NavigateWithDataMsg{
 			Target: core.ViewDeploy,
@@ -323,7 +353,7 @@ func (m *ConfigModel) handleTargetListFileRead(msg fileReadMsg) tea.Cmd {
 				WorkerCount:    workerCount,
 				ComputeMode:    computeMode,
 				ToolName:       m.toolName,
-				ToolOptions:    strings.TrimSpace(m.inputs[cfgFieldOptions].Value()),
+				ToolOptions:    toolOptions,
 				PostDeployView: core.ViewGenericStatus,
 				CleanupPolicy:  cleanupPolicy,
 				OutputDir:      outputDir,
@@ -358,18 +388,52 @@ func (m *ConfigModel) handleWordlistFileRead(msg wordlistReadMsg) tea.Cmd {
 	if computeMode == "" {
 		computeMode = "auto"
 	}
-	if computeMode != "auto" && computeMode != "fargate" && computeMode != "spot" {
-		m.errMsg = "Compute mode must be auto, fargate, or spot"
-		return nil
-	}
 	cloudKind, cloudErr := cloud.ParseKind(strings.TrimSpace(m.wlInputs[wlFieldCloud].Value()))
 	if cloudErr != nil {
 		m.errMsg = fmt.Sprintf("Invalid cloud: %v", cloudErr)
 		return nil
 	}
-	if cloudKind == cloud.KindSelfhosted {
-		m.errMsg = "Selfhosted compute/deploy support lands in PR 6.2/6.3"
+	if err := cloud.ValidateComputeMode(cloudKind, computeMode); err != nil {
+		m.errMsg = err.Error()
 		return nil
+	}
+
+	wlCfg, _ := operator.LoadConfig()
+	wlCleanup := operator.ResolveCleanupPolicy("", wlCfg)
+	wlOutDir := operator.ResolveOutputDir("", wlCfg)
+	toolOptions := strings.TrimSpace(m.wlInputs[wlFieldOptions].Value())
+
+	if cloudKind.IsSelfhostedFamily() {
+		// Selfhosted: bypass deploy view, go directly to status.
+		shCfg := factory.SelfhostedConfigFromEnv()
+		if shCfg.QueueID == "" || shCfg.Bucket == "" {
+			m.errMsg = fmt.Sprintf("%s requires SELFHOSTED_QUEUE_ID and SELFHOSTED_BUCKET environment variables", cloudKind.Canonical())
+			return nil
+		}
+		return func() tea.Msg {
+			return core.NavigateWithDataMsg{
+				Target: core.ViewGenericStatus,
+				Data: core.InfraOutputs{
+					Cloud:           cloudKind,
+					SQSQueueURL:     shCfg.QueueID,
+					S3BucketName:    shCfg.Bucket,
+					WorkerCount:     workerCount,
+					ComputeMode:     computeMode,
+					ToolName:        m.toolName,
+					ToolOptions:     toolOptions,
+					WordlistContent: msg.content,
+					RuntimeTarget:   runtimeTarget,
+					ChunkCount:      chunkCount,
+					CleanupPolicy:   wlCleanup,
+					OutputDir:       wlOutDir,
+					Selfhosted: &core.SelfhostedRuntime{
+						WorkerHosts: shCfg.WorkerHosts,
+						SSHUser:     shCfg.SSHUser,
+						DockerImage: shCfg.DockerImage,
+					},
+				},
+			}
+		}
 	}
 
 	tc, err := infra.ResolveToolConfig(m.toolName)
@@ -377,10 +441,6 @@ func (m *ConfigModel) handleWordlistFileRead(msg wordlistReadMsg) tea.Cmd {
 		m.errMsg = fmt.Sprintf("Error resolving tool config: %v", err)
 		return nil
 	}
-
-	wlCfg, _ := operator.LoadConfig()
-	wlCleanup := operator.ResolveCleanupPolicy("", wlCfg)
-	wlOutDir := operator.ResolveOutputDir("", wlCfg)
 	return func() tea.Msg {
 		return core.NavigateWithDataMsg{
 			Target: core.ViewDeploy,
@@ -397,7 +457,7 @@ func (m *ConfigModel) handleWordlistFileRead(msg wordlistReadMsg) tea.Cmd {
 				WorkerCount:     workerCount,
 				ComputeMode:     computeMode,
 				ToolName:        m.toolName,
-				ToolOptions:     strings.TrimSpace(m.wlInputs[wlFieldOptions].Value()),
+				ToolOptions:     toolOptions,
 				PostDeployView:  core.ViewGenericStatus,
 				WordlistContent: msg.content,
 				RuntimeTarget:   runtimeTarget,
@@ -507,6 +567,14 @@ func (m *ConfigModel) updateFocus() tea.Cmd {
 		}
 	}
 	return tea.Batch(cmds...)
+}
+
+func normalizeCloudValue(value string) string {
+	kind, err := cloud.ParseKind(value)
+	if err != nil {
+		return strings.TrimSpace(value)
+	}
+	return string(kind.Canonical())
 }
 
 func (m *ConfigModel) submit() tea.Cmd {

--- a/internal/tui/views/generic/config_test.go
+++ b/internal/tui/views/generic/config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"heph4estus/internal/cloud"
 	"heph4estus/internal/tui/core"
 )
 
@@ -155,7 +156,71 @@ func TestGenericConfigInvalidComputeMode(t *testing.T) {
 	if cmd != nil {
 		t.Fatal("expected nil command for invalid compute mode")
 	}
-	if !strings.Contains(m.View(), "Compute mode must be") {
+	if !strings.Contains(m.View(), "compute-mode must be") {
 		t.Fatal("expected compute mode error message")
+	}
+}
+
+func TestGenericConfigProviderNavigatesToStatus(t *testing.T) {
+	t.Setenv("SELFHOSTED_QUEUE_ID", "test-stream")
+	t.Setenv("SELFHOSTED_BUCKET", "test-bucket")
+	t.Setenv("SELFHOSTED_WORKER_HOSTS", "10.0.0.1")
+	t.Setenv("SELFHOSTED_SSH_USER", "heph")
+	t.Setenv("SELFHOSTED_DOCKER_IMAGE", "worker:latest")
+
+	m := NewConfig("httpx")
+	m.inputs[cfgFieldCloud].SetValue("hetzner")
+	_, cmd := m.Update(fileReadMsg{content: "example.com\n"})
+	if cmd == nil {
+		t.Fatal("expected navigation command for VPS provider")
+	}
+	msg := cmd()
+	nav, ok := msg.(core.NavigateWithDataMsg)
+	if !ok {
+		t.Fatalf("expected NavigateWithDataMsg, got %T", msg)
+	}
+	if nav.Target != core.ViewGenericStatus {
+		t.Fatalf("expected ViewGenericStatus (bypass deploy), got %v", nav.Target)
+	}
+	infra, ok := nav.Data.(core.InfraOutputs)
+	if !ok {
+		t.Fatalf("expected InfraOutputs, got %T", nav.Data)
+	}
+	if infra.Cloud != cloud.KindHetzner {
+		t.Fatalf("expected cloud hetzner, got %q", infra.Cloud)
+	}
+	if infra.SQSQueueURL != "test-stream" {
+		t.Fatalf("expected queue ID test-stream, got %q", infra.SQSQueueURL)
+	}
+	if infra.S3BucketName != "test-bucket" {
+		t.Fatalf("expected bucket test-bucket, got %q", infra.S3BucketName)
+	}
+}
+
+func TestGenericConfigManualRejectsFargate(t *testing.T) {
+	m := NewConfig("httpx")
+	m.inputs[cfgFieldCloud].SetValue("manual")
+	m.inputs[cfgFieldComputeMode].SetValue("fargate")
+	_, cmd := m.Update(fileReadMsg{content: "example.com\n"})
+	if cmd != nil {
+		t.Fatal("expected nil command for manual + fargate")
+	}
+	if !strings.Contains(m.View(), `provider "manual" only supports`) {
+		t.Fatal("expected provider mode rejection error")
+	}
+}
+
+func TestGenericConfigProviderMissingEnv(t *testing.T) {
+	t.Setenv("SELFHOSTED_QUEUE_ID", "")
+	t.Setenv("SELFHOSTED_BUCKET", "")
+
+	m := NewConfig("httpx")
+	m.inputs[cfgFieldCloud].SetValue("hetzner")
+	_, cmd := m.Update(fileReadMsg{content: "example.com\n"})
+	if cmd != nil {
+		t.Fatal("expected nil command when provider env is missing")
+	}
+	if !strings.Contains(m.View(), "hetzner requires SELFHOSTED_QUEUE_ID") {
+		t.Fatal("expected env var requirement error")
 	}
 }

--- a/internal/tui/views/generic/status.go
+++ b/internal/tui/views/generic/status.go
@@ -23,7 +23,7 @@ import (
 type statusPhase int
 
 const (
-	phaseUploading  statusPhase = iota // wordlist only: uploading chunks
+	phaseUploading statusPhase = iota // wordlist only: uploading chunks
 	phaseEnqueuing
 	phaseLaunching
 	phaseScanning
@@ -160,8 +160,8 @@ type StatusModel struct {
 	tracker    GenericTracker
 	uploader   GenericUploader
 	jobTracker *operator.Tracker
-	storage    cloud.Storage    // for local export on completion
-	destroyer  core.Destroyer   // for auto-destroy after export (nil = no destroy)
+	storage    cloud.Storage  // for local export on completion
+	destroyer  core.Destroyer // for auto-destroy after export (nil = no destroy)
 	infra      core.InfraOutputs
 
 	phase        statusPhase
@@ -262,6 +262,7 @@ func (m *StatusModel) trackCreate() {
 		TotalWords:    m.totalWords,
 		WorkerCount:   m.infra.WorkerCount,
 		ComputeMode:   m.infra.ComputeMode,
+		Cloud:         string(m.infra.Cloud),
 		Bucket:        m.infra.S3BucketName,
 		RuntimeTarget: m.infra.RuntimeTarget,
 	}
@@ -432,8 +433,12 @@ func (m *StatusModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 				m.phase = phaseExporting
 				return m, m.exportResults()
 			}
-			if m.infra.CleanupPolicy == "destroy-after" && m.infra.OutputDir == "" {
-				m.cleanupWarning = "destroy-after skipped: no output directory configured"
+			if m.infra.CleanupPolicy == "destroy-after" {
+				if m.infra.Cloud.IsSelfhostedFamily() {
+					m.cleanupWarning = "destroy-after skipped: selfhosted does not support auto-destroy"
+				} else if m.infra.OutputDir == "" {
+					m.cleanupWarning = "destroy-after skipped: no output directory configured"
+				}
 			}
 			m.phase = phaseComplete
 			return m, m.navigateToResults()
@@ -449,6 +454,11 @@ func (m *StatusModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 		m.infra.Exported = true
 		m.infra.ExportDir = msg.dir
 		// Auto-destroy if destroy-after policy and destroyer is available.
+		if m.infra.Cloud.IsSelfhostedFamily() {
+			m.cleanupWarning = "destroy-after skipped: selfhosted does not support auto-destroy"
+			m.phase = phaseComplete
+			return m, m.navigateToResults()
+		}
 		if m.destroyer != nil {
 			m.phase = phaseDestroying
 			return m, m.runAutoDestroy()
@@ -586,6 +596,10 @@ func (m *StatusModel) View() string {
 }
 
 func useSpot(infra core.InfraOutputs) bool {
+	// Selfhosted only supports RunContainer (no spot instances).
+	if infra.Cloud.IsSelfhostedFamily() {
+		return false
+	}
 	switch infra.ComputeMode {
 	case "spot":
 		return true
@@ -613,8 +627,8 @@ func (m *StatusModel) launchWorkers() tea.Cmd {
 			SecurityGroups: []string{infra.SecurityGroupID},
 			Env: map[string]string{
 				"QUEUE_URL":          infra.SQSQueueURL,
-				"S3_BUCKET":         infra.S3BucketName,
-				"TOOL_NAME":         infra.ToolName,
+				"S3_BUCKET":          infra.S3BucketName,
+				"TOOL_NAME":          infra.ToolName,
 				"JITTER_MAX_SECONDS": strconv.Itoa(infra.JitterMaxSeconds),
 			},
 			Count: infra.WorkerCount,
@@ -633,8 +647,8 @@ func (m *StatusModel) launchSpotWorkers() tea.Cmd {
 			Region:     regionFromECR(infra.ECRRepoURL),
 			EnvVars: map[string]string{
 				"QUEUE_URL":          infra.SQSQueueURL,
-				"S3_BUCKET":         infra.S3BucketName,
-				"TOOL_NAME":         infra.ToolName,
+				"S3_BUCKET":          infra.S3BucketName,
+				"TOOL_NAME":          infra.ToolName,
 				"JITTER_MAX_SECONDS": strconv.Itoa(infra.JitterMaxSeconds),
 			},
 		})

--- a/internal/tui/views/generic/status_test.go
+++ b/internal/tui/views/generic/status_test.go
@@ -446,10 +446,12 @@ func TestGenericStatusViewShowsExportingPhase(t *testing.T) {
 // mockExportStorage is a minimal cloud.Storage for export gating tests.
 type mockExportStorage struct{}
 
-func (s *mockExportStorage) Upload(context.Context, string, string, []byte) error    { return nil }
-func (s *mockExportStorage) Download(context.Context, string, string) ([]byte, error) { return nil, nil }
-func (s *mockExportStorage) List(context.Context, string, string) ([]string, error)   { return nil, nil }
-func (s *mockExportStorage) Count(context.Context, string, string) (int, error)       { return 0, nil }
+func (s *mockExportStorage) Upload(context.Context, string, string, []byte) error { return nil }
+func (s *mockExportStorage) Download(context.Context, string, string) ([]byte, error) {
+	return nil, nil
+}
+func (s *mockExportStorage) List(context.Context, string, string) ([]string, error) { return nil, nil }
+func (s *mockExportStorage) Count(context.Context, string, string) (int, error)     { return 0, nil }
 
 // --- Track 1 PR 5.12: auto-destroy lifecycle tests ---
 
@@ -633,6 +635,89 @@ func TestGenericStatusAutoDestroyEndToEnd(t *testing.T) {
 	}
 	if !navInfra.Destroyed {
 		t.Fatal("expected nav data to carry Destroyed=true")
+	}
+}
+
+func testSelfhostedInfra() core.InfraOutputs {
+	return core.InfraOutputs{
+		Cloud:          cloud.KindHetzner,
+		SQSQueueURL:    "test-stream",
+		S3BucketName:   "test-bucket",
+		ToolName:       "httpx",
+		ToolOptions:    "-silent",
+		TargetsContent: "example.com\n10.0.0.1\n",
+		WorkerCount:    5,
+		ComputeMode:    "auto",
+	}
+}
+
+func TestGenericStatusSelfhostedUsesLaunchWorkers(t *testing.T) {
+	sub := &mockSubmitter{}
+	tracker := &mockTracker{}
+	m := NewStatusWithDeps(testSelfhostedInfra(), sub, tracker, &mockUploader{})
+	m.Init()
+
+	// Enqueue succeeds → launch phase.
+	_, cmd := m.Update(enqueueProgressMsg{sent: 2, total: 2})
+	if m.phase != phaseLaunching {
+		t.Fatalf("expected phaseLaunching, got %d", m.phase)
+	}
+	if cmd == nil {
+		t.Fatal("expected launch command")
+	}
+	// Execute the launch command — should call LaunchWorkers, not LaunchSpotWorkers.
+	msg := cmd()
+	_, ok := msg.(launchProgressMsg)
+	if !ok {
+		t.Fatalf("expected launchProgressMsg (not spotLaunchMsg), got %T", msg)
+	}
+}
+
+func TestGenericStatusSelfhostedNeverUsesSpot(t *testing.T) {
+	infra := testSelfhostedInfra()
+	infra.WorkerCount = 200 // above SpotThreshold
+	infra.ComputeMode = "auto"
+	if useSpot(infra) {
+		t.Fatal("selfhosted should never use spot even with high worker count")
+	}
+}
+
+func TestGenericStatusSelfhostedDestroyAfterSkipped(t *testing.T) {
+	infra := testSelfhostedInfra()
+	infra.CleanupPolicy = "destroy-after"
+	infra.OutputDir = ""
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{}, &mockUploader{})
+	m.totalTargets = 2
+	m.phase = phaseScanning
+
+	m.Update(scanProgressMsg{completed: 2})
+	if m.phase != phaseComplete {
+		t.Fatalf("expected phaseComplete, got %d", m.phase)
+	}
+	if !strings.Contains(m.cleanupWarning, "selfhosted does not support auto-destroy") {
+		t.Fatalf("expected selfhosted destroy warning, got %q", m.cleanupWarning)
+	}
+}
+
+func TestGenericStatusSelfhostedExportComplete_SkipsDestroy(t *testing.T) {
+	infra := testSelfhostedInfra()
+	infra.CleanupPolicy = "destroy-after"
+	infra.OutputDir = "/tmp/export"
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{}, &mockUploader{})
+	m.storage = &mockExportStorage{}
+	m.destroyer = &mockDestroyer{} // destroyer exists but should be skipped
+	m.phase = phaseExporting
+
+	_, cmd := m.Update(exportCompleteMsg{dir: "/tmp/export/httpx/job-sh", count: 2})
+	// Selfhosted should skip destroy and go to complete.
+	if m.phase != phaseComplete {
+		t.Fatalf("expected phaseComplete (selfhosted skips destroy), got %d", m.phase)
+	}
+	if !strings.Contains(m.cleanupWarning, "selfhosted does not support auto-destroy") {
+		t.Fatalf("expected selfhosted destroy warning, got %q", m.cleanupWarning)
+	}
+	if cmd == nil {
+		t.Fatal("expected navigate command")
 	}
 }
 

--- a/internal/tui/views/nmap/config.go
+++ b/internal/tui/views/nmap/config.go
@@ -12,6 +12,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"heph4estus/internal/cloud"
+	"heph4estus/internal/cloud/factory"
 	"heph4estus/internal/infra"
 	"heph4estus/internal/operator"
 	"heph4estus/internal/tui/core"
@@ -124,7 +125,7 @@ func NewConfig() *ConfigModel {
 
 	savedCloud := ""
 	if cfg != nil {
-		savedCloud = cfg.Cloud
+		savedCloud = normalizeCloudValue(cfg.Cloud)
 	}
 	cloudInput := textinput.New()
 	cloudInput.Placeholder = "aws"
@@ -204,22 +205,56 @@ func (m *ConfigModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 		if computeMode == "" {
 			computeMode = "auto"
 		}
-		if computeMode != "auto" && computeMode != "fargate" && computeMode != "spot" {
-			m.errMsg = "Compute mode must be auto, fargate, or spot"
+		cloudKind, cloudErr := cloud.ParseKind(strings.TrimSpace(m.inputs[fieldCloud].Value()))
+		if cloudErr != nil {
+			m.errMsg = fmt.Sprintf("Invalid cloud: %v", cloudErr)
+			return m, nil
+		}
+		if err := cloud.ValidateComputeMode(cloudKind, computeMode); err != nil {
+			m.errMsg = err.Error()
 			return m, nil
 		}
 		jitterMax, _ := strconv.Atoi(strings.TrimSpace(m.inputs[fieldJitterMax].Value()))
 		if jitterMax < 0 {
 			jitterMax = 0
 		}
-		cloudKind, cloudErr := cloud.ParseKind(strings.TrimSpace(m.inputs[fieldCloud].Value()))
-		if cloudErr != nil {
-			m.errMsg = fmt.Sprintf("Invalid cloud: %v", cloudErr)
-			return m, nil
-		}
-		if cloudKind == cloud.KindSelfhosted {
-			m.errMsg = "Selfhosted compute/deploy support lands in PR 6.2/6.3"
-			return m, nil
+
+		opCfg, _ := operator.LoadConfig()
+		cleanupPolicy := operator.ResolveCleanupPolicy("", opCfg)
+		outputDir := operator.ResolveOutputDir("", opCfg)
+
+		if cloudKind.IsSelfhostedFamily() {
+			// Selfhosted: bypass deploy view, go directly to status.
+			shCfg := factory.SelfhostedConfigFromEnv()
+			if shCfg.QueueID == "" || shCfg.Bucket == "" {
+				m.errMsg = fmt.Sprintf("%s requires SELFHOSTED_QUEUE_ID and SELFHOSTED_BUCKET environment variables", cloudKind.Canonical())
+				return m, nil
+			}
+			return m, func() tea.Msg {
+				return core.NavigateWithDataMsg{
+					Target: core.ViewNmapStatus,
+					Data: core.InfraOutputs{
+						Cloud:              cloudKind,
+						SQSQueueURL:        shCfg.QueueID,
+						S3BucketName:       shCfg.Bucket,
+						TargetsContent:     msg.content,
+						NmapOptions:        m.inputs[fieldNmapOptions].Value(),
+						WorkerCount:        workerCount,
+						ComputeMode:        computeMode,
+						JitterMaxSeconds:   jitterMax,
+						NmapTimingTemplate: strings.TrimSpace(m.inputs[fieldTimingTemplate].Value()),
+						DNSServers:         strings.TrimSpace(m.inputs[fieldDNSServers].Value()),
+						NoRDNS:             m.noRDNS,
+						CleanupPolicy:      cleanupPolicy,
+						OutputDir:          outputDir,
+						Selfhosted: &core.SelfhostedRuntime{
+							WorkerHosts: shCfg.WorkerHosts,
+							SSHUser:     shCfg.SSHUser,
+							DockerImage: shCfg.DockerImage,
+						},
+					},
+				}
+			}
 		}
 
 		tc, err := infra.ResolveToolConfig("nmap")
@@ -227,9 +262,6 @@ func (m *ConfigModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 			m.errMsg = fmt.Sprintf("Error resolving nmap config: %v", err)
 			return m, nil
 		}
-		opCfg, _ := operator.LoadConfig()
-		cleanupPolicy := operator.ResolveCleanupPolicy("", opCfg)
-		outputDir := operator.ResolveOutputDir("", opCfg)
 		return m, func() tea.Msg {
 			return core.NavigateWithDataMsg{
 				Target: core.ViewDeploy,
@@ -356,4 +388,12 @@ func (m *ConfigModel) submit() tea.Cmd {
 		}
 		return fileReadMsg{content: string(data)}
 	}
+}
+
+func normalizeCloudValue(value string) string {
+	kind, err := cloud.ParseKind(value)
+	if err != nil {
+		return strings.TrimSpace(value)
+	}
+	return string(kind.Canonical())
 }

--- a/internal/tui/views/nmap/config_test.go
+++ b/internal/tui/views/nmap/config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"heph4estus/internal/cloud"
 	"heph4estus/internal/tui/core"
 )
 
@@ -76,6 +77,51 @@ func TestConfigModel_SubmitEmptyShowsError(t *testing.T) {
 	m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
 	if m.errMsg == "" {
 		t.Fatal("expected error message for empty target file")
+	}
+}
+
+func TestConfigModel_ProviderNavigatesToStatus(t *testing.T) {
+	t.Setenv("SELFHOSTED_QUEUE_ID", "nmap-stream")
+	t.Setenv("SELFHOSTED_BUCKET", "nmap-bucket")
+	t.Setenv("SELFHOSTED_WORKER_HOSTS", "10.0.0.1")
+	t.Setenv("SELFHOSTED_SSH_USER", "heph")
+	t.Setenv("SELFHOSTED_DOCKER_IMAGE", "worker:latest")
+
+	m := NewConfig()
+	m.Init()
+	m.inputs[fieldCloud].SetValue("manual")
+	_, cmd := m.Update(fileReadMsg{content: "1.1.1.1\n2.2.2.2\n"})
+	if cmd == nil {
+		t.Fatal("expected navigation command for manual provider")
+	}
+	msg := cmd()
+	nav, ok := msg.(core.NavigateWithDataMsg)
+	if !ok {
+		t.Fatalf("expected NavigateWithDataMsg, got %T", msg)
+	}
+	if nav.Target != core.ViewNmapStatus {
+		t.Fatalf("expected ViewNmapStatus (bypass deploy), got %v", nav.Target)
+	}
+	infra, ok := nav.Data.(core.InfraOutputs)
+	if !ok {
+		t.Fatalf("expected InfraOutputs, got %T", nav.Data)
+	}
+	if infra.Cloud != cloud.KindManual {
+		t.Fatalf("expected cloud manual, got %q", infra.Cloud)
+	}
+}
+
+func TestConfigModel_ProviderRejectsSpot(t *testing.T) {
+	m := NewConfig()
+	m.Init()
+	m.inputs[fieldCloud].SetValue("linode")
+	m.inputs[fieldComputeMode].SetValue("spot")
+	_, cmd := m.Update(fileReadMsg{content: "1.1.1.1\n"})
+	if cmd != nil {
+		t.Fatal("expected nil command for VPS provider + spot")
+	}
+	if !strings.Contains(m.View(), `provider "linode" only supports`) {
+		t.Fatal("expected provider mode rejection error")
 	}
 }
 

--- a/internal/tui/views/nmap/status.go
+++ b/internal/tui/views/nmap/status.go
@@ -152,8 +152,8 @@ type StatusModel struct {
 	submitter  JobSubmitter
 	tracker    ProgressTracker
 	jobTracker *operator.Tracker
-	storage    cloud.Storage    // for local export on completion
-	destroyer  core.Destroyer   // for auto-destroy after export (nil = no destroy)
+	storage    cloud.Storage  // for local export on completion
+	destroyer  core.Destroyer // for auto-destroy after export (nil = no destroy)
 	infra      core.InfraOutputs
 
 	phase        statusPhase
@@ -253,6 +253,7 @@ func (m *StatusModel) trackCreate() {
 		TotalTasks:  m.totalTargets,
 		WorkerCount: m.infra.WorkerCount,
 		ComputeMode: m.infra.ComputeMode,
+		Cloud:       string(m.infra.Cloud),
 		Bucket:      m.infra.S3BucketName,
 	})
 }
@@ -378,8 +379,12 @@ func (m *StatusModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 				m.phase = phaseExporting
 				return m, m.exportResults()
 			}
-			if m.infra.CleanupPolicy == "destroy-after" && m.infra.OutputDir == "" {
-				m.cleanupWarning = "destroy-after skipped: no output directory configured"
+			if m.infra.CleanupPolicy == "destroy-after" {
+				if m.infra.Cloud.IsSelfhostedFamily() {
+					m.cleanupWarning = "destroy-after skipped: selfhosted does not support auto-destroy"
+				} else if m.infra.OutputDir == "" {
+					m.cleanupWarning = "destroy-after skipped: no output directory configured"
+				}
 			}
 			m.phase = phaseComplete
 			return m, m.navigateToResults()
@@ -395,6 +400,11 @@ func (m *StatusModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 		m.infra.Exported = true
 		m.infra.ExportDir = msg.dir
 		// Auto-destroy if destroy-after policy and destroyer is available.
+		if m.infra.Cloud.IsSelfhostedFamily() {
+			m.cleanupWarning = "destroy-after skipped: selfhosted does not support auto-destroy"
+			m.phase = phaseComplete
+			return m, m.navigateToResults()
+		}
 		if m.destroyer != nil {
 			m.phase = phaseDestroying
 			return m, m.runAutoDestroy()
@@ -512,6 +522,10 @@ func (m *StatusModel) View() string {
 
 // useSpot returns true if the compute mode resolves to spot instances.
 func useSpot(infra core.InfraOutputs) bool {
+	// Selfhosted only supports RunContainer (no spot instances).
+	if infra.Cloud.IsSelfhostedFamily() {
+		return false
+	}
 	switch infra.ComputeMode {
 	case "spot":
 		return true

--- a/internal/tui/views/nmap/status_test.go
+++ b/internal/tui/views/nmap/status_test.go
@@ -282,6 +282,88 @@ func (m *mockCountStorage) Count(ctx context.Context, bucket, prefix string) (in
 	return m.countFunc(ctx, bucket, prefix)
 }
 
+func testSelfhostedInfra() core.InfraOutputs {
+	return core.InfraOutputs{
+		Cloud:          cloud.KindManual,
+		SQSQueueURL:    "test-stream",
+		S3BucketName:   "test-bucket",
+		JobID:          "job-sh",
+		TargetsContent: "1.1.1.1\n2.2.2.2\n",
+		NmapOptions:    "-sS",
+		WorkerCount:    2,
+		ComputeMode:    "auto",
+	}
+}
+
+func TestStatusModel_SelfhostedUsesLaunchWorkers(t *testing.T) {
+	sub := &mockSubmitter{}
+	m := NewStatusWithDeps(testSelfhostedInfra(), sub, &mockTracker{})
+	m.Init()
+
+	// Enqueue succeeds → launch phase.
+	_, cmd := m.Update(enqueueProgressMsg{sent: 2, total: 2})
+	if m.phase != phaseLaunching {
+		t.Fatalf("expected phaseLaunching, got %d", m.phase)
+	}
+	if cmd == nil {
+		t.Fatal("expected launch command")
+	}
+	// Execute the launch command — should call LaunchWorkers, not LaunchSpotWorkers.
+	msg := cmd()
+	_, ok := msg.(launchProgressMsg)
+	if !ok {
+		t.Fatalf("expected launchProgressMsg (not spotLaunchMsg), got %T", msg)
+	}
+}
+
+func TestStatusModel_SelfhostedNeverUsesSpot(t *testing.T) {
+	infra := testSelfhostedInfra()
+	infra.WorkerCount = 200 // above SpotThreshold
+	infra.ComputeMode = "auto"
+	if useSpot(infra) {
+		t.Fatal("selfhosted should never use spot even with high worker count")
+	}
+}
+
+func TestStatusModel_SelfhostedDestroyAfterSkipped(t *testing.T) {
+	infra := testSelfhostedInfra()
+	infra.CleanupPolicy = "destroy-after"
+	infra.OutputDir = ""
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{})
+	m.totalTargets = 2
+	m.phase = phaseScanning
+
+	m.Update(scanProgressMsg{completed: 2})
+	if m.phase != phaseComplete {
+		t.Fatalf("expected phaseComplete, got %d", m.phase)
+	}
+	if !strings.Contains(m.cleanupWarning, "selfhosted does not support auto-destroy") {
+		t.Fatalf("expected selfhosted destroy warning, got %q", m.cleanupWarning)
+	}
+}
+
+func TestStatusModel_SelfhostedExportComplete_SkipsDestroy(t *testing.T) {
+	infra := testSelfhostedInfra()
+	infra.CleanupPolicy = "destroy-after"
+	infra.OutputDir = "/tmp/export"
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{})
+	m.storage = &mockExportStorage{}
+	m.destroyer = &mockDestroyer{} // destroyer exists but should be skipped
+	m.phase = phaseExporting
+
+	_, cmd := m.Update(exportCompleteMsg{dir: "/tmp/export/nmap/job-sh", count: 2})
+	// Selfhosted should skip destroy and go to complete.
+	if m.phase != phaseComplete {
+		t.Fatalf("expected phaseComplete (selfhosted skips destroy), got %d", m.phase)
+	}
+	if !strings.Contains(m.cleanupWarning, "selfhosted does not support auto-destroy") {
+		t.Fatalf("expected selfhosted destroy warning, got %q", m.cleanupWarning)
+	}
+	if cmd == nil {
+		t.Fatal("expected navigate command")
+	}
+}
+
 func TestUseSpot_Auto(t *testing.T) {
 	low := core.InfraOutputs{WorkerCount: 10, ComputeMode: "auto"}
 	if useSpot(low) {
@@ -532,10 +614,12 @@ func TestStatusModel_ReusePolicyNoExport(t *testing.T) {
 // mockExportStorage is a minimal cloud.Storage for export gating tests.
 type mockExportStorage struct{}
 
-func (s *mockExportStorage) Upload(context.Context, string, string, []byte) error    { return nil }
-func (s *mockExportStorage) Download(context.Context, string, string) ([]byte, error) { return nil, nil }
-func (s *mockExportStorage) List(context.Context, string, string) ([]string, error)   { return nil, nil }
-func (s *mockExportStorage) Count(context.Context, string, string) (int, error)       { return 0, nil }
+func (s *mockExportStorage) Upload(context.Context, string, string, []byte) error { return nil }
+func (s *mockExportStorage) Download(context.Context, string, string) ([]byte, error) {
+	return nil, nil
+}
+func (s *mockExportStorage) List(context.Context, string, string) ([]string, error) { return nil, nil }
+func (s *mockExportStorage) Count(context.Context, string, string) (int, error)     { return 0, nil }
 
 // --- Track 1 PR 5.12: auto-destroy lifecycle tests ---
 

--- a/internal/tui/views/settings/model.go
+++ b/internal/tui/views/settings/model.go
@@ -12,6 +12,7 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"heph4estus/internal/cloud"
 	"heph4estus/internal/doctor"
 	"heph4estus/internal/operator"
 	"heph4estus/internal/tui/core"
@@ -160,7 +161,7 @@ func NewWithDeps(deps Deps) *Model {
 	cloudInput.Placeholder = "aws"
 	cloudInput.CharLimit = 12
 	if cfg.Cloud != "" {
-		cloudInput.SetValue(cfg.Cloud)
+		cloudInput.SetValue(normalizeCloudValue(cfg.Cloud))
 	}
 
 	h := help.New()
@@ -363,7 +364,7 @@ func (m *Model) buildConfig() *operator.OperatorConfig {
 		ComputeMode:   strings.TrimSpace(m.inputs[fieldComputeMode].Value()),
 		CleanupPolicy: strings.TrimSpace(m.inputs[fieldCleanupPolicy].Value()),
 		OutputDir:     strings.TrimSpace(m.inputs[fieldOutputDir].Value()),
-		Cloud:         strings.TrimSpace(m.inputs[fieldCloud].Value()),
+		Cloud:         normalizeCloudValue(m.inputs[fieldCloud].Value()),
 	}
 }
 
@@ -415,4 +416,12 @@ func diagIcon(s doctor.Status) string {
 	default:
 		return "????"
 	}
+}
+
+func normalizeCloudValue(value string) string {
+	kind, err := cloud.ParseKind(value)
+	if err != nil {
+		return strings.TrimSpace(value)
+	}
+	return string(kind.Canonical())
 }

--- a/internal/tui/views/settings/model_test.go
+++ b/internal/tui/views/settings/model_test.go
@@ -49,6 +49,7 @@ func TestNew_LoadsSavedConfig(t *testing.T) {
 		Profile:     "staging",
 		WorkerCount: 20,
 		ComputeMode: "spot",
+		Cloud:       "selfhosted",
 	}
 	m := NewWithDeps(testDeps(cfg))
 
@@ -63,6 +64,9 @@ func TestNew_LoadsSavedConfig(t *testing.T) {
 	}
 	if v := m.inputs[fieldComputeMode].Value(); v != "spot" {
 		t.Errorf("compute mode: got %q, want spot", v)
+	}
+	if v := m.inputs[fieldCloud].Value(); v != "manual" {
+		t.Errorf("cloud: got %q, want manual", v)
 	}
 }
 
@@ -108,6 +112,7 @@ func TestSave_PersistsConfig(t *testing.T) {
 	m.inputs[fieldComputeMode].SetValue("fargate")
 	m.inputs[fieldCleanupPolicy].SetValue("destroy-after")
 	m.inputs[fieldOutputDir].SetValue("/tmp/out")
+	m.inputs[fieldCloud].SetValue("selfhosted")
 
 	// Trigger save
 	cmd := m.save()
@@ -138,6 +143,9 @@ func TestSave_PersistsConfig(t *testing.T) {
 	}
 	if saved.OutputDir != "/tmp/out" {
 		t.Errorf("output dir: got %q", saved.OutputDir)
+	}
+	if saved.Cloud != "manual" {
+		t.Errorf("cloud: got %q, want manual", saved.Cloud)
 	}
 }
 


### PR DESCRIPTION
## Summary                                                                                  
                                                                                              
  - Add named VPS provider kinds (`manual`, `hetzner`, `linode`, `scaleway`, `vultr`)         
  alongside AWS, with `IsSelfhostedFamily()` / `RuntimeFamily()` helpers and centralized      
  compute-mode validation                                                                     
  - Implement Docker-over-SSH compute: pull + run detached containers on remote worker hosts, 
  round-robin across the host list, with transport env auto-injection
  - Add provider-aware image publish (`ECRPublisher` / `RegistryPublisher`), output redaction 
  for sensitive values, and per-cloud required-output contracts for lifecycle probing
  - Ship portable selfhosted controller Terraform module (NATS JetStream + MinIO + Docker     
  registry via cloud-init); does not provision the VM — provider modules compose it
  - Wire VPS-family scan execution through CLI (`heph nmap --cloud manual`, `heph scan --cloud
   hetzner`) and TUI config/status views, bypassing Terraform deploy when selfhosted
  - Block `heph infra deploy/destroy` for VPS-family providers with a message pointing to 
  - Legacy `--cloud selfhosted` accepted as compatibility alias for `manual`                  
                                                            
                                                                                              
  ## Test plan                                                                                
                                                                                              
  - [X] `go test ./internal/cloud/...` — kind model, factory config, selfhosted provider +    
  Docker compute                                                                              
  - [X] `go test ./cmd/heph/...` — CLI cloud validation, compute-mode rejection, VPS env      
  requirement, selfhosted scan paths                                                          
  - [X] `go test ./internal/infra/...` — publisher selection, output redaction, provider-aware
   lifecycle probing                                                                          
  - [X] `go test ./internal/tui/...` — config bypass for VPS providers, status destroy-after  
  skip, generic stage labels                  
  - [X] `go test ./internal/operator/...` — legacy alias parsing, config round-trip           
  - [X] `go test ./internal/config/...` — worker config selfhosted scan runtime
  - [X] `go vet ./...` — clean 