### PR TITLE
Feat/hetzner fleet platform

### DIFF
--- a/cmd/heph/cloud.go
+++ b/cmd/heph/cloud.go
@@ -20,8 +20,11 @@ func resolveCLICloud(explicit string, cfg *operator.OperatorConfig) (cloud.Kind,
 // requireDeploySupport returns an error when the selected cloud does not
 // yet support infrastructure deploy/destroy.
 func requireDeploySupport(kind cloud.Kind) error {
+	if kind.IsProviderNative() {
+		return nil // Hetzner has provider-native deploy support
+	}
 	if kind.IsSelfhostedFamily() {
-		return fmt.Errorf("%s infrastructure deploy/destroy lands in PR 6.3", kind.Canonical())
+		return fmt.Errorf("%s infrastructure deploy/destroy is not supported — use 'hetzner' for provider-native VPS deploy, or 'manual' with your own infrastructure", kind.Canonical())
 	}
 	return nil
 }

--- a/cmd/heph/cloud_test.go
+++ b/cmd/heph/cloud_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"strings"
 	"testing"
 
 	"heph4estus/internal/cloud"
@@ -43,13 +42,16 @@ func TestValidateComputeMode_ProviderSpotRejected(t *testing.T) {
 	}
 }
 
-func TestRequireDeploySupport_ProviderFamilyBlocked(t *testing.T) {
-	err := requireDeploySupport(cloud.KindHetzner)
-	if err == nil {
-		t.Fatal("expected error: VPS deploy should be blocked")
+func TestRequireDeploySupport_HetznerAllowed(t *testing.T) {
+	if err := requireDeploySupport(cloud.KindHetzner); err != nil {
+		t.Fatalf("Hetzner deploy should be allowed (provider-native): %v", err)
 	}
-	if !strings.Contains(err.Error(), "PR 6.3") {
-		t.Fatalf("error should mention PR 6.3 deferral, got: %v", err)
+}
+
+func TestRequireDeploySupport_ManualBlocked(t *testing.T) {
+	err := requireDeploySupport(cloud.KindManual)
+	if err == nil {
+		t.Fatal("expected error: manual deploy should be blocked")
 	}
 }
 

--- a/cmd/heph/cmd_infra.go
+++ b/cmd/heph/cmd_infra.go
@@ -14,11 +14,11 @@ import (
 )
 
 // resolveToolConfig validates the backend flag and delegates to infra.ResolveToolConfig.
-func resolveToolConfig(tool, backend string) (*infra.ToolConfig, error) {
+func resolveToolConfig(tool, backend string, kind ...cloud.Kind) (*infra.ToolConfig, error) {
 	if backend == "dedicated" {
 		return nil, fmt.Errorf("--backend dedicated is no longer supported; use --backend generic for %q", tool)
 	}
-	return infra.ResolveToolConfig(tool)
+	return infra.ResolveToolConfig(tool, kind...)
 }
 
 func runInfra(args []string, log logger.Logger) error {
@@ -55,11 +55,6 @@ func runInfraDeploy(args []string, log logger.Logger) error {
 		return fmt.Errorf("--backend must be generic (got %q)", *backend)
 	}
 
-	cfg, err := resolveToolConfig(*tool, *backend)
-	if err != nil {
-		return err
-	}
-
 	// Resolve region from operator config when not explicitly set.
 	opCfg, _ := operator.LoadConfig()
 	*region = operator.ResolveRegion(*region, opCfg)
@@ -72,8 +67,14 @@ func runInfraDeploy(args []string, log logger.Logger) error {
 		return err
 	}
 
+	cfg, err := resolveToolConfig(*tool, *backend, cloudKind)
+	if err != nil {
+		return err
+	}
+
 	_, err = infra.RunDeploy(mainContext(), infra.DeployOpts{
 		ToolConfig:  cfg,
+		Cloud:       cloudKind,
 		Region:      *region,
 		AutoApprove: *autoApprove,
 		Stream:      os.Stderr,
@@ -99,17 +100,17 @@ func runInfraDestroy(args []string, log logger.Logger) error {
 		return fmt.Errorf("--backend must be generic (got %q)", *backend)
 	}
 
-	cfg, err := resolveToolConfig(*tool, *backend)
-	if err != nil {
-		return err
-	}
-
 	opCfg, _ := operator.LoadConfig()
 	cloudKind, err := resolveCLICloud(*cloudFlag, opCfg)
 	if err != nil {
 		return err
 	}
 	if err := requireDeploySupport(cloudKind); err != nil {
+		return err
+	}
+
+	cfg, err := resolveToolConfig(*tool, *backend, cloudKind)
+	if err != nil {
 		return err
 	}
 

--- a/cmd/heph/cmd_lifecycle_test.go
+++ b/cmd/heph/cmd_lifecycle_test.go
@@ -54,13 +54,17 @@ func (s *mockStorage) Count(context.Context, string, string) (int, error) {
 type mockCompute struct {
 	runContainerErr error
 	runSpotErr      error
+	runContainerN   int
+	runSpotN        int
 }
 
 func (c *mockCompute) RunContainer(context.Context, cloud.ContainerOpts) (string, error) {
+	c.runContainerN++
 	return "task-1", c.runContainerErr
 }
 
 func (c *mockCompute) RunSpotInstances(context.Context, cloud.SpotOpts) ([]string, error) {
+	c.runSpotN++
 	if c.runSpotErr != nil {
 		return nil, c.runSpotErr
 	}
@@ -229,12 +233,18 @@ func TestRunNmapScanWithDepsStartedTrueOnOutputFailure(t *testing.T) {
 	}
 }
 
-func TestRunNmapScanWithDeps_SelfhostedUsesRunContainer(t *testing.T) {
+func TestRunNmapScanWithDeps_ProviderNativeSkipsRunContainer(t *testing.T) {
 	tasks := []nmaptool.ScanTask{{
 		JobID:   "job-sh",
 		Target:  "10.0.0.1",
 		Options: "-sS",
 	}}
+
+	oldWait := waitForProviderNativeFleetFunc
+	waitForProviderNativeFleetFunc = func(context.Context, cloud.Kind, map[string]string) (int, error) {
+		return 1, nil
+	}
+	t.Cleanup(func() { waitForProviderNativeFleetFunc = oldWait })
 
 	comp := &mockCompute{}
 	started, err := runNmapScanWithDeps(
@@ -260,6 +270,12 @@ func TestRunNmapScanWithDeps_SelfhostedUsesRunContainer(t *testing.T) {
 	}
 	if !started {
 		t.Fatal("expected started=true")
+	}
+	if comp.runContainerN != 0 {
+		t.Fatalf("expected provider-native Hetzner path to skip RunContainer, got %d calls", comp.runContainerN)
+	}
+	if comp.runSpotN != 0 {
+		t.Fatalf("expected provider-native Hetzner path to skip RunSpotInstances, got %d calls", comp.runSpotN)
 	}
 }
 
@@ -295,6 +311,52 @@ func TestRunNmapScanWithDeps_SelfhostedNeverCallsSpot(t *testing.T) {
 	}
 	if !started {
 		t.Fatal("expected started=true")
+	}
+	if comp.runSpotN != 0 {
+		t.Fatalf("expected manual selfhosted path to avoid spot, got %d calls", comp.runSpotN)
+	}
+}
+
+func TestRunTargetListScan_ProviderNativeSkipsRunContainer(t *testing.T) {
+	oldWait := waitForProviderNativeFleetFunc
+	waitForProviderNativeFleetFunc = func(context.Context, cloud.Kind, map[string]string) (int, error) {
+		return 3, nil
+	}
+	t.Cleanup(func() { waitForProviderNativeFleetFunc = oldWait })
+
+	comp := &mockCompute{}
+	started, err := runTargetListScan(
+		context.Background(),
+		"httpx",
+		"job-hetzner",
+		"targets.txt",
+		"example.com\n",
+		"",
+		10,
+		"auto",
+		"text",
+		&mockQueue{},
+		&mockStorage{count: 1},
+		comp,
+		map[string]string{
+			"sqs_queue_url":  "heph-tasks",
+			"s3_bucket_name": "heph-results",
+			"nats_url":       "nats://10.0.1.2:4222",
+			"worker_count":   "3",
+		},
+		"heph-results",
+		"heph-tasks",
+		operator.NoopTracker(),
+		cloud.KindHetzner,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !started {
+		t.Fatal("expected started=true")
+	}
+	if comp.runContainerN != 0 {
+		t.Fatalf("expected provider-native target-list path to skip RunContainer, got %d calls", comp.runContainerN)
 	}
 }
 

--- a/cmd/heph/cmd_nmap.go
+++ b/cmd/heph/cmd_nmap.go
@@ -142,8 +142,25 @@ func runNmap(args []string, log logger.Logger) error {
 		toolCfg *infra.ToolConfig
 	)
 
-	if cloudKind.IsSelfhostedFamily() {
-		// Selfhosted: no Terraform/deploy — read queue ID and bucket from config.
+	if cloudKind.IsProviderNative() {
+		// Provider-native (Hetzner): Terraform deploy + selfhosted runtime.
+		toolCfg, err = infra.ResolveToolConfig("nmap", cloudKind)
+		if err != nil {
+			return err
+		}
+		ensureResult, ensureErr := infra.EnsureInfra(ctx, toolCfg, infra.LifecyclePolicy{
+			NoDeploy:     *noDeploy,
+			AutoApprove:  *autoApprove,
+			DestroyAfter: *destroyAfter,
+		}, "", os.Stderr, deployPrompt, log)
+		if ensureErr != nil {
+			return ensureErr
+		}
+		outputs = ensureResult.Outputs
+		reused = ensureResult.Reused
+		bucket = outputs["s3_bucket_name"]
+	} else if cloudKind.IsSelfhostedFamily() {
+		// Manual selfhosted: no Terraform/deploy — read queue ID and bucket from env.
 		shCfg := factory.SelfhostedConfigFromEnv()
 		if shCfg.QueueID == "" || shCfg.Bucket == "" {
 			return fmt.Errorf("%s requires SELFHOSTED_QUEUE_ID and SELFHOSTED_BUCKET environment variables", cloudKind.Canonical())
@@ -199,7 +216,7 @@ func runNmap(args []string, log logger.Logger) error {
 	if *outDir != "" && scanErr == nil && started {
 		logStatus("Exporting results to %s...", *outDir)
 
-		exportProvider, provErr := factory.BuildForKind(ctx, cloudKind, log)
+		exportProvider, provErr := buildRuntimeProvider(ctx, cloudKind, outputs, log)
 		if provErr != nil {
 			return fmt.Errorf("building cloud provider for export: %w", provErr)
 		}
@@ -223,9 +240,9 @@ func runNmap(args []string, log logger.Logger) error {
 
 	// Destroy only after execution has actually started and export is done.
 	if *destroyAfter && started {
-		if cloudKind.IsSelfhostedFamily() {
+		if cloudKind.IsSelfhostedFamily() && !cloudKind.IsProviderNative() {
 			logStatus("Skipping destroy: %s does not support auto-destroy", cloudKind.Canonical())
-		} else {
+		} else if toolCfg != nil {
 			logStatus("Destroying infrastructure (--destroy-after)...")
 			if destroyErr := infra.RunDestroy(ctx, toolCfg, os.Stderr, log); destroyErr != nil {
 				if scanErr != nil {
@@ -251,9 +268,15 @@ func runNmapScan(ctx context.Context, tasks []nmap.ScanTask, workers int, comput
 		return false, fmt.Errorf("terraform outputs missing sqs_queue_url or s3_bucket_name")
 	}
 
-	provider, err := factory.BuildForKind(ctx, cloudKind, log)
-	if err != nil {
-		return false, fmt.Errorf("building cloud provider: %w", err)
+	// Build the cloud provider. For provider-native paths, use Terraform
+	// outputs as the config source rather than environment variables.
+	var (
+		provider cloud.Provider
+		provErr  error
+	)
+	provider, provErr = buildRuntimeProvider(ctx, cloudKind, outputs, log)
+	if provErr != nil {
+		return false, fmt.Errorf("building cloud provider: %w", provErr)
 	}
 	return runNmapScanWithDeps(ctx, tasks, workers, computeMode, jitterMax, format, outputs, provider.Queue(), provider.Storage(), provider.Compute(), tracker, jobID, cloudKind)
 }
@@ -303,55 +326,63 @@ func runNmapScanWithDeps(ctx context.Context, tasks []nmap.ScanTask, workers int
 	launchCtx, launchCancel := context.WithTimeout(ctx, launchTimeout)
 	defer launchCancel()
 
-	containerName := "nmap-worker"
-	workerEnv := map[string]string{
-		"QUEUE_URL":          queueURL,
-		"S3_BUCKET":          bucket,
-		"JITTER_MAX_SECONDS": strconv.Itoa(jitterMax),
-		"TOOL_NAME":          "nmap",
-	}
-
-	// Selfhosted only supports RunContainer (no spot instances).
-	isSelfhosted := len(cloudKind) > 0 && cloudKind[0].IsSelfhostedFamily()
-	useSpot := !isSelfhosted && resolveComputeMode(computeMode, workers)
-	if useSpot {
-		ecrURL := outputs["ecr_repo_url"]
-		userData := awscloud.GenerateUserData(awscloud.UserDataOpts{
-			ECRRepoURL: ecrURL,
-			ImageTag:   "latest",
-			Region:     regionFromECR(ecrURL),
-			EnvVars:    workerEnv,
-		})
-		ids, err := compute.RunSpotInstances(launchCtx, cloud.SpotOpts{
-			AMI:             outputs["ami_id"],
-			Count:           workers,
-			SecurityGroups:  []string{outputs["security_group_id"]},
-			SubnetIDs:       splitOutputList(outputs["subnet_ids"]),
-			InstanceProfile: outputs["instance_profile_arn"],
-			UserData:        userData,
-			Tags: map[string]string{
-				"Project": "heph4estus",
-				"Tool":    "nmap",
-			},
-		})
+	if len(cloudKind) > 0 && cloudKind[0].IsProviderNative() {
+		ready, err := waitForProviderNativeFleetFunc(launchCtx, cloudKind[0], outputs)
 		if err != nil {
-			return false, fmt.Errorf("launching spot instances: %w", err)
+			return false, err
 		}
-		logStatus("Launched %d spot instances", len(ids))
+		logStatus("Using provider-native %s fleet (%d ready workers)", cloudKind[0].Canonical(), ready)
 	} else {
-		_, err := compute.RunContainer(launchCtx, cloud.ContainerOpts{
-			Cluster:        outputs["ecs_cluster_name"],
-			TaskDefinition: outputs["task_definition_arn"],
-			ContainerName:  containerName,
-			Subnets:        splitOutputList(outputs["subnet_ids"]),
-			SecurityGroups: []string{outputs["security_group_id"]},
-			Env:            workerEnv,
-			Count:          workers,
-		})
-		if err != nil {
-			return false, fmt.Errorf("launching workers: %w", err)
+		containerName := "nmap-worker"
+		workerEnv := map[string]string{
+			"QUEUE_URL":          queueURL,
+			"S3_BUCKET":          bucket,
+			"JITTER_MAX_SECONDS": strconv.Itoa(jitterMax),
+			"TOOL_NAME":          "nmap",
 		}
-		logStatus("Launched %d workers", workers)
+
+		// Selfhosted only supports RunContainer (no spot instances).
+		isSelfhosted := len(cloudKind) > 0 && cloudKind[0].IsSelfhostedFamily()
+		useSpot := !isSelfhosted && resolveComputeMode(computeMode, workers)
+		if useSpot {
+			ecrURL := outputs["ecr_repo_url"]
+			userData := awscloud.GenerateUserData(awscloud.UserDataOpts{
+				ECRRepoURL: ecrURL,
+				ImageTag:   "latest",
+				Region:     regionFromECR(ecrURL),
+				EnvVars:    workerEnv,
+			})
+			ids, err := compute.RunSpotInstances(launchCtx, cloud.SpotOpts{
+				AMI:             outputs["ami_id"],
+				Count:           workers,
+				SecurityGroups:  []string{outputs["security_group_id"]},
+				SubnetIDs:       splitOutputList(outputs["subnet_ids"]),
+				InstanceProfile: outputs["instance_profile_arn"],
+				UserData:        userData,
+				Tags: map[string]string{
+					"Project": "heph4estus",
+					"Tool":    "nmap",
+				},
+			})
+			if err != nil {
+				return false, fmt.Errorf("launching spot instances: %w", err)
+			}
+			logStatus("Launched %d spot instances", len(ids))
+		} else {
+			_, err := compute.RunContainer(launchCtx, cloud.ContainerOpts{
+				Cluster:        outputs["ecs_cluster_name"],
+				TaskDefinition: outputs["task_definition_arn"],
+				ContainerName:  containerName,
+				Subnets:        splitOutputList(outputs["subnet_ids"]),
+				SecurityGroups: []string{outputs["security_group_id"]},
+				Env:            workerEnv,
+				Count:          workers,
+			})
+			if err != nil {
+				return false, fmt.Errorf("launching workers: %w", err)
+			}
+			logStatus("Launched %d workers", workers)
+		}
 	}
 
 	_ = tracker.UpdatePhase(jobID, operator.PhaseScanning)

--- a/cmd/heph/cmd_scan.go
+++ b/cmd/heph/cmd_scan.go
@@ -134,8 +134,29 @@ func runScan(args []string, log logger.Logger) error {
 		toolCfg  *infra.ToolConfig
 	)
 
-	if cloudKind.IsSelfhostedFamily() {
-		// Selfhosted: no Terraform/deploy — read queue ID and bucket from config.
+	if cloudKind.IsProviderNative() {
+		// Provider-native (Hetzner): Terraform deploy + selfhosted runtime.
+		toolCfg, err = infra.ResolveToolConfig(*tool, cloudKind)
+		if err != nil {
+			return err
+		}
+		ensureResult, ensureErr := infra.EnsureInfra(ctx, toolCfg, infra.LifecyclePolicy{
+			NoDeploy:     *noDeploy,
+			AutoApprove:  *autoApprove,
+			DestroyAfter: *destroyAfter,
+		}, "", os.Stderr, deployPrompt, log)
+		if ensureErr != nil {
+			return ensureErr
+		}
+		outputs = ensureResult.Outputs
+		reused = ensureResult.Reused
+		queueURL = outputs["sqs_queue_url"]
+		bucket = outputs["s3_bucket_name"]
+		if queueURL == "" || bucket == "" {
+			return fmt.Errorf("terraform outputs missing sqs_queue_url or s3_bucket_name")
+		}
+	} else if cloudKind.IsSelfhostedFamily() {
+		// Manual selfhosted: no Terraform/deploy — read queue ID and bucket from env.
 		shCfg := factory.SelfhostedConfigFromEnv()
 		queueURL = shCfg.QueueID
 		bucket = shCfg.Bucket
@@ -166,8 +187,10 @@ func runScan(args []string, log logger.Logger) error {
 		}
 	}
 
-	// Build the cloud provider.
-	provider, err := factory.BuildForKind(ctx, cloudKind, log)
+	// Build the cloud provider. For provider-native paths, use Terraform
+	// outputs as the config source rather than environment variables.
+	var provider cloud.Provider
+	provider, err = buildRuntimeProvider(ctx, cloudKind, outputs, log)
 	if err != nil {
 		return fmt.Errorf("building cloud provider: %w", err)
 	}
@@ -232,9 +255,9 @@ func runScan(args []string, log logger.Logger) error {
 
 	// Destroy only after execution has actually started and export is done.
 	if *destroyAfter && started {
-		if cloudKind.IsSelfhostedFamily() {
+		if cloudKind.IsSelfhostedFamily() && !cloudKind.IsProviderNative() {
 			logStatus("Skipping destroy: %s does not support auto-destroy", cloudKind.Canonical())
-		} else {
+		} else if toolCfg != nil {
 			logStatus("Destroying infrastructure (--destroy-after)...")
 			if destroyErr := infra.RunDestroy(ctx, toolCfg, os.Stderr, log); destroyErr != nil {
 				if scanErr != nil {
@@ -405,6 +428,15 @@ func launchGenericWorkers(ctx context.Context, tool string, workers int, compute
 	logStatus("Launching %d workers (mode: %s)...", workers, computeMode)
 	launchCtx, launchCancel := context.WithTimeout(ctx, launchTimeout)
 	defer launchCancel()
+
+	if cloudKind.IsProviderNative() {
+		ready, err := waitForProviderNativeFleetFunc(launchCtx, cloudKind, outputs)
+		if err != nil {
+			return err
+		}
+		logStatus("Using provider-native %s fleet (%d ready workers)", cloudKind.Canonical(), ready)
+		return nil
+	}
 
 	containerName := fmt.Sprintf("%s-worker", tool)
 	workerEnv := map[string]string{

--- a/cmd/heph/main_test.go
+++ b/cmd/heph/main_test.go
@@ -358,7 +358,7 @@ func TestScanCloudInvalidValue(t *testing.T) {
 	}
 }
 
-func TestScanCloudProviderRequiresEnv(t *testing.T) {
+func TestScanCloudManualRequiresEnv(t *testing.T) {
 	t.Setenv("SELFHOSTED_QUEUE_ID", "")
 	t.Setenv("SELFHOSTED_BUCKET", "")
 
@@ -366,11 +366,11 @@ func TestScanCloudProviderRequiresEnv(t *testing.T) {
 	f := dir + "/targets.txt"
 	_ = os.WriteFile(f, []byte("example.com\n"), 0o644)
 
-	err := run([]string{"scan", "--tool", "httpx", "--file", f, "--cloud", "hetzner"}, testLogger())
+	err := run([]string{"scan", "--tool", "httpx", "--file", f, "--cloud", "manual"}, testLogger())
 	if err == nil {
-		t.Fatal("expected error for provider without env config")
+		t.Fatal("expected error for manual provider without env config")
 	}
-	if !strings.Contains(err.Error(), "hetzner requires SELFHOSTED_QUEUE_ID") {
+	if !strings.Contains(err.Error(), "manual requires SELFHOSTED_QUEUE_ID") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -395,22 +395,22 @@ func TestScanCloudProviderRejectsSpot(t *testing.T) {
 	}
 }
 
-func TestInfraDeployCloudProviderRejected(t *testing.T) {
-	err := run([]string{"infra", "deploy", "--tool", "nmap", "--cloud", "hetzner"}, testLogger())
+func TestInfraDeployManualCloudRejected(t *testing.T) {
+	err := run([]string{"infra", "deploy", "--tool", "nmap", "--cloud", "manual"}, testLogger())
 	if err == nil {
-		t.Fatal("expected error for VPS provider")
+		t.Fatal("expected error for manual cloud deploy")
 	}
-	if !strings.Contains(err.Error(), "hetzner infrastructure deploy/destroy lands in PR 6.3") {
+	if !strings.Contains(err.Error(), "not supported") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
-func TestInfraDestroyCloudProviderRejected(t *testing.T) {
+func TestInfraDestroyManualCloudRejected(t *testing.T) {
 	err := run([]string{"infra", "destroy", "--tool", "nmap", "--auto-approve", "--cloud", "manual"}, testLogger())
 	if err == nil {
-		t.Fatal("expected error for manual cloud")
+		t.Fatal("expected error for manual cloud destroy")
 	}
-	if !strings.Contains(err.Error(), "manual infrastructure deploy/destroy lands in PR 6.3") {
+	if !strings.Contains(err.Error(), "not supported") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/cmd/heph/provider_runtime.go
+++ b/cmd/heph/provider_runtime.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"heph4estus/internal/cloud"
+	"heph4estus/internal/cloud/factory"
+	"heph4estus/internal/fleet"
+	"heph4estus/internal/logger"
+)
+
+var waitForProviderNativeFleetFunc = waitForProviderNativeFleet
+
+func buildRuntimeProvider(ctx context.Context, kind cloud.Kind, outputs map[string]string, log logger.Logger) (cloud.Provider, error) {
+	if kind.IsProviderNative() && outputs != nil {
+		return factory.Build(factory.Config{
+			Kind:       kind,
+			Selfhosted: factory.SelfhostedConfigFromOutputs(outputs),
+			Logger:     log,
+		})
+	}
+	return factory.BuildForKind(ctx, kind, log)
+}
+
+func waitForProviderNativeFleet(ctx context.Context, kind cloud.Kind, outputs map[string]string) (int, error) {
+	natsURL := outputs["nats_url"]
+	if natsURL == "" {
+		return 0, fmt.Errorf("terraform outputs missing nats_url")
+	}
+
+	desired := fleetWorkerCount(outputs)
+	if desired <= 0 {
+		desired = 1
+	}
+
+	mgr, err := fleet.NewNATSFleetManager(fleet.NATSFleetManagerConfig{
+		NATSURL:        natsURL,
+		DesiredWorkers: desired,
+		ControllerIP:   outputs["controller_ip"],
+		GenerationID:   outputs["generation_id"],
+		Cloud:          string(kind.Canonical()),
+	}, logger.NewSimpleLogger())
+	if err != nil {
+		return 0, fmt.Errorf("starting provider-native fleet manager: %w", err)
+	}
+	defer mgr.Close()
+
+	state, err := mgr.WaitForWorkers(ctx, desired)
+	if err != nil {
+		return 0, fmt.Errorf("waiting for provider-native fleet: %w", err)
+	}
+	summary := state.Summarize()
+	logStatus(
+		"Provider-native fleet ready: %d/%d workers ready, %d IPv6-ready, %d unique IPv4",
+		summary.ReadyCount, summary.DesiredWorkers, summary.IPv6ReadyCount, summary.UniqueIPv4Count,
+	)
+	return summary.ReadyCount, nil
+}
+
+func fleetWorkerCount(outputs map[string]string) int {
+	if outputs == nil {
+		return 0
+	}
+	raw := outputs["worker_count"]
+	if raw == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return n
+}

--- a/cmd/heph/provider_runtime.go
+++ b/cmd/heph/provider_runtime.go
@@ -45,7 +45,7 @@ func waitForProviderNativeFleet(ctx context.Context, kind cloud.Kind, outputs ma
 	if err != nil {
 		return 0, fmt.Errorf("starting provider-native fleet manager: %w", err)
 	}
-	defer mgr.Close()
+	defer func() { _ = mgr.Close() }()
 
 	state, err := mgr.WaitForWorkers(ctx, desired)
 	if err != nil {

--- a/cmd/workers/generic/heartbeat.go
+++ b/cmd/workers/generic/heartbeat.go
@@ -91,7 +91,7 @@ func probeIPv6() bool {
 	if err != nil {
 		return false
 	}
-	conn.Close()
+	_ = conn.Close()
 	return true
 }
 

--- a/cmd/workers/generic/heartbeat.go
+++ b/cmd/workers/generic/heartbeat.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"time"
+
+	appconfig "heph4estus/internal/config"
+	"heph4estus/internal/fleet"
+	"heph4estus/internal/logger"
+
+	"github.com/nats-io/nats.go"
+)
+
+// startHeartbeat launches a background goroutine that publishes fleet
+// heartbeat messages over NATS. It returns a cancel function to stop
+// the heartbeat.
+func startHeartbeat(ctx context.Context, cfg *appconfig.WorkerConfig, log logger.Logger) (cancel func()) {
+	if !cfg.FleetHeartbeat || cfg.NATSURL == "" {
+		return func() {}
+	}
+
+	conn, err := nats.Connect(cfg.NATSURL,
+		nats.Name("heph-worker-heartbeat-"+cfg.WorkerID),
+		nats.MaxReconnects(-1),
+	)
+	if err != nil {
+		log.Error("Fleet heartbeat: failed to connect to NATS: %v", err)
+		return func() {}
+	}
+
+	// Probe IPv6 connectivity once at startup.
+	ipv6Ready := probeIPv6()
+	publicIPv4, publicIPv6 := detectPublicIPs()
+
+	hbCtx, hbCancel := context.WithCancel(ctx)
+
+	go func() {
+		ticker := time.NewTicker(fleet.DefaultHeartbeatInterval)
+		defer ticker.Stop()
+		defer conn.Close()
+
+		// Publish initial heartbeat immediately.
+		publishHeartbeat(conn, cfg, publicIPv4, publicIPv6, ipv6Ready, log)
+
+		for {
+			select {
+			case <-hbCtx.Done():
+				return
+			case <-ticker.C:
+				publishHeartbeat(conn, cfg, publicIPv4, publicIPv6, ipv6Ready, log)
+			}
+		}
+	}()
+
+	return hbCancel
+}
+
+func publishHeartbeat(conn *nats.Conn, cfg *appconfig.WorkerConfig, ipv4, ipv6 string, ipv6Ready bool, log logger.Logger) {
+	msg := fleet.HeartbeatMessage{
+		WorkerID:     cfg.WorkerID,
+		Host:         cfg.WorkerHost,
+		PublicIPv4:   ipv4,
+		PublicIPv6:   ipv6,
+		IPv6Ready:    ipv6Ready,
+		Version:      cfg.WorkerVersion,
+		Ready:        true,
+		Cloud:        cfg.Cloud,
+		GenerationID: cfg.GenerationID,
+		Timestamp:    time.Now().Unix(),
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		log.Error("Fleet heartbeat: marshal error: %v", err)
+		return
+	}
+
+	if err := conn.Publish(fleet.HeartbeatSubject, data); err != nil {
+		log.Error("Fleet heartbeat: publish error: %v", err)
+	}
+}
+
+// probeIPv6 tests IPv6 connectivity by dialing a well-known IPv6 address.
+// Returns true if the connection succeeds from inside the container.
+func probeIPv6() bool {
+	// Try to establish a UDP "connection" to Google's public DNS over IPv6.
+	// This doesn't send any data — it just checks if the OS can route IPv6.
+	conn, err := net.DialTimeout("udp6", "[2001:4860:4860::8888]:53", 5*time.Second)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+// detectPublicIPs attempts to determine the host's public IPv4 and IPv6
+// addresses by examining network interfaces.
+func detectPublicIPs() (ipv4, ipv6 string) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return "", ""
+	}
+	for _, addr := range addrs {
+		ipNet, ok := addr.(*net.IPNet)
+		if !ok || ipNet.IP.IsLoopback() || ipNet.IP.IsPrivate() || ipNet.IP.IsLinkLocalUnicast() {
+			continue
+		}
+		if ipNet.IP.To4() != nil && ipv4 == "" {
+			ipv4 = ipNet.IP.String()
+		} else if ipNet.IP.To4() == nil && ipv6 == "" {
+			ipv6 = ipNet.IP.String()
+		}
+	}
+	return ipv4, ipv6
+}

--- a/cmd/workers/generic/main.go
+++ b/cmd/workers/generic/main.go
@@ -54,6 +54,11 @@ func main() {
 	executor := worker.NewExecutor(log, provider.Storage(), cfg.Bucket)
 
 	ctx := context.Background()
+
+	// Start fleet heartbeat if configured (selfhosted/Hetzner workers).
+	stopHeartbeat := startHeartbeat(ctx, cfg, log)
+	defer stopHeartbeat()
+
 	for {
 		processed, err := processMessage(ctx, log, cfg, mod, provider.Queue(), provider.Storage(), executor)
 		if err != nil {

--- a/deployments/hetzner/main.tf
+++ b/deployments/hetzner/main.tf
@@ -1,0 +1,255 @@
+# Hetzner Cloud fleet module — provisions a controller VM (NATS + MinIO +
+# registry via the selfhosted controller module) and N worker VMs that
+# auto-join the fleet on boot via cloud-init.
+#
+# The controller module generates credentials and cloud-init; this module
+# adds all Hetzner-specific resources (servers, networking, firewall).
+
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = ">= 1.45"
+    }
+  }
+}
+
+provider "hcloud" {
+  token = var.hcloud_token
+}
+
+# --- Generation ID ---
+
+resource "random_id" "generation" {
+  byte_length = 8
+}
+
+locals {
+  generation_id         = var.generation_id != "" ? var.generation_id : random_id.generation.hex
+  controller_private_ip = "10.0.1.2"
+
+  # Map Hetzner locations to their primary datacenter names.
+  location_to_dc = {
+    fsn1 = "fsn1-dc14"
+    nbg1 = "nbg1-dc3"
+    hel1 = "hel1-dc2"
+    ash  = "ash-dc1"
+    hil  = "hil-dc1"
+  }
+  datacenter = lookup(local.location_to_dc, var.location, "${var.location}-dc1")
+}
+
+# --- SSH Key ---
+
+resource "hcloud_ssh_key" "deploy" {
+  name       = var.ssh_key_name
+  public_key = var.ssh_public_key
+}
+
+# --- Primary IP (allocated before server so IP is known at plan time) ---
+
+resource "hcloud_primary_ip" "controller" {
+  name          = "heph-controller-ip"
+  type          = "ipv4"
+  datacenter    = local.datacenter
+  assignee_type = "server"
+  auto_delete   = true
+  labels = {
+    Project = "heph4estus"
+    Role    = "controller"
+    Tool    = var.tool_name
+  }
+}
+
+# --- Controller module (credentials + cloud-init) ---
+
+module "controller" {
+  source = "../selfhosted/controller"
+
+  controller_ip = hcloud_primary_ip.controller.ip_address
+  tool_name     = var.tool_name
+  minio_bucket  = var.minio_bucket
+}
+
+# --- Networking ---
+
+resource "hcloud_network" "fleet" {
+  name     = "heph-fleet"
+  ip_range = "10.0.0.0/16"
+  labels = {
+    Project = "heph4estus"
+  }
+}
+
+resource "hcloud_network_subnet" "nodes" {
+  network_id   = hcloud_network.fleet.id
+  type         = "cloud"
+  network_zone = "eu-central"
+  ip_range     = "10.0.1.0/24"
+}
+
+# --- Firewall ---
+
+resource "hcloud_firewall" "fleet" {
+  name = "heph-fleet-fw"
+
+  labels = {
+    Project = "heph4estus"
+  }
+
+  # Inbound: SSH from anywhere
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "22"
+    source_ips = ["0.0.0.0/0", "::/0"]
+  }
+
+  # Inbound: operator-facing controller services.
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "4222"
+    source_ips = ["0.0.0.0/0", "::/0"]
+  }
+
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "5000"
+    source_ips = ["0.0.0.0/0", "::/0"]
+  }
+
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "9000"
+    source_ips = ["0.0.0.0/0", "::/0"]
+  }
+
+  # Inbound: all traffic from private network
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "any"
+    source_ips = ["10.0.0.0/16"]
+  }
+
+  rule {
+    direction  = "in"
+    protocol   = "udp"
+    port       = "any"
+    source_ips = ["10.0.0.0/16"]
+  }
+
+  # Outbound: all IPv4 and IPv6
+  rule {
+    direction       = "out"
+    protocol        = "tcp"
+    port            = "any"
+    destination_ips = ["0.0.0.0/0", "::/0"]
+  }
+
+  rule {
+    direction       = "out"
+    protocol        = "udp"
+    port            = "any"
+    destination_ips = ["0.0.0.0/0", "::/0"]
+  }
+
+  rule {
+    direction       = "out"
+    protocol        = "icmp"
+    destination_ips = ["0.0.0.0/0", "::/0"]
+  }
+}
+
+# --- Controller Server ---
+
+resource "hcloud_server" "controller" {
+  name        = "heph-controller"
+  server_type = var.controller_type
+  image       = "ubuntu-24.04"
+  location    = var.location
+  user_data   = module.controller.cloud_init
+
+  public_net {
+    ipv4_enabled = true
+    ipv4         = hcloud_primary_ip.controller.id
+    ipv6_enabled = true
+  }
+
+  network {
+    network_id = hcloud_network.fleet.id
+    ip         = local.controller_private_ip
+  }
+
+  firewall_ids = [hcloud_firewall.fleet.id]
+  ssh_keys     = [hcloud_ssh_key.deploy.id]
+
+  labels = {
+    Project = "heph4estus"
+    Role    = "controller"
+    Tool    = var.tool_name
+  }
+
+  depends_on = [hcloud_network_subnet.nodes]
+}
+
+# --- Worker cloud-init ---
+
+locals {
+  worker_cloud_init = [
+    for i in range(var.worker_count) : templatefile("${path.module}/templates/worker-cloud-init.yaml", {
+      controller_private_ip = local.controller_private_ip
+      nats_port             = 4222
+      nats_subject          = module.controller.nats_stream
+      minio_port            = 9000
+      minio_access_key      = module.controller.s3_access_key
+      minio_secret_key      = module.controller.s3_secret_key
+      minio_bucket          = var.minio_bucket
+      registry_port         = 5000
+      tool_name             = var.tool_name
+      docker_image          = var.docker_image
+      generation_id         = local.generation_id
+      worker_index          = i
+      worker_private_ip     = "10.0.1.${i + 10}"
+    })
+  ]
+}
+
+# --- Worker Servers ---
+
+resource "hcloud_server" "worker" {
+  count = var.worker_count
+
+  name        = "heph-worker-${count.index}"
+  server_type = var.worker_type
+  image       = "ubuntu-24.04"
+  location    = var.location
+  user_data   = local.worker_cloud_init[count.index]
+
+  public_net {
+    ipv4_enabled = true
+    ipv6_enabled = true
+  }
+
+  network {
+    network_id = hcloud_network.fleet.id
+    ip         = "10.0.1.${count.index + 10}"
+  }
+
+  firewall_ids = [hcloud_firewall.fleet.id]
+  ssh_keys     = [hcloud_ssh_key.deploy.id]
+
+  labels = {
+    Project = "heph4estus"
+    Role    = "worker"
+    Tool    = var.tool_name
+    Index   = tostring(count.index)
+  }
+
+  depends_on = [hcloud_network_subnet.nodes, hcloud_server.controller]
+}

--- a/deployments/hetzner/outputs.tf
+++ b/deployments/hetzner/outputs.tf
@@ -1,0 +1,119 @@
+# Output names map onto the selfhosted env family so the Go deploy UX can
+# wire these directly into the operator's environment.  Sensitive outputs
+# are marked so Terraform does not display them in plan/apply output.
+#
+# sqs_queue_url is intentionally used for the NATS subject name to maintain
+# compatibility with the existing scan launch code which reads
+# outputs["sqs_queue_url"].
+
+output "tool_name" {
+  description = "Tool name (passed through for lifecycle mismatch detection)."
+  value       = var.tool_name
+}
+
+output "cloud" {
+  description = "Cloud provider identifier."
+  value       = "hetzner"
+}
+
+output "nats_url" {
+  description = "NATS client URL for workers and the operator CLI."
+  value       = "nats://${hcloud_server.controller.ipv4_address}:4222"
+}
+
+output "nats_stream" {
+  description = "NATS JetStream stream name."
+  value       = module.controller.nats_stream
+}
+
+output "s3_endpoint" {
+  description = "MinIO S3-compatible endpoint URL."
+  value       = "http://${hcloud_server.controller.ipv4_address}:9000"
+}
+
+output "s3_region" {
+  description = "S3 region (MinIO ignores this but clients require it)."
+  value       = "us-east-1"
+}
+
+output "s3_access_key" {
+  description = "MinIO root access key."
+  value       = module.controller.s3_access_key
+  sensitive   = true
+}
+
+output "s3_secret_key" {
+  description = "MinIO root secret key."
+  value       = module.controller.s3_secret_key
+  sensitive   = true
+}
+
+output "s3_path_style" {
+  description = "Whether to use path-style S3 access (always true for MinIO)."
+  value       = "true"
+}
+
+output "s3_bucket_name" {
+  description = "Default storage bucket name."
+  value       = var.minio_bucket
+}
+
+output "registry_url" {
+  description = "Docker registry URL for worker image distribution."
+  value       = "${hcloud_server.controller.ipv4_address}:5000"
+}
+
+output "docker_image" {
+  description = "Worker Docker image path relative to the controller registry."
+  value       = var.docker_image
+}
+
+output "sqs_queue_url" {
+  description = "NATS subject name (named sqs_queue_url for scan launch compatibility)."
+  value       = module.controller.nats_stream
+}
+
+output "worker_count" {
+  description = "Number of worker VMs in the fleet."
+  value       = var.worker_count
+}
+
+output "controller_ip" {
+  description = "Controller public IPv4 address."
+  value       = hcloud_server.controller.ipv4_address
+}
+
+output "controller_ipv6" {
+  description = "Controller public IPv6 address."
+  value       = hcloud_server.controller.ipv6_address
+}
+
+output "worker_ips" {
+  description = "List of worker public IPv4 addresses."
+  value       = hcloud_server.worker[*].ipv4_address
+}
+
+output "worker_ipv6s" {
+  description = "List of worker public IPv6 addresses."
+  value       = hcloud_server.worker[*].ipv6_address
+}
+
+output "worker_private_ips" {
+  description = "List of worker private IPs on the fleet network."
+  value       = [for i in range(var.worker_count) : "10.0.1.${i + 10}"]
+}
+
+output "worker_hosts" {
+  description = "Comma-separated worker IPs for SELFHOSTED_WORKER_HOSTS compatibility."
+  value       = join(",", hcloud_server.worker[*].ipv4_address)
+}
+
+output "ssh_key_name" {
+  description = "SSH key name used for VM access."
+  value       = var.ssh_key_name
+}
+
+output "generation_id" {
+  description = "Fleet generation ID for ownership tracking."
+  value       = local.generation_id
+}

--- a/deployments/hetzner/templates/worker-cloud-init.yaml
+++ b/deployments/hetzner/templates/worker-cloud-init.yaml
@@ -1,0 +1,71 @@
+#cloud-config
+# Worker VM bootstrap — installs Docker, configures the controller's insecure
+# registry, pulls the worker image, and starts the worker as a systemd service.
+
+package_update: true
+
+packages:
+  - docker.io
+  - jq
+
+write_files:
+  # Configure Docker to trust the controller's insecure registry
+  - path: /etc/docker/daemon.json
+    content: |
+      {
+        "insecure-registries": ["${controller_private_ip}:${registry_port}"]
+      }
+
+  # Worker systemd service
+  - path: /etc/systemd/system/heph-worker.service
+    content: |
+      [Unit]
+      Description=Heph4estus Worker
+      After=docker.service
+      Requires=docker.service
+
+      [Service]
+      Restart=always
+      RestartSec=10
+      ExecStartPre=-/usr/bin/docker rm -f heph-worker
+      ExecStartPre=/usr/bin/docker pull ${controller_private_ip}:${registry_port}/${docker_image}
+      ExecStart=/usr/bin/docker run --name heph-worker \
+        -e CLOUD=hetzner \
+        -e QUEUE_URL=${nats_subject} \
+        -e S3_BUCKET=${minio_bucket} \
+        -e TOOL_NAME=${tool_name} \
+        -e NATS_URL=nats://${controller_private_ip}:${nats_port} \
+        -e S3_ENDPOINT=http://${controller_private_ip}:${minio_port} \
+        -e S3_REGION=us-east-1 \
+        -e S3_ACCESS_KEY=${minio_access_key} \
+        -e S3_SECRET_KEY=${minio_secret_key} \
+        -e S3_PATH_STYLE=true \
+        -e FLEET_HEARTBEAT=true \
+        -e FLEET_GENERATION_ID=${generation_id} \
+        -e WORKER_ID=heph-worker-${worker_index} \
+        -e WORKER_HOST=${worker_private_ip} \
+        -e WORKER_VERSION=${docker_image} \
+        ${controller_private_ip}:${registry_port}/${docker_image}
+      ExecStop=/usr/bin/docker stop heph-worker
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  - mkdir -p /data
+  - systemctl daemon-reload
+  - systemctl enable --now docker
+
+  # Restart Docker to pick up insecure registry config
+  - systemctl restart docker
+
+  # Wait for controller registry to be reachable
+  - |
+    for i in $(seq 1 60); do
+      curl -sf http://${controller_private_ip}:${registry_port}/v2/ && break
+      echo "Waiting for controller registry (attempt $i)..."
+      sleep 5
+    done
+
+  # Start the worker service
+  - systemctl enable --now heph-worker

--- a/deployments/hetzner/variables.tf
+++ b/deployments/hetzner/variables.tf
@@ -1,0 +1,63 @@
+variable "hcloud_token" {
+  description = "Hetzner Cloud API token."
+  type        = string
+  sensitive   = true
+}
+
+variable "tool_name" {
+  description = "Tool name for lifecycle detection."
+  type        = string
+}
+
+variable "worker_count" {
+  description = "Number of worker VMs."
+  type        = number
+  default     = 3
+}
+
+variable "controller_type" {
+  description = "Hetzner server type for controller."
+  type        = string
+  default     = "cx22"
+}
+
+variable "worker_type" {
+  description = "Hetzner server type for workers."
+  type        = string
+  default     = "cx22"
+}
+
+variable "location" {
+  description = "Hetzner datacenter location."
+  type        = string
+  default     = "fsn1"
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key for VM access."
+  type        = string
+}
+
+variable "ssh_key_name" {
+  description = "Name for the SSH key resource."
+  type        = string
+  default     = "heph-deploy"
+}
+
+variable "minio_bucket" {
+  description = "MinIO bucket name."
+  type        = string
+  default     = "heph-results"
+}
+
+variable "docker_image" {
+  description = "Worker Docker image (relative to controller registry)."
+  type        = string
+  default     = "heph-worker:latest"
+}
+
+variable "generation_id" {
+  description = "Fleet generation ID for ownership tracking."
+  type        = string
+  default     = ""
+}

--- a/internal/cloud/factory/factory.go
+++ b/internal/cloud/factory/factory.go
@@ -79,6 +79,8 @@ func Build(cfg Config) (cloud.Provider, error) {
 		}
 		return awscloud.NewProvider(cfg.AWS.SDKConfig, cfg.Logger), nil
 	case cloud.KindManual:
+		// Manual mode uses the selfhosted runtime end-to-end, including
+		// Docker-over-SSH compute.
 		if cfg.Selfhosted == nil {
 			return nil, fmt.Errorf("factory: selfhosted config is required for cloud %q", cfg.Kind.Canonical())
 		}
@@ -107,6 +109,31 @@ func Build(cfg Config) (cloud.Provider, error) {
 				SSHKeyPath:  cfg.Selfhosted.SSHKeyPath,
 				SSHPort:     cfg.Selfhosted.SSHPort,
 				DockerImage: cfg.Selfhosted.DockerImage,
+			}
+		}
+		return selfhosted.NewProvider(pcfg, cfg.Logger)
+	case cloud.KindHetzner:
+		// Provider-native Hetzner reuses the selfhosted queue/storage runtime,
+		// but normal operator flows must not fall back to ad hoc SSH launches.
+		if cfg.Selfhosted == nil {
+			return nil, fmt.Errorf("factory: selfhosted config is required for cloud %q", cfg.Kind.Canonical())
+		}
+		pcfg := selfhosted.ProviderConfig{
+			Storage: selfhosted.StorageConfig{
+				Endpoint:  cfg.Selfhosted.S3Endpoint,
+				Region:    cfg.Selfhosted.S3Region,
+				AccessKey: cfg.Selfhosted.S3AccessKey,
+				Secret:    cfg.Selfhosted.S3Secret,
+				PathStyle: cfg.Selfhosted.S3PathStyle,
+			},
+		}
+		if cfg.Selfhosted.NATSURL != "" {
+			pcfg.Queue = &selfhosted.QueueConfig{
+				URL:            cfg.Selfhosted.NATSURL,
+				StreamName:     cfg.Selfhosted.StreamName,
+				DurablePrefix:  cfg.Selfhosted.DurablePrefix,
+				AckWaitSeconds: cfg.Selfhosted.AckWaitSeconds,
+				MaxDeliver:     cfg.Selfhosted.MaxDeliver,
 			}
 		}
 		return selfhosted.NewProvider(pcfg, cfg.Logger)
@@ -164,7 +191,7 @@ func BuildForKind(ctx context.Context, kind cloud.Kind, log logger.Logger) (clou
 			AWS:    &AWSConfig{SDKConfig: sdkCfg},
 			Logger: log,
 		})
-	case cloud.KindManual:
+	case cloud.KindManual, cloud.KindHetzner:
 		return Build(Config{
 			Kind:       kind.Canonical(),
 			Selfhosted: SelfhostedConfigFromEnv(),
@@ -173,6 +200,29 @@ func BuildForKind(ctx context.Context, kind cloud.Kind, log logger.Logger) (clou
 	default:
 		return nil, fmt.Errorf("factory: unsupported cloud %q", kind)
 	}
+}
+
+// SelfhostedConfigFromOutputs constructs a SelfhostedConfig from Terraform
+// outputs. This is used by provider-native paths (Hetzner) where the
+// controller endpoints and credentials come from deploy outputs rather than
+// operator environment variables.
+func SelfhostedConfigFromOutputs(outputs map[string]string) *SelfhostedConfig {
+	cfg := &SelfhostedConfig{
+		NATSURL:     outputs["nats_url"],
+		StreamName:  outputs["nats_stream"],
+		S3Endpoint:  outputs["s3_endpoint"],
+		S3Region:    outputs["s3_region"],
+		S3AccessKey: outputs["s3_access_key"],
+		S3Secret:    outputs["s3_secret_key"],
+		S3PathStyle: outputs["s3_path_style"] == "true",
+		QueueID:     outputs["sqs_queue_url"],
+		Bucket:      outputs["s3_bucket_name"],
+		DockerImage: outputs["registry_url"] + "/" + outputs["docker_image"],
+	}
+	if hosts := outputs["worker_hosts"]; hosts != "" {
+		cfg.WorkerHosts = splitCommaList(hosts)
+	}
+	return cfg
 }
 
 func envOr(key, fallback string) string {

--- a/internal/cloud/factory/factory_test.go
+++ b/internal/cloud/factory/factory_test.go
@@ -1,6 +1,8 @@
 package factory
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	"heph4estus/internal/cloud"
@@ -326,5 +328,58 @@ func TestBuildSelfhostedWithComputeConfig(t *testing.T) {
 	// Compute is backed by real DockerCompute when config is present.
 	if p.Compute() == nil {
 		t.Fatal("expected compute surface")
+	}
+}
+
+func TestSelfhostedConfigFromOutputs(t *testing.T) {
+	cfg := SelfhostedConfigFromOutputs(map[string]string{
+		"nats_url":       "nats://ctrl:4222",
+		"nats_stream":    "heph-tasks",
+		"s3_endpoint":    "http://ctrl:9000",
+		"s3_region":      "us-east-1",
+		"s3_access_key":  "ak",
+		"s3_secret_key":  "sk",
+		"s3_path_style":  "true",
+		"sqs_queue_url":  "heph-tasks",
+		"s3_bucket_name": "heph-results",
+		"registry_url":   "10.0.1.2:5000",
+		"docker_image":   "heph-nmap-worker:latest",
+		"worker_hosts":   "203.0.113.10,203.0.113.11",
+	})
+
+	if cfg.QueueID != "heph-tasks" {
+		t.Fatalf("QueueID = %q, want heph-tasks", cfg.QueueID)
+	}
+	if cfg.DockerImage != "10.0.1.2:5000/heph-nmap-worker:latest" {
+		t.Fatalf("DockerImage = %q", cfg.DockerImage)
+	}
+	if len(cfg.WorkerHosts) != 2 {
+		t.Fatalf("WorkerHosts = %v, want 2 entries", cfg.WorkerHosts)
+	}
+}
+
+func TestBuildHetznerDisablesSSHCompute(t *testing.T) {
+	p, err := Build(Config{
+		Kind: cloud.KindHetzner,
+		Selfhosted: &SelfhostedConfig{
+			S3Endpoint:  "http://ctrl:9000",
+			S3Region:    "us-east-1",
+			S3AccessKey: "ak",
+			S3Secret:    "sk",
+			S3PathStyle: true,
+			WorkerHosts: []string{"203.0.113.10"},
+			SSHUser:     "root",
+			SSHKeyPath:  "/tmp/key",
+			DockerImage: "10.0.1.2:5000/heph-nmap-worker:latest",
+		},
+		Logger: logger.NewSimpleLogger(),
+	})
+	if err != nil {
+		t.Fatalf("Build hetzner: %v", err)
+	}
+	if _, err := p.Compute().RunContainer(context.Background(), cloud.ContainerOpts{}); err == nil {
+		t.Fatal("expected provider-native Hetzner compute to reject RunContainer")
+	} else if !strings.Contains(err.Error(), "compute is not configured") {
+		t.Fatalf("unexpected RunContainer error: %v", err)
 	}
 }

--- a/internal/cloud/kind.go
+++ b/internal/cloud/kind.go
@@ -69,11 +69,30 @@ func (k Kind) IsSelfhostedFamily() bool {
 
 // RuntimeFamily collapses provider-specific selectors onto the shared
 // execution family used by the implementation.
+//
+// Hetzner keeps its own kind so the factory can route it to the fleet-manager
+// path instead of the manual SSH path.  All selfhosted-family providers share
+// the same queue/storage runtime but Hetzner has provider-native deploy.
 func (k Kind) RuntimeFamily() Kind {
-	if k.IsSelfhostedFamily() {
+	switch k.Canonical() {
+	case KindHetzner:
+		return KindHetzner
+	case KindManual, KindLinode, KindScaleway, KindVultr:
 		return KindManual
+	default:
+		return KindAWS
 	}
-	return KindAWS
+}
+
+// IsProviderNative reports whether the kind has provider-native deploy
+// support (Terraform + fleet manager) as opposed to manual/operator-managed.
+func (k Kind) IsProviderNative() bool {
+	switch k.Canonical() {
+	case KindHetzner:
+		return true
+	default:
+		return false
+	}
 }
 
 // SupportedKindsText returns the canonical user-facing list for help text.

--- a/internal/cloud/kind_test.go
+++ b/internal/cloud/kind_test.go
@@ -85,7 +85,7 @@ func TestSelfhostedFamilyHelpers(t *testing.T) {
 		{KindManual, true, KindManual, KindManual},
 		{KindSelfhosted, true, KindManual, KindManual},
 		{Kind("selfhosted"), true, KindManual, KindManual},
-		{KindHetzner, true, KindManual, KindHetzner},
+		{KindHetzner, true, KindHetzner, KindHetzner},
 		{KindLinode, true, KindManual, KindLinode},
 	}
 	for _, tt := range tests {

--- a/internal/cloud/selfhosted/nats_test.go
+++ b/internal/cloud/selfhosted/nats_test.go
@@ -14,7 +14,12 @@ import (
 func startEmbeddedNATS(t *testing.T) *natsserver.Server {
 	t.Helper()
 	opts := &natsserver.Options{
+		Host:      "127.0.0.1",
 		Port:      -1,
+		HTTPHost:  "127.0.0.1",
+		HTTPPort:  -1,
+		NoSigs:    true,
+		NoLog:     true,
 		JetStream: true,
 		StoreDir:  t.TempDir(),
 	}

--- a/internal/config/worker_config.go
+++ b/internal/config/worker_config.go
@@ -13,6 +13,14 @@ type WorkerConfig struct {
 	Bucket           string // S3_BUCKET — storage bucket name
 	ToolName         string
 	JitterMaxSeconds int // JITTER_MAX_SECONDS; 0 = disabled
+
+	// Fleet heartbeat settings (selfhosted/Hetzner workers).
+	FleetHeartbeat bool   // FLEET_HEARTBEAT; enables heartbeat publishing
+	WorkerID       string // WORKER_ID; unique worker identifier
+	WorkerHost     string // WORKER_HOST; private IP or hostname
+	NATSURL        string // NATS_URL; NATS server for heartbeats
+	WorkerVersion  string // WORKER_VERSION; image tag/version for fleet reporting
+	GenerationID   string // FLEET_GENERATION_ID; provider-native fleet generation marker
 }
 
 // NewWorkerConfig creates a new generic worker configuration from environment variables.
@@ -44,11 +52,24 @@ func NewWorkerConfig() (*WorkerConfig, error) {
 		}
 	}
 
+	fleetHeartbeat := os.Getenv("FLEET_HEARTBEAT") == "true"
+	workerID := os.Getenv("WORKER_ID")
+	if workerID == "" {
+		hostname, _ := os.Hostname()
+		workerID = hostname
+	}
+
 	return &WorkerConfig{
 		Cloud:            cloudVal,
 		QueueID:          queueID,
 		Bucket:           bucket,
 		ToolName:         toolName,
 		JitterMaxSeconds: jitterMax,
+		FleetHeartbeat:   fleetHeartbeat,
+		WorkerID:         workerID,
+		WorkerHost:       os.Getenv("WORKER_HOST"),
+		NATSURL:          os.Getenv("NATS_URL"),
+		WorkerVersion:    os.Getenv("WORKER_VERSION"),
+		GenerationID:     os.Getenv("FLEET_GENERATION_ID"),
 	}, nil
 }

--- a/internal/config/worker_config_test.go
+++ b/internal/config/worker_config_test.go
@@ -104,6 +104,33 @@ func TestNewWorkerConfig_SelfhostedScanRuntime(t *testing.T) {
 	}
 }
 
+func TestNewWorkerConfig_FleetMetadata(t *testing.T) {
+	t.Setenv("QUEUE_URL", "heph-tasks")
+	t.Setenv("S3_BUCKET", "heph-results")
+	t.Setenv("TOOL_NAME", "nmap")
+	t.Setenv("CLOUD", "hetzner")
+	t.Setenv("FLEET_HEARTBEAT", "true")
+	t.Setenv("WORKER_ID", "heph-worker-0")
+	t.Setenv("WORKER_HOST", "10.0.1.10")
+	t.Setenv("NATS_URL", "nats://10.0.1.2:4222")
+	t.Setenv("WORKER_VERSION", "heph-nmap-worker:latest")
+	t.Setenv("FLEET_GENERATION_ID", "gen-123")
+
+	cfg, err := NewWorkerConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.FleetHeartbeat {
+		t.Fatal("expected FleetHeartbeat=true")
+	}
+	if cfg.WorkerVersion != "heph-nmap-worker:latest" {
+		t.Fatalf("WorkerVersion = %q", cfg.WorkerVersion)
+	}
+	if cfg.GenerationID != "gen-123" {
+		t.Fatalf("GenerationID = %q", cfg.GenerationID)
+	}
+}
+
 func TestNewWorkerConfig_MissingRequired(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -75,6 +75,9 @@ func RunAll(ctx context.Context, deps Deps) []CheckResult {
 		checkSTSIdentity(ctx, deps),
 		checkConfigDirWritable(deps),
 		checkOutputDir(deps),
+		// Hetzner checks.
+		checkHetznerToken(deps),
+		checkHetznerSSHKey(deps),
 	}
 }
 
@@ -251,6 +254,52 @@ func checkConfigDirWritable(deps Deps) CheckResult {
 		Name:    "config_dir",
 		Status:  StatusPass,
 		Summary: fmt.Sprintf("Config directory %s is writable", dir),
+	}
+}
+
+// checkHetznerToken checks for HCLOUD_TOKEN environment variable.
+func checkHetznerToken(deps Deps) CheckResult {
+	if v := deps.Getenv("HCLOUD_TOKEN"); v != "" {
+		return CheckResult{
+			Name:    "hetzner_token",
+			Status:  StatusPass,
+			Summary: "HCLOUD_TOKEN is set",
+		}
+	}
+	return CheckResult{
+		Name:    "hetzner_token",
+		Status:  StatusWarn,
+		Summary: "HCLOUD_TOKEN is not set (required for --cloud hetzner)",
+		Fix:     "Set HCLOUD_TOKEN with your Hetzner Cloud API token, or skip if not using Hetzner.",
+	}
+}
+
+// checkHetznerSSHKey checks for an SSH key that can be used for Hetzner VMs.
+func checkHetznerSSHKey(deps Deps) CheckResult {
+	// Check common SSH key paths.
+	home := deps.Getenv("HOME")
+	if home == "" {
+		return CheckResult{
+			Name:    "hetzner_ssh_key",
+			Status:  StatusWarn,
+			Summary: "Cannot determine HOME directory for SSH key check",
+		}
+	}
+	for _, name := range []string{"id_ed25519", "id_rsa"} {
+		path := filepath.Join(home, ".ssh", name+".pub")
+		if _, err := os.Stat(path); err == nil {
+			return CheckResult{
+				Name:    "hetzner_ssh_key",
+				Status:  StatusPass,
+				Summary: fmt.Sprintf("SSH public key found at %s", path),
+			}
+		}
+	}
+	return CheckResult{
+		Name:    "hetzner_ssh_key",
+		Status:  StatusWarn,
+		Summary: "No SSH public key found in ~/.ssh/ (needed for Hetzner VM access)",
+		Fix:     "Generate an SSH key with 'ssh-keygen -t ed25519' or skip if not using Hetzner.",
 	}
 }
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -265,8 +265,8 @@ func TestRunAll_ReturnsAllChecks(t *testing.T) {
 	d := baseDeps()
 	d.Getenv = envWith(map[string]string{"AWS_REGION": "us-east-1"})
 	results := RunAll(context.Background(), d)
-	if len(results) != 9 {
-		t.Fatalf("expected 9 checks, got %d", len(results))
+	if len(results) != 11 {
+		t.Fatalf("expected 11 checks, got %d", len(results))
 	}
 }
 
@@ -305,10 +305,72 @@ func TestRunAll_OrderIsStable(t *testing.T) {
 		"sts_identity",
 		"config_dir",
 		"output_dir",
+		"hetzner_token",
+		"hetzner_ssh_key",
 	}
 	for i, name := range expected {
 		if results[i].Name != name {
 			t.Errorf("check %d: expected %s, got %s", i, name, results[i].Name)
 		}
+	}
+}
+
+// --- Hetzner token ---
+
+func TestCheckHetznerToken_Set(t *testing.T) {
+	d := baseDeps()
+	d.Getenv = envWith(map[string]string{"HCLOUD_TOKEN": "test-token-abc123"})
+	r := checkHetznerToken(d)
+	if r.Status != StatusPass {
+		t.Fatalf("expected pass, got %s: %s", r.Status, r.Summary)
+	}
+	if r.Name != "hetzner_token" {
+		t.Fatalf("unexpected name: %s", r.Name)
+	}
+}
+
+func TestCheckHetznerToken_Unset(t *testing.T) {
+	d := baseDeps()
+	r := checkHetznerToken(d)
+	if r.Status != StatusWarn {
+		t.Fatalf("expected warn, got %s: %s", r.Status, r.Summary)
+	}
+	if r.Fix == "" {
+		t.Fatal("expected a fix suggestion")
+	}
+}
+
+// --- Hetzner SSH key ---
+
+func TestCheckHetznerSSHKey_Found(t *testing.T) {
+	tmp := t.TempDir()
+	sshDir := filepath.Join(tmp, ".ssh")
+	if err := os.MkdirAll(sshDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sshDir, "id_ed25519.pub"), []byte("ssh-ed25519 AAAA..."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d := baseDeps()
+	d.Getenv = envWith(map[string]string{"HOME": tmp})
+	r := checkHetznerSSHKey(d)
+	if r.Status != StatusPass {
+		t.Fatalf("expected pass, got %s: %s", r.Status, r.Summary)
+	}
+	if r.Name != "hetzner_ssh_key" {
+		t.Fatalf("unexpected name: %s", r.Name)
+	}
+}
+
+func TestCheckHetznerSSHKey_Missing(t *testing.T) {
+	tmp := t.TempDir()
+	d := baseDeps()
+	d.Getenv = envWith(map[string]string{"HOME": tmp})
+	r := checkHetznerSSHKey(d)
+	if r.Status != StatusWarn {
+		t.Fatalf("expected warn, got %s: %s", r.Status, r.Summary)
+	}
+	if r.Fix == "" {
+		t.Fatal("expected a fix suggestion")
 	}
 }

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -1,0 +1,105 @@
+package fleet
+
+import (
+	"context"
+	"time"
+)
+
+// HeartbeatSubject is the NATS subject workers publish heartbeats on.
+const HeartbeatSubject = "heph.fleet.heartbeat"
+
+// DefaultHeartbeatInterval is how often workers should publish heartbeats.
+const DefaultHeartbeatInterval = 30 * time.Second
+
+// DefaultHealthTimeout is how long since the last heartbeat before a worker
+// is considered unhealthy. Set to 3x the heartbeat interval so transient
+// network hiccups don't trigger false positives.
+const DefaultHealthTimeout = 3 * DefaultHeartbeatInterval
+
+// HeartbeatMessage is the JSON payload workers publish on HeartbeatSubject.
+type HeartbeatMessage struct {
+	WorkerID     string `json:"worker_id"`
+	Host         string `json:"host"`
+	PublicIPv4   string `json:"public_ipv4"`
+	PublicIPv6   string `json:"public_ipv6"`
+	IPv6Ready    bool   `json:"ipv6_ready"`
+	Version      string `json:"version"`
+	Ready        bool   `json:"ready"`
+	Cloud        string `json:"cloud"`
+	GenerationID string `json:"generation_id"`
+	Timestamp    int64  `json:"timestamp"`
+}
+
+// WorkerInfo holds metadata about a single worker VM.
+type WorkerInfo struct {
+	ID            string    // unique worker identifier (e.g. "heph-worker-0")
+	Host          string    // private IP or hostname
+	PublicIPv4    string    // public IPv4 address
+	PublicIPv6    string    // public IPv6 address
+	IPv6Ready     bool      // true if IPv6 is validated from inside the container
+	Version       string    // container image version
+	Ready         bool      // true if the worker is ready to accept tasks
+	Healthy       bool      // true if heartbeat is recent
+	RegisteredAt  time.Time // when the worker first registered
+	LastHeartbeat time.Time // last heartbeat timestamp
+}
+
+// FleetState is a snapshot of the fleet at a point in time.
+type FleetState struct {
+	DesiredWorkers int                    // expected from Terraform/config
+	Workers        map[string]*WorkerInfo // keyed by WorkerInfo.ID
+	ControllerIP   string
+	GenerationID   string // ownership/generation marker
+	Cloud          string // provider name ("hetzner")
+}
+
+// FleetSummary is a concise view of fleet health for CLI/TUI display.
+type FleetSummary struct {
+	DesiredWorkers  int
+	RegisteredCount int
+	HealthyCount    int
+	ReadyCount      int
+	IPv6ReadyCount  int
+	UniqueIPv4Count int
+}
+
+// Summarize returns a FleetSummary from the current state.
+func (s *FleetState) Summarize() FleetSummary {
+	seen := make(map[string]struct{})
+	summary := FleetSummary{
+		DesiredWorkers:  s.DesiredWorkers,
+		RegisteredCount: len(s.Workers),
+	}
+	for _, w := range s.Workers {
+		if w.Healthy {
+			summary.HealthyCount++
+		}
+		if w.Ready {
+			summary.ReadyCount++
+		}
+		if w.IPv6Ready {
+			summary.IPv6ReadyCount++
+		}
+		if w.PublicIPv4 != "" {
+			if _, dup := seen[w.PublicIPv4]; !dup {
+				seen[w.PublicIPv4] = struct{}{}
+				summary.UniqueIPv4Count++
+			}
+		}
+	}
+	return summary
+}
+
+// Manager is the interface for fleet lifecycle operations.
+type Manager interface {
+	// Reconcile compares desired state against actual registered workers.
+	// Returns the current fleet state.
+	Reconcile(ctx context.Context) (*FleetState, error)
+
+	// WaitForWorkers blocks until at least minReady workers are ready,
+	// or the context is cancelled. Returns the fleet state at that point.
+	WaitForWorkers(ctx context.Context, minReady int) (*FleetState, error)
+
+	// Close stops the manager and releases resources.
+	Close() error
+}

--- a/internal/fleet/fleet_test.go
+++ b/internal/fleet/fleet_test.go
@@ -1,0 +1,644 @@
+package fleet
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"heph4estus/internal/logger"
+
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+)
+
+func startEmbeddedNATS(t *testing.T) *natsserver.Server {
+	t.Helper()
+	opts := &natsserver.Options{
+		Host:     "127.0.0.1",
+		Port:     -1,
+		HTTPHost: "127.0.0.1",
+		HTTPPort: -1,
+		NoSigs:   true,
+		NoLog:    true,
+	}
+	srv, err := natsserver.NewServer(opts)
+	if err != nil {
+		t.Fatalf("embedded nats: %v", err)
+	}
+	srv.Start()
+	if !srv.ReadyForConnections(5 * time.Second) {
+		t.Fatal("embedded nats not ready")
+	}
+	t.Cleanup(srv.Shutdown)
+	return srv
+}
+
+func TestHeartbeatMessage_Roundtrip(t *testing.T) {
+	orig := HeartbeatMessage{
+		WorkerID:   "heph-worker-0",
+		Host:       "10.0.1.5",
+		PublicIPv4: "203.0.113.10",
+		PublicIPv6: "2001:db8::1",
+		IPv6Ready:  true,
+		Version:    "v0.6.3",
+		Ready:      true,
+		Timestamp:  1713200000,
+	}
+
+	data, err := json.Marshal(orig)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var decoded HeartbeatMessage
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if decoded != orig {
+		t.Fatalf("roundtrip mismatch:\n  got:  %+v\n  want: %+v", decoded, orig)
+	}
+}
+
+func TestHeartbeatMessage_PartialFields(t *testing.T) {
+	// Workers may omit optional fields (IPv6, version).
+	raw := `{"worker_id":"w-1","host":"10.0.0.1","public_ipv4":"1.2.3.4","ready":true,"timestamp":1}`
+	var hb HeartbeatMessage
+	if err := json.Unmarshal([]byte(raw), &hb); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if hb.WorkerID != "w-1" {
+		t.Fatalf("worker_id = %q, want %q", hb.WorkerID, "w-1")
+	}
+	if hb.PublicIPv6 != "" {
+		t.Fatalf("expected empty PublicIPv6, got %q", hb.PublicIPv6)
+	}
+	if hb.IPv6Ready {
+		t.Fatal("expected IPv6Ready false for missing field")
+	}
+}
+
+func TestFleetState_Summarize(t *testing.T) {
+	state := &FleetState{
+		DesiredWorkers: 5,
+		Workers: map[string]*WorkerInfo{
+			"w-0": {
+				ID: "w-0", PublicIPv4: "1.1.1.1",
+				Healthy: true, Ready: true, IPv6Ready: true,
+			},
+			"w-1": {
+				ID: "w-1", PublicIPv4: "2.2.2.2",
+				Healthy: true, Ready: true, IPv6Ready: false,
+			},
+			"w-2": {
+				ID: "w-2", PublicIPv4: "3.3.3.3",
+				Healthy: false, Ready: false, IPv6Ready: false,
+			},
+			"w-3": {
+				ID: "w-3", PublicIPv4: "1.1.1.1", // duplicate IP
+				Healthy: true, Ready: false, IPv6Ready: true,
+			},
+		},
+		ControllerIP: "10.0.0.1",
+		GenerationID: "gen-abc",
+		Cloud:        "hetzner",
+	}
+
+	s := state.Summarize()
+
+	assertInt(t, "DesiredWorkers", s.DesiredWorkers, 5)
+	assertInt(t, "RegisteredCount", s.RegisteredCount, 4)
+	assertInt(t, "HealthyCount", s.HealthyCount, 3)
+	assertInt(t, "ReadyCount", s.ReadyCount, 2)
+	assertInt(t, "IPv6ReadyCount", s.IPv6ReadyCount, 2)
+	assertInt(t, "UniqueIPv4Count", s.UniqueIPv4Count, 3) // 1.1.1.1 counted once
+}
+
+func TestFleetState_Summarize_Empty(t *testing.T) {
+	state := &FleetState{
+		DesiredWorkers: 3,
+		Workers:        map[string]*WorkerInfo{},
+	}
+	s := state.Summarize()
+
+	assertInt(t, "DesiredWorkers", s.DesiredWorkers, 3)
+	assertInt(t, "RegisteredCount", s.RegisteredCount, 0)
+	assertInt(t, "HealthyCount", s.HealthyCount, 0)
+	assertInt(t, "ReadyCount", s.ReadyCount, 0)
+	assertInt(t, "UniqueIPv4Count", s.UniqueIPv4Count, 0)
+}
+
+func TestNATSFleetManager_Heartbeat(t *testing.T) {
+	srv := startEmbeddedNATS(t)
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	t.Cleanup(nc.Close)
+
+	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
+		DesiredWorkers: 2,
+		ControllerIP:   "10.0.0.1",
+		GenerationID:   "gen-1",
+		Cloud:          "hetzner",
+		HealthTimeout:  10 * time.Second,
+	}, logger.NewSimpleLogger())
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	defer mgr.Close()
+
+	// Publish a heartbeat from a separate connection to simulate a worker.
+	pub, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("pub connect: %v", err)
+	}
+	defer pub.Close()
+
+	hb := HeartbeatMessage{
+		WorkerID:     "heph-worker-0",
+		Host:         "10.0.1.5",
+		PublicIPv4:   "203.0.113.10",
+		PublicIPv6:   "2001:db8::1",
+		IPv6Ready:    true,
+		Version:      "v0.6.3",
+		Ready:        true,
+		Cloud:        "hetzner",
+		GenerationID: "gen-1",
+		Timestamp:    time.Now().Unix(),
+	}
+	data, _ := json.Marshal(hb)
+	if err := pub.Publish(HeartbeatSubject, data); err != nil {
+		t.Fatalf("publish heartbeat: %v", err)
+	}
+	pub.Flush()
+
+	// Give the subscription handler time to fire.
+	time.Sleep(200 * time.Millisecond)
+
+	state, err := mgr.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	if len(state.Workers) != 1 {
+		t.Fatalf("expected 1 worker, got %d", len(state.Workers))
+	}
+	w, ok := state.Workers["heph-worker-0"]
+	if !ok {
+		t.Fatal("worker heph-worker-0 not found")
+	}
+	if w.PublicIPv4 != "203.0.113.10" {
+		t.Fatalf("PublicIPv4 = %q, want %q", w.PublicIPv4, "203.0.113.10")
+	}
+	if !w.Healthy {
+		t.Fatal("expected worker to be healthy")
+	}
+	if !w.Ready {
+		t.Fatal("expected worker to be ready")
+	}
+	if !w.IPv6Ready {
+		t.Fatal("expected worker to have IPv6Ready=true")
+	}
+	if state.DesiredWorkers != 2 {
+		t.Fatalf("DesiredWorkers = %d, want 2", state.DesiredWorkers)
+	}
+	if state.Cloud != "hetzner" {
+		t.Fatalf("Cloud = %q, want %q", state.Cloud, "hetzner")
+	}
+}
+
+func TestNATSFleetManager_MultipleWorkers(t *testing.T) {
+	srv := startEmbeddedNATS(t)
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	t.Cleanup(nc.Close)
+
+	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
+		DesiredWorkers: 3,
+		Cloud:          "hetzner",
+		HealthTimeout:  10 * time.Second,
+	}, logger.NewSimpleLogger())
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	defer mgr.Close()
+
+	pub, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("pub connect: %v", err)
+	}
+	defer pub.Close()
+
+	for i := range 3 {
+		hb := HeartbeatMessage{
+			WorkerID:   fmt.Sprintf("heph-worker-%d", i),
+			PublicIPv4: fmt.Sprintf("10.0.0.%d", i+1),
+			Ready:      true,
+			Cloud:      "hetzner",
+			Timestamp:  time.Now().Unix(),
+		}
+		data, _ := json.Marshal(hb)
+		if err := pub.Publish(HeartbeatSubject, data); err != nil {
+			t.Fatalf("publish worker %d: %v", i, err)
+		}
+	}
+	pub.Flush()
+	time.Sleep(200 * time.Millisecond)
+
+	state, err := mgr.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(state.Workers) != 3 {
+		t.Fatalf("expected 3 workers, got %d", len(state.Workers))
+	}
+	s := state.Summarize()
+	assertInt(t, "ReadyCount", s.ReadyCount, 3)
+	assertInt(t, "HealthyCount", s.HealthyCount, 3)
+}
+
+func TestNATSFleetManager_HeartbeatUpdate(t *testing.T) {
+	srv := startEmbeddedNATS(t)
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	t.Cleanup(nc.Close)
+
+	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
+		DesiredWorkers: 1,
+		Cloud:          "hetzner",
+		HealthTimeout:  10 * time.Second,
+	}, logger.NewSimpleLogger())
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	defer mgr.Close()
+
+	pub, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("pub connect: %v", err)
+	}
+	defer pub.Close()
+
+	// First heartbeat: not ready yet.
+	hb1 := HeartbeatMessage{
+		WorkerID:   "heph-worker-0",
+		PublicIPv4: "1.2.3.4",
+		Ready:      false,
+		Version:    "v0.6.2",
+		Cloud:      "hetzner",
+		Timestamp:  time.Now().Unix(),
+	}
+	data, _ := json.Marshal(hb1)
+	pub.Publish(HeartbeatSubject, data)
+	pub.Flush()
+	time.Sleep(200 * time.Millisecond)
+
+	state, _ := mgr.Reconcile(context.Background())
+	w := state.Workers["heph-worker-0"]
+	if w.Ready {
+		t.Fatal("expected worker not ready on first heartbeat")
+	}
+	if w.Version != "v0.6.2" {
+		t.Fatalf("Version = %q, want %q", w.Version, "v0.6.2")
+	}
+	regTime := w.RegisteredAt
+
+	// Second heartbeat: now ready, new version.
+	hb2 := HeartbeatMessage{
+		WorkerID:   "heph-worker-0",
+		PublicIPv4: "1.2.3.4",
+		Ready:      true,
+		Version:    "v0.6.3",
+		Cloud:      "hetzner",
+		Timestamp:  time.Now().Unix(),
+	}
+	data, _ = json.Marshal(hb2)
+	pub.Publish(HeartbeatSubject, data)
+	pub.Flush()
+	time.Sleep(200 * time.Millisecond)
+
+	state, _ = mgr.Reconcile(context.Background())
+	w = state.Workers["heph-worker-0"]
+	if !w.Ready {
+		t.Fatal("expected worker ready after second heartbeat")
+	}
+	if w.Version != "v0.6.3" {
+		t.Fatalf("Version = %q, want %q", w.Version, "v0.6.3")
+	}
+	// RegisteredAt should NOT change on update.
+	if !w.RegisteredAt.Equal(regTime) {
+		t.Fatalf("RegisteredAt changed: was %v, now %v", regTime, w.RegisteredAt)
+	}
+	// Worker count should still be 1 (update, not new registration).
+	if len(state.Workers) != 1 {
+		t.Fatalf("expected 1 worker after update, got %d", len(state.Workers))
+	}
+}
+
+func TestWorkerHealthTimeout(t *testing.T) {
+	srv := startEmbeddedNATS(t)
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	t.Cleanup(nc.Close)
+
+	// Use a very short health timeout for testing.
+	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
+		DesiredWorkers: 1,
+		Cloud:          "hetzner",
+		HealthTimeout:  100 * time.Millisecond,
+	}, logger.NewSimpleLogger())
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	defer mgr.Close()
+
+	pub, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("pub connect: %v", err)
+	}
+	defer pub.Close()
+
+	hb := HeartbeatMessage{
+		WorkerID:   "heph-worker-0",
+		PublicIPv4: "5.6.7.8",
+		Ready:      true,
+		Cloud:      "hetzner",
+		Timestamp:  time.Now().Unix(),
+	}
+	data, _ := json.Marshal(hb)
+	pub.Publish(HeartbeatSubject, data)
+	pub.Flush()
+	time.Sleep(50 * time.Millisecond)
+
+	// Should be healthy immediately after heartbeat.
+	state, err := mgr.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	w := state.Workers["heph-worker-0"]
+	if !w.Healthy {
+		t.Fatal("expected healthy right after heartbeat")
+	}
+	if !w.Ready {
+		t.Fatal("expected ready right after heartbeat")
+	}
+
+	// Wait for the health timeout to expire.
+	time.Sleep(200 * time.Millisecond)
+
+	state, err = mgr.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("reconcile after timeout: %v", err)
+	}
+	w = state.Workers["heph-worker-0"]
+	if w.Healthy {
+		t.Fatal("expected unhealthy after timeout")
+	}
+	if w.Ready {
+		t.Fatal("expected not ready after health timeout")
+	}
+}
+
+func TestNATSFleetManager_WaitForWorkers(t *testing.T) {
+	srv := startEmbeddedNATS(t)
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	t.Cleanup(nc.Close)
+
+	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
+		DesiredWorkers: 2,
+		Cloud:          "hetzner",
+		HealthTimeout:  10 * time.Second,
+	}, logger.NewSimpleLogger())
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	defer mgr.Close()
+
+	pub, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("pub connect: %v", err)
+	}
+	defer pub.Close()
+
+	// Publish 2 ready workers before calling WaitForWorkers.
+	for i := range 2 {
+		hb := HeartbeatMessage{
+			WorkerID:   fmt.Sprintf("heph-worker-%d", i),
+			PublicIPv4: fmt.Sprintf("10.0.0.%d", i+1),
+			Ready:      true,
+			Cloud:      "hetzner",
+			Timestamp:  time.Now().Unix(),
+		}
+		data, _ := json.Marshal(hb)
+		pub.Publish(HeartbeatSubject, data)
+	}
+	pub.Flush()
+	time.Sleep(200 * time.Millisecond)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	state, err := mgr.WaitForWorkers(ctx, 2)
+	if err != nil {
+		t.Fatalf("WaitForWorkers: %v", err)
+	}
+	s := state.Summarize()
+	if s.ReadyCount < 2 {
+		t.Fatalf("expected at least 2 ready, got %d", s.ReadyCount)
+	}
+}
+
+func TestNATSFleetManager_WaitForWorkers_ContextCancel(t *testing.T) {
+	srv := startEmbeddedNATS(t)
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	t.Cleanup(nc.Close)
+
+	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
+		DesiredWorkers: 5,
+		Cloud:          "hetzner",
+		HealthTimeout:  10 * time.Second,
+	}, logger.NewSimpleLogger())
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	defer mgr.Close()
+
+	// No workers published, so WaitForWorkers should block until context cancels.
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	state, err := mgr.WaitForWorkers(ctx, 5)
+	if err == nil {
+		t.Fatal("expected error from context timeout")
+	}
+	if state == nil {
+		t.Fatal("expected partial state even on timeout")
+	}
+}
+
+func TestNATSFleetManager_InvalidHeartbeat(t *testing.T) {
+	srv := startEmbeddedNATS(t)
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	t.Cleanup(nc.Close)
+
+	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
+		DesiredWorkers: 1,
+		Cloud:          "hetzner",
+		HealthTimeout:  10 * time.Second,
+	}, logger.NewSimpleLogger())
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	defer mgr.Close()
+
+	pub, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("pub connect: %v", err)
+	}
+	defer pub.Close()
+
+	// Publish garbage data.
+	pub.Publish(HeartbeatSubject, []byte("not json"))
+	// Publish valid JSON but missing worker_id.
+	pub.Publish(HeartbeatSubject, []byte(`{"ready":true}`))
+	pub.Flush()
+	time.Sleep(200 * time.Millisecond)
+
+	state, err := mgr.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	// Neither message should register a worker.
+	if len(state.Workers) != 0 {
+		t.Fatalf("expected 0 workers after invalid heartbeats, got %d", len(state.Workers))
+	}
+}
+
+func TestNATSFleetManager_IgnoresMismatchedGeneration(t *testing.T) {
+	srv := startEmbeddedNATS(t)
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+	t.Cleanup(nc.Close)
+
+	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
+		DesiredWorkers: 1,
+		Cloud:          "hetzner",
+		GenerationID:   "gen-expected",
+		HealthTimeout:  10 * time.Second,
+	}, logger.NewSimpleLogger())
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	defer mgr.Close()
+
+	pub, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("pub connect: %v", err)
+	}
+	defer pub.Close()
+
+	hb := HeartbeatMessage{
+		WorkerID:     "heph-worker-0",
+		PublicIPv4:   "203.0.113.10",
+		Ready:        true,
+		Cloud:        "hetzner",
+		GenerationID: "gen-other",
+		Timestamp:    time.Now().Unix(),
+	}
+	data, _ := json.Marshal(hb)
+	if err := pub.Publish(HeartbeatSubject, data); err != nil {
+		t.Fatalf("publish heartbeat: %v", err)
+	}
+	pub.Flush()
+	time.Sleep(200 * time.Millisecond)
+
+	state, err := mgr.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if len(state.Workers) != 0 {
+		t.Fatalf("expected 0 workers after mismatched generation, got %d", len(state.Workers))
+	}
+}
+
+func TestNATSFleetManager_Close(t *testing.T) {
+	srv := startEmbeddedNATS(t)
+
+	nc, err := nats.Connect(srv.ClientURL())
+	if err != nil {
+		t.Fatalf("nats connect: %v", err)
+	}
+
+	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
+		DesiredWorkers: 1,
+		Cloud:          "hetzner",
+	}, logger.NewSimpleLogger())
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	if err := mgr.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Reconcile after close should error.
+	_, err = mgr.Reconcile(context.Background())
+	if err == nil {
+		t.Fatal("expected error from Reconcile after Close")
+	}
+
+	// Double close should not panic.
+	if err := mgr.Close(); err != nil {
+		t.Fatalf("double close: %v", err)
+	}
+}
+
+func TestNewNATSFleetManager_Validation(t *testing.T) {
+	// Missing logger.
+	_, err := NewNATSFleetManager(NATSFleetManagerConfig{NATSURL: "nats://localhost:4222"}, nil)
+	if err == nil {
+		t.Fatal("expected error for nil logger")
+	}
+
+	// Missing NATS URL.
+	_, err = NewNATSFleetManager(NATSFleetManagerConfig{}, logger.NewSimpleLogger())
+	if err == nil {
+		t.Fatal("expected error for empty NATS URL")
+	}
+}
+
+// assertInt is a small test helper.
+func assertInt(t *testing.T, name string, got, want int) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("%s = %d, want %d", name, got, want)
+	}
+}

--- a/internal/fleet/fleet_test.go
+++ b/internal/fleet/fleet_test.go
@@ -149,7 +149,7 @@ func TestNATSFleetManager_Heartbeat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new manager: %v", err)
 	}
-	defer mgr.Close()
+	defer func() { _ = mgr.Close() }()
 
 	// Publish a heartbeat from a separate connection to simulate a worker.
 	pub, err := nats.Connect(srv.ClientURL())
@@ -174,7 +174,7 @@ func TestNATSFleetManager_Heartbeat(t *testing.T) {
 	if err := pub.Publish(HeartbeatSubject, data); err != nil {
 		t.Fatalf("publish heartbeat: %v", err)
 	}
-	pub.Flush()
+	_ = pub.Flush()
 
 	// Give the subscription handler time to fire.
 	time.Sleep(200 * time.Millisecond)
@@ -228,7 +228,7 @@ func TestNATSFleetManager_MultipleWorkers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new manager: %v", err)
 	}
-	defer mgr.Close()
+	defer func() { _ = mgr.Close() }()
 
 	pub, err := nats.Connect(srv.ClientURL())
 	if err != nil {
@@ -249,7 +249,7 @@ func TestNATSFleetManager_MultipleWorkers(t *testing.T) {
 			t.Fatalf("publish worker %d: %v", i, err)
 		}
 	}
-	pub.Flush()
+	_ = pub.Flush()
 	time.Sleep(200 * time.Millisecond)
 
 	state, err := mgr.Reconcile(context.Background())
@@ -281,7 +281,7 @@ func TestNATSFleetManager_HeartbeatUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new manager: %v", err)
 	}
-	defer mgr.Close()
+	defer func() { _ = mgr.Close() }()
 
 	pub, err := nats.Connect(srv.ClientURL())
 	if err != nil {
@@ -299,8 +299,8 @@ func TestNATSFleetManager_HeartbeatUpdate(t *testing.T) {
 		Timestamp:  time.Now().Unix(),
 	}
 	data, _ := json.Marshal(hb1)
-	pub.Publish(HeartbeatSubject, data)
-	pub.Flush()
+	_ = pub.Publish(HeartbeatSubject, data)
+	_ = pub.Flush()
 	time.Sleep(200 * time.Millisecond)
 
 	state, _ := mgr.Reconcile(context.Background())
@@ -323,8 +323,8 @@ func TestNATSFleetManager_HeartbeatUpdate(t *testing.T) {
 		Timestamp:  time.Now().Unix(),
 	}
 	data, _ = json.Marshal(hb2)
-	pub.Publish(HeartbeatSubject, data)
-	pub.Flush()
+	_ = pub.Publish(HeartbeatSubject, data)
+	_ = pub.Flush()
 	time.Sleep(200 * time.Millisecond)
 
 	state, _ = mgr.Reconcile(context.Background())
@@ -363,7 +363,7 @@ func TestWorkerHealthTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new manager: %v", err)
 	}
-	defer mgr.Close()
+	defer func() { _ = mgr.Close() }()
 
 	pub, err := nats.Connect(srv.ClientURL())
 	if err != nil {
@@ -379,8 +379,8 @@ func TestWorkerHealthTimeout(t *testing.T) {
 		Timestamp:  time.Now().Unix(),
 	}
 	data, _ := json.Marshal(hb)
-	pub.Publish(HeartbeatSubject, data)
-	pub.Flush()
+	_ = pub.Publish(HeartbeatSubject, data)
+	_ = pub.Flush()
 	time.Sleep(50 * time.Millisecond)
 
 	// Should be healthy immediately after heartbeat.
@@ -429,7 +429,7 @@ func TestNATSFleetManager_WaitForWorkers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new manager: %v", err)
 	}
-	defer mgr.Close()
+	defer func() { _ = mgr.Close() }()
 
 	pub, err := nats.Connect(srv.ClientURL())
 	if err != nil {
@@ -447,9 +447,9 @@ func TestNATSFleetManager_WaitForWorkers(t *testing.T) {
 			Timestamp:  time.Now().Unix(),
 		}
 		data, _ := json.Marshal(hb)
-		pub.Publish(HeartbeatSubject, data)
+		_ = pub.Publish(HeartbeatSubject, data)
 	}
-	pub.Flush()
+	_ = pub.Flush()
 	time.Sleep(200 * time.Millisecond)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -482,7 +482,7 @@ func TestNATSFleetManager_WaitForWorkers_ContextCancel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new manager: %v", err)
 	}
-	defer mgr.Close()
+	defer func() { _ = mgr.Close() }()
 
 	// No workers published, so WaitForWorkers should block until context cancels.
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
@@ -514,7 +514,7 @@ func TestNATSFleetManager_InvalidHeartbeat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new manager: %v", err)
 	}
-	defer mgr.Close()
+	defer func() { _ = mgr.Close() }()
 
 	pub, err := nats.Connect(srv.ClientURL())
 	if err != nil {
@@ -523,10 +523,10 @@ func TestNATSFleetManager_InvalidHeartbeat(t *testing.T) {
 	defer pub.Close()
 
 	// Publish garbage data.
-	pub.Publish(HeartbeatSubject, []byte("not json"))
+	_ = pub.Publish(HeartbeatSubject, []byte("not json"))
 	// Publish valid JSON but missing worker_id.
-	pub.Publish(HeartbeatSubject, []byte(`{"ready":true}`))
-	pub.Flush()
+	_ = pub.Publish(HeartbeatSubject, []byte(`{"ready":true}`))
+	_ = pub.Flush()
 	time.Sleep(200 * time.Millisecond)
 
 	state, err := mgr.Reconcile(context.Background())
@@ -557,7 +557,7 @@ func TestNATSFleetManager_IgnoresMismatchedGeneration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("new manager: %v", err)
 	}
-	defer mgr.Close()
+	defer func() { _ = mgr.Close() }()
 
 	pub, err := nats.Connect(srv.ClientURL())
 	if err != nil {
@@ -577,7 +577,7 @@ func TestNATSFleetManager_IgnoresMismatchedGeneration(t *testing.T) {
 	if err := pub.Publish(HeartbeatSubject, data); err != nil {
 		t.Fatalf("publish heartbeat: %v", err)
 	}
-	pub.Flush()
+	_ = pub.Flush()
 	time.Sleep(200 * time.Millisecond)
 
 	state, err := mgr.Reconcile(context.Background())

--- a/internal/fleet/manager.go
+++ b/internal/fleet/manager.go
@@ -1,0 +1,258 @@
+package fleet
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"heph4estus/internal/logger"
+
+	"github.com/nats-io/nats.go"
+)
+
+// waitPollInterval is how often WaitForWorkers re-checks readiness.
+const waitPollInterval = 5 * time.Second
+
+// NATSFleetManagerConfig configures a NATSFleetManager.
+type NATSFleetManagerConfig struct {
+	NATSURL        string
+	DesiredWorkers int
+	ControllerIP   string
+	GenerationID   string
+	Cloud          string
+	HealthTimeout  time.Duration // 0 means DefaultHealthTimeout
+}
+
+// NATSFleetManager implements Manager by subscribing to NATS heartbeats.
+type NATSFleetManager struct {
+	natsURL        string
+	desiredWorkers int
+	controllerIP   string
+	generationID   string
+	cloud          string
+	healthTimeout  time.Duration
+
+	mu      sync.RWMutex
+	workers map[string]*WorkerInfo
+
+	conn   *nats.Conn
+	sub    *nats.Subscription
+	log    logger.Logger
+	closed chan struct{}
+}
+
+// Compile-time interface check.
+var _ Manager = (*NATSFleetManager)(nil)
+
+// NewNATSFleetManager connects to NATS and subscribes to worker heartbeats.
+func NewNATSFleetManager(cfg NATSFleetManagerConfig, log logger.Logger) (*NATSFleetManager, error) {
+	if log == nil {
+		return nil, fmt.Errorf("fleet: logger is required")
+	}
+	if cfg.NATSURL == "" {
+		return nil, fmt.Errorf("fleet: NATS URL is required")
+	}
+
+	ht := cfg.HealthTimeout
+	if ht == 0 {
+		ht = DefaultHealthTimeout
+	}
+
+	nc, err := nats.Connect(cfg.NATSURL)
+	if err != nil {
+		return nil, fmt.Errorf("fleet: nats connect: %w", err)
+	}
+
+	m := &NATSFleetManager{
+		natsURL:        cfg.NATSURL,
+		desiredWorkers: cfg.DesiredWorkers,
+		controllerIP:   cfg.ControllerIP,
+		generationID:   cfg.GenerationID,
+		cloud:          cfg.Cloud,
+		healthTimeout:  ht,
+		workers:        make(map[string]*WorkerInfo),
+		conn:           nc,
+		log:            log,
+		closed:         make(chan struct{}),
+	}
+
+	sub, err := nc.Subscribe(HeartbeatSubject, m.handleHeartbeat)
+	if err != nil {
+		nc.Close()
+		return nil, fmt.Errorf("fleet: subscribe heartbeat: %w", err)
+	}
+	m.sub = sub
+
+	log.Info("Fleet manager subscribed to %s on %s", HeartbeatSubject, cfg.NATSURL)
+	return m, nil
+}
+
+// NewNATSFleetManagerFromConn wraps an existing NATS connection. Used by
+// tests that spin up an embedded server and want to share the connection.
+func NewNATSFleetManagerFromConn(nc *nats.Conn, cfg NATSFleetManagerConfig, log logger.Logger) (*NATSFleetManager, error) {
+	if log == nil {
+		return nil, fmt.Errorf("fleet: logger is required")
+	}
+
+	ht := cfg.HealthTimeout
+	if ht == 0 {
+		ht = DefaultHealthTimeout
+	}
+
+	m := &NATSFleetManager{
+		natsURL:        cfg.NATSURL,
+		desiredWorkers: cfg.DesiredWorkers,
+		controllerIP:   cfg.ControllerIP,
+		generationID:   cfg.GenerationID,
+		cloud:          cfg.Cloud,
+		healthTimeout:  ht,
+		workers:        make(map[string]*WorkerInfo),
+		conn:           nc,
+		log:            log,
+		closed:         make(chan struct{}),
+	}
+
+	sub, err := nc.Subscribe(HeartbeatSubject, m.handleHeartbeat)
+	if err != nil {
+		return nil, fmt.Errorf("fleet: subscribe heartbeat: %w", err)
+	}
+	m.sub = sub
+
+	log.Info("Fleet manager subscribed to %s (shared conn)", HeartbeatSubject)
+	return m, nil
+}
+
+// handleHeartbeat processes a single heartbeat message from a worker.
+func (m *NATSFleetManager) handleHeartbeat(msg *nats.Msg) {
+	var hb HeartbeatMessage
+	if err := json.Unmarshal(msg.Data, &hb); err != nil {
+		m.log.Error("Fleet: invalid heartbeat JSON: %v", err)
+		return
+	}
+	if hb.WorkerID == "" {
+		m.log.Error("Fleet: heartbeat missing worker_id, ignoring")
+		return
+	}
+	if m.cloud != "" && hb.Cloud != m.cloud {
+		m.log.Info("Fleet: ignoring worker %s from cloud %q (want %q)", hb.WorkerID, hb.Cloud, m.cloud)
+		return
+	}
+	if m.generationID != "" && hb.GenerationID != m.generationID {
+		m.log.Info("Fleet: ignoring worker %s from generation %q (want %q)", hb.WorkerID, hb.GenerationID, m.generationID)
+		return
+	}
+
+	now := time.Now()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	w, exists := m.workers[hb.WorkerID]
+	if !exists {
+		w = &WorkerInfo{
+			ID:           hb.WorkerID,
+			RegisteredAt: now,
+		}
+		m.workers[hb.WorkerID] = w
+		m.log.Info("Fleet: new worker registered: %s (%s)", hb.WorkerID, hb.PublicIPv4)
+	}
+
+	w.Host = hb.Host
+	w.PublicIPv4 = hb.PublicIPv4
+	w.PublicIPv6 = hb.PublicIPv6
+	w.IPv6Ready = hb.IPv6Ready
+	w.Version = hb.Version
+	w.Ready = hb.Ready
+	w.LastHeartbeat = now
+	w.Healthy = true
+}
+
+// Reconcile snapshots the current fleet state, marking workers whose last
+// heartbeat exceeds the health timeout as unhealthy.
+func (m *NATSFleetManager) Reconcile(ctx context.Context) (*FleetState, error) {
+	select {
+	case <-m.closed:
+		return nil, fmt.Errorf("fleet: manager is closed")
+	default:
+	}
+
+	now := time.Now()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	snapshot := make(map[string]*WorkerInfo, len(m.workers))
+	for id, w := range m.workers {
+		// Mark unhealthy if heartbeat is stale.
+		if now.Sub(w.LastHeartbeat) > m.healthTimeout {
+			w.Healthy = false
+			w.Ready = false
+		}
+		cp := *w
+		snapshot[id] = &cp
+	}
+
+	return &FleetState{
+		DesiredWorkers: m.desiredWorkers,
+		Workers:        snapshot,
+		ControllerIP:   m.controllerIP,
+		GenerationID:   m.generationID,
+		Cloud:          m.cloud,
+	}, nil
+}
+
+// WaitForWorkers polls Reconcile until at least minReady workers report
+// ready, or until the context is cancelled.
+func (m *NATSFleetManager) WaitForWorkers(ctx context.Context, minReady int) (*FleetState, error) {
+	for {
+		state, err := m.Reconcile(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		readyCount := 0
+		for _, w := range state.Workers {
+			if w.Ready && w.Healthy {
+				readyCount++
+			}
+		}
+
+		if readyCount >= minReady {
+			m.log.Info("Fleet: %d/%d workers ready (desired %d)", readyCount, len(state.Workers), m.desiredWorkers)
+			return state, nil
+		}
+
+		m.log.Info("Fleet: waiting for workers — %d/%d ready, need %d", readyCount, len(state.Workers), minReady)
+
+		select {
+		case <-ctx.Done():
+			return state, ctx.Err()
+		case <-m.closed:
+			return state, fmt.Errorf("fleet: manager closed while waiting")
+		case <-time.After(waitPollInterval):
+		}
+	}
+}
+
+// Close unsubscribes from heartbeats and closes the NATS connection.
+func (m *NATSFleetManager) Close() error {
+	select {
+	case <-m.closed:
+		return nil // already closed
+	default:
+	}
+	close(m.closed)
+
+	if m.sub != nil {
+		if err := m.sub.Unsubscribe(); err != nil {
+			m.log.Error("Fleet: unsubscribe error: %v", err)
+		}
+	}
+	if m.conn != nil {
+		m.conn.Close()
+	}
+	m.log.Info("Fleet manager closed")
+	return nil
+}

--- a/internal/infra/pipeline.go
+++ b/internal/infra/pipeline.go
@@ -149,15 +149,18 @@ type EnsureResult struct {
 }
 
 // EnsureInfra runs the lifecycle check and, if needed, deploys infrastructure.
-// Returns the terraform outputs and whether infra was reused.
+// Returns the terraform outputs and whether infra was reused. The cloud kind
+// is read from cfg.Cloud so the correct required-output set is used for
+// lifecycle probing.
 func EnsureInfra(ctx context.Context, cfg *ToolConfig, policy LifecyclePolicy, region string, stream io.Writer, promptFunc func(string) bool, log logger.Logger) (*EnsureResult, error) {
 	tf := NewTerraformClient(log)
 
-	// Probe current state.
-	// EnsureInfra is currently only called from AWS paths (selfhosted
-	// compute is blocked). Default to AWS required outputs. Track 2 will
-	// thread cloud.Kind through ToolConfig when selfhosted scan paths open.
-	probe := Probe(ctx, tf, cloud.DefaultKind, cfg.TerraformDir, cfg.ToolName)
+	kind := cfg.Cloud
+	if kind == "" {
+		kind = cloud.DefaultKind
+	}
+
+	probe := Probe(ctx, tf, kind, cfg.TerraformDir, cfg.ToolName)
 	decision := Decide(probe, policy)
 
 	if err := writef(stream, "==> Lifecycle: %s\n", decision.Message); err != nil {
@@ -174,6 +177,7 @@ func EnsureInfra(ctx context.Context, cfg *ToolConfig, policy LifecyclePolicy, r
 	case DecisionDeploy:
 		result, err := RunDeploy(ctx, DeployOpts{
 			ToolConfig:  cfg,
+			Cloud:       kind,
 			Region:      region,
 			AutoApprove: policy.AutoApprove,
 			Stream:      stream,

--- a/internal/infra/runtime.go
+++ b/internal/infra/runtime.go
@@ -29,11 +29,38 @@ var SelfhostedRequiredOutputKeys = []string{
 	"tool_name",
 }
 
+// HetznerRequiredOutputKeys lists the Terraform output keys that must be
+// present for a Hetzner deploy to be considered ready. These are produced
+// by deployments/hetzner/ and include both controller endpoints and worker
+// metadata.
+var HetznerRequiredOutputKeys = []string{
+	"tool_name",
+	"cloud",
+	"nats_url",
+	"nats_stream",
+	"s3_endpoint",
+	"s3_access_key",
+	"s3_secret_key",
+	"s3_bucket_name",
+	"registry_url",
+	"docker_image",
+	"sqs_queue_url",
+	"controller_ip",
+	"generation_id",
+	"worker_count",
+	"worker_hosts",
+}
+
 // RequiredOutputKeysForCloud returns the required output keys for the given
 // cloud provider family. Unknown kinds fall back to the AWS set.
 func RequiredOutputKeysForCloud(kind cloud.Kind) []string {
-	if kind.IsSelfhostedFamily() {
-		return SelfhostedRequiredOutputKeys
+	switch kind.Canonical() {
+	case cloud.KindHetzner:
+		return HetznerRequiredOutputKeys
+	default:
+		if kind.IsSelfhostedFamily() {
+			return SelfhostedRequiredOutputKeys
+		}
+		return AWSRequiredOutputKeys
 	}
-	return AWSRequiredOutputKeys
 }

--- a/internal/infra/toolconfig.go
+++ b/internal/infra/toolconfig.go
@@ -24,7 +24,9 @@ type ToolConfig struct {
 }
 
 // ResolveToolConfig derives Docker/Terraform configuration from a module definition.
-func ResolveToolConfig(tool string) (*ToolConfig, error) {
+// When kind is empty or AWS, it returns the AWS Terraform path. For Hetzner,
+// it returns the Hetzner Terraform path.
+func ResolveToolConfig(tool string, kind ...cloud.Kind) (*ToolConfig, error) {
 	reg, err := modules.NewDefaultRegistry()
 	if err != nil {
 		return nil, fmt.Errorf("loading module registry: %w", err)
@@ -35,20 +37,38 @@ func ResolveToolConfig(tool string) (*ToolConfig, error) {
 		return nil, fmt.Errorf("unknown tool: %q (available: %s)", tool, strings.Join(names, ", "))
 	}
 
-	return &ToolConfig{
-		ToolName:     tool,
-		TerraformDir: "deployments/aws/generic/environments/dev",
-		Dockerfile:   "containers/generic/Dockerfile",
-		DockerCtx:    ".",
-		DockerTag:    fmt.Sprintf("heph-%s-worker:latest", tool),
-		ECRRepoName:  fmt.Sprintf("heph-dev-%s", tool),
-		BuildArgs:    InstallCmdToBuildArgs(mod.InstallCmd),
-		TerraformVars: map[string]string{
+	var cloudKind cloud.Kind
+	if len(kind) > 0 {
+		cloudKind = kind[0]
+	}
+
+	cfg := &ToolConfig{
+		Cloud:       cloudKind,
+		ToolName:    tool,
+		Dockerfile:  "containers/generic/Dockerfile",
+		DockerCtx:   ".",
+		DockerTag:   fmt.Sprintf("heph-%s-worker:latest", tool),
+		ECRRepoName: fmt.Sprintf("heph-dev-%s", tool),
+		BuildArgs:   InstallCmdToBuildArgs(mod.InstallCmd),
+	}
+
+	switch cloudKind.Canonical() {
+	case cloud.KindHetzner:
+		cfg.TerraformDir = "deployments/hetzner"
+		cfg.TerraformVars = map[string]string{
+			"tool_name":    tool,
+			"docker_image": cfg.DockerTag,
+		}
+	default:
+		cfg.TerraformDir = "deployments/aws/generic/environments/dev"
+		cfg.TerraformVars = map[string]string{
 			"tool_name":   tool,
 			"task_cpu":    fmt.Sprintf("%d", mod.DefaultCPU),
 			"task_memory": fmt.Sprintf("%d", mod.DefaultMemory),
-		},
-	}, nil
+		}
+	}
+
+	return cfg, nil
 }
 
 // InstallCmdToBuildArgs maps a module's install_cmd to the correct Docker build arg.

--- a/internal/infra/toolconfig_test.go
+++ b/internal/infra/toolconfig_test.go
@@ -2,6 +2,8 @@ package infra
 
 import (
 	"testing"
+
+	"heph4estus/internal/cloud"
 )
 
 func TestResolveToolConfig_Nmap(t *testing.T) {
@@ -67,5 +69,18 @@ func TestAWSRegion_Default(t *testing.T) {
 	region := AWSRegion()
 	if region == "" {
 		t.Error("expected non-empty region")
+	}
+}
+
+func TestResolveToolConfig_HetznerSetsDockerImageVar(t *testing.T) {
+	cfg, err := ResolveToolConfig("nmap", cloud.KindHetzner)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.TerraformDir != "deployments/hetzner" {
+		t.Fatalf("TerraformDir = %q, want deployments/hetzner", cfg.TerraformDir)
+	}
+	if got := cfg.TerraformVars["docker_image"]; got != "heph-nmap-worker:latest" {
+		t.Fatalf("TerraformVars[docker_image] = %q, want heph-nmap-worker:latest", got)
 	}
 }

--- a/internal/tui/core/types.go
+++ b/internal/tui/core/types.go
@@ -100,6 +100,10 @@ type InfraOutputs struct {
 	// cloud.DefaultKind so existing AWS-only call sites stay valid.
 	Cloud cloud.Kind
 
+	// FleetWorkerCount is the provisioned provider-native fleet size when the
+	// cloud manages standing workers (e.g. Hetzner). Zero means unknown.
+	FleetWorkerCount int
+
 	// --- AWS runtime fields (unchanged for backward compat) ---
 
 	SQSQueueURL       string

--- a/internal/tui/views/deploy/model.go
+++ b/internal/tui/views/deploy/model.go
@@ -3,6 +3,7 @@ package deploy
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -429,6 +430,8 @@ func (m *Model) emitNavigateToStatus() tea.Cmd {
 		return core.NavigateWithDataMsg{
 			Target: target,
 			Data: core.InfraOutputs{
+				Cloud:              cfg.Cloud,
+				FleetWorkerCount:   parseInt(outputs["worker_count"]),
 				SQSQueueURL:        outputs["sqs_queue_url"],
 				ECRRepoURL:         outputs["ecr_repo_url"],
 				S3BucketName:       outputs["s3_bucket_name"],
@@ -511,6 +514,14 @@ func splitCSV(s string) []string {
 		}
 	}
 	return result
+}
+
+func parseInt(s string) int {
+	n, err := strconv.Atoi(strings.TrimSpace(s))
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return n
 }
 
 // simpleLogger satisfies logger.Logger for the default deployer.

--- a/internal/tui/views/deploy/model_test.go
+++ b/internal/tui/views/deploy/model_test.go
@@ -343,9 +343,9 @@ func TestDeployModel_GenericPostDeployNavigation(t *testing.T) {
 
 	// Run the full pipeline.
 	msg := cmd()
-	_, cmd = m.Update(msg)   // init complete -> plan
+	_, cmd = m.Update(msg) // init complete -> plan
 	msg = cmd()
-	_, _ = m.Update(msg)     // plan complete -> approval
+	_, _ = m.Update(msg)                          // plan complete -> approval
 	_, cmd = m.Update(tea.KeyPressMsg{Code: 'y'}) // approve
 	msgs := drainBatch(cmd)
 	for _, msg := range msgs {
@@ -355,13 +355,35 @@ func TestDeployModel_GenericPostDeployNavigation(t *testing.T) {
 		}
 	}
 	// Read outputs
-	if cmd != nil { msg = cmd(); _, cmd = m.Update(msg) }
+	if cmd != nil {
+		msg = cmd()
+		_, cmd = m.Update(msg)
+	}
 	// Docker build
-	if cmd != nil { msgs = drainBatch(cmd); for _, msg := range msgs { if sc, ok := msg.(core.StageCompleteMsg); ok { _, cmd = m.Update(sc); break } } }
+	if cmd != nil {
+		msgs = drainBatch(cmd)
+		for _, msg := range msgs {
+			if sc, ok := msg.(core.StageCompleteMsg); ok {
+				_, cmd = m.Update(sc)
+				break
+			}
+		}
+	}
 	// Registry auth
-	if cmd != nil { msg = cmd(); _, cmd = m.Update(msg) }
+	if cmd != nil {
+		msg = cmd()
+		_, cmd = m.Update(msg)
+	}
 	// Image publish
-	if cmd != nil { msgs = drainBatch(cmd); for _, msg := range msgs { if sc, ok := msg.(core.StageCompleteMsg); ok { _, cmd = m.Update(sc); break } } }
+	if cmd != nil {
+		msgs = drainBatch(cmd)
+		for _, msg := range msgs {
+			if sc, ok := msg.(core.StageCompleteMsg); ok {
+				_, cmd = m.Update(sc)
+				break
+			}
+		}
+	}
 
 	if m.stage != stageComplete {
 		t.Fatalf("expected stageComplete, got %s", m.stage)
@@ -383,6 +405,40 @@ func TestDeployModel_GenericPostDeployNavigation(t *testing.T) {
 		if infraOut.ToolName != "httpx" {
 			t.Fatalf("expected tool httpx, got %q", infraOut.ToolName)
 		}
+	}
+}
+
+func TestDeployModel_PropagatesProviderNativeCloudAndFleetSize(t *testing.T) {
+	outputs := map[string]string{
+		"sqs_queue_url":  "heph-tasks",
+		"s3_bucket_name": "heph-results",
+		"worker_count":   "3",
+	}
+	cfg := core.DeployConfig{
+		Cloud:          cloud.KindHetzner,
+		TargetsContent: "1.1.1.1\n",
+		WorkerCount:    10,
+	}
+	m := NewWithDeployer(cfg, &mockDeployer{})
+
+	_, cmd := simulateLifecycleReuse(m, outputs)
+	if cmd == nil {
+		t.Fatal("expected navigate command")
+	}
+	msg := cmd()
+	nav, ok := msg.(core.NavigateWithDataMsg)
+	if !ok {
+		t.Fatalf("expected NavigateWithDataMsg, got %T", msg)
+	}
+	infraOut, ok := nav.Data.(core.InfraOutputs)
+	if !ok {
+		t.Fatalf("expected InfraOutputs, got %T", nav.Data)
+	}
+	if infraOut.Cloud != cloud.KindHetzner {
+		t.Fatalf("Cloud = %q, want hetzner", infraOut.Cloud)
+	}
+	if infraOut.FleetWorkerCount != 3 {
+		t.Fatalf("FleetWorkerCount = %d, want 3", infraOut.FleetWorkerCount)
 	}
 }
 
@@ -546,14 +602,41 @@ func TestDeployModel_FreshDeployCarriesCleanupFields(t *testing.T) {
 	msg := cmd()
 	_, cmd = m.Update(msg) // init
 	msg = cmd()
-	_, _ = m.Update(msg) // plan
+	_, _ = m.Update(msg)                          // plan
 	_, cmd = m.Update(tea.KeyPressMsg{Code: 'y'}) // approve
 	msgs := drainBatch(cmd)
-	for _, msg := range msgs { if sc, ok := msg.(core.StageCompleteMsg); ok { _, cmd = m.Update(sc); break } }
-	if cmd != nil { msg = cmd(); _, cmd = m.Update(msg) } // read outputs
-	if cmd != nil { msgs = drainBatch(cmd); for _, msg := range msgs { if sc, ok := msg.(core.StageCompleteMsg); ok { _, cmd = m.Update(sc); break } } } // docker build
-	if cmd != nil { msg = cmd(); _, cmd = m.Update(msg) } // registry auth
-	if cmd != nil { msgs = drainBatch(cmd); for _, msg := range msgs { if sc, ok := msg.(core.StageCompleteMsg); ok { _, cmd = m.Update(sc); break } } } // image publish
+	for _, msg := range msgs {
+		if sc, ok := msg.(core.StageCompleteMsg); ok {
+			_, cmd = m.Update(sc)
+			break
+		}
+	}
+	if cmd != nil {
+		msg = cmd()
+		_, cmd = m.Update(msg)
+	} // read outputs
+	if cmd != nil {
+		msgs = drainBatch(cmd)
+		for _, msg := range msgs {
+			if sc, ok := msg.(core.StageCompleteMsg); ok {
+				_, cmd = m.Update(sc)
+				break
+			}
+		}
+	} // docker build
+	if cmd != nil {
+		msg = cmd()
+		_, cmd = m.Update(msg)
+	} // registry auth
+	if cmd != nil {
+		msgs = drainBatch(cmd)
+		for _, msg := range msgs {
+			if sc, ok := msg.(core.StageCompleteMsg); ok {
+				_, cmd = m.Update(sc)
+				break
+			}
+		}
+	} // image publish
 
 	if cmd == nil {
 		t.Fatal("expected navigate command")

--- a/internal/tui/views/generic/config.go
+++ b/internal/tui/views/generic/config.go
@@ -300,8 +300,8 @@ func (m *ConfigModel) handleTargetListFileRead(msg fileReadMsg) tea.Cmd {
 	outputDir := operator.ResolveOutputDir("", opCfg)
 	toolOptions := strings.TrimSpace(m.inputs[cfgFieldOptions].Value())
 
-	if cloudKind.IsSelfhostedFamily() {
-		// Selfhosted: bypass deploy view, go directly to status.
+	if cloudKind.IsSelfhostedFamily() && !cloudKind.IsProviderNative() {
+		// Manual selfhosted: bypass deploy view, go directly to status.
 		shCfg := factory.SelfhostedConfigFromEnv()
 		if shCfg.QueueID == "" || shCfg.Bucket == "" {
 			m.errMsg = fmt.Sprintf("%s requires SELFHOSTED_QUEUE_ID and SELFHOSTED_BUCKET environment variables", cloudKind.Canonical())
@@ -331,7 +331,7 @@ func (m *ConfigModel) handleTargetListFileRead(msg fileReadMsg) tea.Cmd {
 		}
 	}
 
-	tc, err := infra.ResolveToolConfig(m.toolName)
+	tc, err := infra.ResolveToolConfig(m.toolName, cloudKind)
 	if err != nil {
 		m.errMsg = fmt.Sprintf("Error resolving tool config: %v", err)
 		return nil
@@ -403,8 +403,8 @@ func (m *ConfigModel) handleWordlistFileRead(msg wordlistReadMsg) tea.Cmd {
 	wlOutDir := operator.ResolveOutputDir("", wlCfg)
 	toolOptions := strings.TrimSpace(m.wlInputs[wlFieldOptions].Value())
 
-	if cloudKind.IsSelfhostedFamily() {
-		// Selfhosted: bypass deploy view, go directly to status.
+	if cloudKind.IsSelfhostedFamily() && !cloudKind.IsProviderNative() {
+		// Manual selfhosted: bypass deploy view, go directly to status.
 		shCfg := factory.SelfhostedConfigFromEnv()
 		if shCfg.QueueID == "" || shCfg.Bucket == "" {
 			m.errMsg = fmt.Sprintf("%s requires SELFHOSTED_QUEUE_ID and SELFHOSTED_BUCKET environment variables", cloudKind.Canonical())
@@ -436,7 +436,7 @@ func (m *ConfigModel) handleWordlistFileRead(msg wordlistReadMsg) tea.Cmd {
 		}
 	}
 
-	tc, err := infra.ResolveToolConfig(m.toolName)
+	tc, err := infra.ResolveToolConfig(m.toolName, cloudKind)
 	if err != nil {
 		m.errMsg = fmt.Sprintf("Error resolving tool config: %v", err)
 		return nil

--- a/internal/tui/views/generic/config_test.go
+++ b/internal/tui/views/generic/config_test.go
@@ -161,7 +161,35 @@ func TestGenericConfigInvalidComputeMode(t *testing.T) {
 	}
 }
 
-func TestGenericConfigProviderNavigatesToStatus(t *testing.T) {
+func TestGenericConfigHetznerNavigatesToDeploy(t *testing.T) {
+	// Hetzner is provider-native: goes through deploy view, not direct to status.
+	m := NewConfig("httpx")
+	m.inputs[cfgFieldCloud].SetValue("hetzner")
+	_, cmd := m.Update(fileReadMsg{content: "example.com\n"})
+	if cmd == nil {
+		t.Fatal("expected navigation command for Hetzner provider")
+	}
+	msg := cmd()
+	nav, ok := msg.(core.NavigateWithDataMsg)
+	if !ok {
+		t.Fatalf("expected NavigateWithDataMsg, got %T", msg)
+	}
+	if nav.Target != core.ViewDeploy {
+		t.Fatalf("expected ViewDeploy for provider-native Hetzner, got %v", nav.Target)
+	}
+	cfg, ok := nav.Data.(core.DeployConfig)
+	if !ok {
+		t.Fatalf("expected DeployConfig, got %T", nav.Data)
+	}
+	if cfg.Cloud != cloud.KindHetzner {
+		t.Fatalf("expected cloud hetzner, got %q", cfg.Cloud)
+	}
+	if cfg.TerraformDir != "deployments/hetzner" {
+		t.Fatalf("expected hetzner terraform dir, got %q", cfg.TerraformDir)
+	}
+}
+
+func TestGenericConfigManualNavigatesToStatus(t *testing.T) {
 	t.Setenv("SELFHOSTED_QUEUE_ID", "test-stream")
 	t.Setenv("SELFHOSTED_BUCKET", "test-bucket")
 	t.Setenv("SELFHOSTED_WORKER_HOSTS", "10.0.0.1")
@@ -169,10 +197,10 @@ func TestGenericConfigProviderNavigatesToStatus(t *testing.T) {
 	t.Setenv("SELFHOSTED_DOCKER_IMAGE", "worker:latest")
 
 	m := NewConfig("httpx")
-	m.inputs[cfgFieldCloud].SetValue("hetzner")
+	m.inputs[cfgFieldCloud].SetValue("manual")
 	_, cmd := m.Update(fileReadMsg{content: "example.com\n"})
 	if cmd == nil {
-		t.Fatal("expected navigation command for VPS provider")
+		t.Fatal("expected navigation command for manual provider")
 	}
 	msg := cmd()
 	nav, ok := msg.(core.NavigateWithDataMsg)
@@ -180,20 +208,14 @@ func TestGenericConfigProviderNavigatesToStatus(t *testing.T) {
 		t.Fatalf("expected NavigateWithDataMsg, got %T", msg)
 	}
 	if nav.Target != core.ViewGenericStatus {
-		t.Fatalf("expected ViewGenericStatus (bypass deploy), got %v", nav.Target)
+		t.Fatalf("expected ViewGenericStatus (bypass deploy for manual), got %v", nav.Target)
 	}
 	infra, ok := nav.Data.(core.InfraOutputs)
 	if !ok {
 		t.Fatalf("expected InfraOutputs, got %T", nav.Data)
 	}
-	if infra.Cloud != cloud.KindHetzner {
-		t.Fatalf("expected cloud hetzner, got %q", infra.Cloud)
-	}
-	if infra.SQSQueueURL != "test-stream" {
-		t.Fatalf("expected queue ID test-stream, got %q", infra.SQSQueueURL)
-	}
-	if infra.S3BucketName != "test-bucket" {
-		t.Fatalf("expected bucket test-bucket, got %q", infra.S3BucketName)
+	if infra.Cloud != cloud.KindManual {
+		t.Fatalf("expected cloud manual, got %q", infra.Cloud)
 	}
 }
 
@@ -210,17 +232,17 @@ func TestGenericConfigManualRejectsFargate(t *testing.T) {
 	}
 }
 
-func TestGenericConfigProviderMissingEnv(t *testing.T) {
+func TestGenericConfigManualMissingEnv(t *testing.T) {
 	t.Setenv("SELFHOSTED_QUEUE_ID", "")
 	t.Setenv("SELFHOSTED_BUCKET", "")
 
 	m := NewConfig("httpx")
-	m.inputs[cfgFieldCloud].SetValue("hetzner")
+	m.inputs[cfgFieldCloud].SetValue("manual")
 	_, cmd := m.Update(fileReadMsg{content: "example.com\n"})
 	if cmd != nil {
-		t.Fatal("expected nil command when provider env is missing")
+		t.Fatal("expected nil command when manual env is missing")
 	}
-	if !strings.Contains(m.View(), "hetzner requires SELFHOSTED_QUEUE_ID") {
+	if !strings.Contains(m.View(), "manual requires SELFHOSTED_QUEUE_ID") {
 		t.Fatal("expected env var requirement error")
 	}
 }

--- a/internal/tui/views/generic/status.go
+++ b/internal/tui/views/generic/status.go
@@ -434,7 +434,7 @@ func (m *StatusModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 				return m, m.exportResults()
 			}
 			if m.infra.CleanupPolicy == "destroy-after" {
-				if m.infra.Cloud.IsSelfhostedFamily() {
+				if m.infra.Cloud.IsSelfhostedFamily() && !m.infra.Cloud.IsProviderNative() {
 					m.cleanupWarning = "destroy-after skipped: selfhosted does not support auto-destroy"
 				} else if m.infra.OutputDir == "" {
 					m.cleanupWarning = "destroy-after skipped: no output directory configured"
@@ -454,7 +454,7 @@ func (m *StatusModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 		m.infra.Exported = true
 		m.infra.ExportDir = msg.dir
 		// Auto-destroy if destroy-after policy and destroyer is available.
-		if m.infra.Cloud.IsSelfhostedFamily() {
+		if m.infra.Cloud.IsSelfhostedFamily() && !m.infra.Cloud.IsProviderNative() {
 			m.cleanupWarning = "destroy-after skipped: selfhosted does not support auto-destroy"
 			m.phase = phaseComplete
 			return m, m.navigateToResults()
@@ -616,6 +616,18 @@ func (m *StatusModel) launchWorkers() tea.Cmd {
 
 	if useSpot(infra) {
 		return m.launchSpotWorkers()
+	}
+	if infra.Cloud.IsProviderNative() {
+		return func() tea.Msg {
+			launched := infra.FleetWorkerCount
+			if launched <= 0 {
+				launched = infra.WorkerCount
+			}
+			if launched <= 0 {
+				launched = 1
+			}
+			return launchProgressMsg{launched: launched, total: launched}
+		}
 	}
 
 	return func() tea.Msg {

--- a/internal/tui/views/generic/status_test.go
+++ b/internal/tui/views/generic/status_test.go
@@ -31,6 +31,8 @@ type mockSubmitter struct {
 	enqueueErr    error
 	launchErr     error
 	spotErr       error
+	launchCalls   int
+	spotCalls     int
 }
 
 func (s *mockSubmitter) EnqueueTasks(_ context.Context, _ string, tasks []worker.Task) error {
@@ -39,10 +41,12 @@ func (s *mockSubmitter) EnqueueTasks(_ context.Context, _ string, tasks []worker
 }
 
 func (s *mockSubmitter) LaunchWorkers(_ context.Context, _ cloud.ContainerOpts) (string, error) {
+	s.launchCalls++
 	return "task-123", s.launchErr
 }
 
 func (s *mockSubmitter) LaunchSpotWorkers(_ context.Context, _ cloud.SpotOpts) ([]string, error) {
+	s.spotCalls++
 	return []string{"i-123"}, s.spotErr
 }
 
@@ -638,9 +642,30 @@ func TestGenericStatusAutoDestroyEndToEnd(t *testing.T) {
 	}
 }
 
+func TestGenericStatusProviderNativeDestroyAfterUsesDestroyer(t *testing.T) {
+	infra := testInfra()
+	infra.Cloud = cloud.KindHetzner
+	infra.CleanupPolicy = "destroy-after"
+	infra.OutputDir = "/tmp/export"
+
+	destroyer := &mockDestroyer{}
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{}, &mockUploader{})
+	m.storage = &mockExportStorage{}
+	m.destroyer = destroyer
+	m.phase = phaseExporting
+
+	_, cmd := m.Update(exportCompleteMsg{dir: "/tmp/export/httpx/job-1", count: 2})
+	if m.phase != phaseDestroying {
+		t.Fatalf("expected phaseDestroying, got %d", m.phase)
+	}
+	if cmd == nil {
+		t.Fatal("expected destroy command")
+	}
+}
+
 func testSelfhostedInfra() core.InfraOutputs {
 	return core.InfraOutputs{
-		Cloud:          cloud.KindHetzner,
+		Cloud:          cloud.KindManual,
 		SQSQueueURL:    "test-stream",
 		S3BucketName:   "test-bucket",
 		ToolName:       "httpx",
@@ -670,6 +695,9 @@ func TestGenericStatusSelfhostedUsesLaunchWorkers(t *testing.T) {
 	_, ok := msg.(launchProgressMsg)
 	if !ok {
 		t.Fatalf("expected launchProgressMsg (not spotLaunchMsg), got %T", msg)
+	}
+	if sub.launchCalls != 1 {
+		t.Fatalf("expected LaunchWorkers to be called once, got %d", sub.launchCalls)
 	}
 }
 
@@ -718,6 +746,31 @@ func TestGenericStatusSelfhostedExportComplete_SkipsDestroy(t *testing.T) {
 	}
 	if cmd == nil {
 		t.Fatal("expected navigate command")
+	}
+}
+
+func TestGenericStatusProviderNativeSkipsLaunchWorkers(t *testing.T) {
+	infra := testInfra()
+	infra.Cloud = cloud.KindHetzner
+	infra.FleetWorkerCount = 3
+
+	sub := &mockSubmitter{}
+	m := NewStatusWithDeps(infra, sub, &mockTracker{}, &mockUploader{})
+	m.Init()
+
+	_, cmd := m.Update(enqueueProgressMsg{sent: 2, total: 2})
+	if cmd == nil {
+		t.Fatal("expected launch command")
+	}
+	msg := cmd()
+	if _, ok := msg.(launchProgressMsg); !ok {
+		t.Fatalf("expected launchProgressMsg, got %T", msg)
+	}
+	if sub.launchCalls != 0 {
+		t.Fatalf("expected provider-native path to skip LaunchWorkers, got %d calls", sub.launchCalls)
+	}
+	if sub.spotCalls != 0 {
+		t.Fatalf("expected provider-native path to skip LaunchSpotWorkers, got %d calls", sub.spotCalls)
 	}
 }
 

--- a/internal/tui/views/nmap/config.go
+++ b/internal/tui/views/nmap/config.go
@@ -223,8 +223,8 @@ func (m *ConfigModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 		cleanupPolicy := operator.ResolveCleanupPolicy("", opCfg)
 		outputDir := operator.ResolveOutputDir("", opCfg)
 
-		if cloudKind.IsSelfhostedFamily() {
-			// Selfhosted: bypass deploy view, go directly to status.
+		if cloudKind.IsSelfhostedFamily() && !cloudKind.IsProviderNative() {
+			// Manual selfhosted: bypass deploy view, go directly to status.
 			shCfg := factory.SelfhostedConfigFromEnv()
 			if shCfg.QueueID == "" || shCfg.Bucket == "" {
 				m.errMsg = fmt.Sprintf("%s requires SELFHOSTED_QUEUE_ID and SELFHOSTED_BUCKET environment variables", cloudKind.Canonical())
@@ -257,7 +257,7 @@ func (m *ConfigModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 			}
 		}
 
-		tc, err := infra.ResolveToolConfig("nmap")
+		tc, err := infra.ResolveToolConfig("nmap", cloudKind)
 		if err != nil {
 			m.errMsg = fmt.Sprintf("Error resolving nmap config: %v", err)
 			return m, nil

--- a/internal/tui/views/nmap/status.go
+++ b/internal/tui/views/nmap/status.go
@@ -380,7 +380,7 @@ func (m *StatusModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 				return m, m.exportResults()
 			}
 			if m.infra.CleanupPolicy == "destroy-after" {
-				if m.infra.Cloud.IsSelfhostedFamily() {
+				if m.infra.Cloud.IsSelfhostedFamily() && !m.infra.Cloud.IsProviderNative() {
 					m.cleanupWarning = "destroy-after skipped: selfhosted does not support auto-destroy"
 				} else if m.infra.OutputDir == "" {
 					m.cleanupWarning = "destroy-after skipped: no output directory configured"
@@ -400,7 +400,7 @@ func (m *StatusModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 		m.infra.Exported = true
 		m.infra.ExportDir = msg.dir
 		// Auto-destroy if destroy-after policy and destroyer is available.
-		if m.infra.Cloud.IsSelfhostedFamily() {
+		if m.infra.Cloud.IsSelfhostedFamily() && !m.infra.Cloud.IsProviderNative() {
 			m.cleanupWarning = "destroy-after skipped: selfhosted does not support auto-destroy"
 			m.phase = phaseComplete
 			return m, m.navigateToResults()
@@ -542,6 +542,18 @@ func (m *StatusModel) launchWorkers() tea.Cmd {
 
 	if useSpot(infra) {
 		return m.launchSpotWorkers()
+	}
+	if infra.Cloud.IsProviderNative() {
+		return func() tea.Msg {
+			launched := infra.FleetWorkerCount
+			if launched <= 0 {
+				launched = infra.WorkerCount
+			}
+			if launched <= 0 {
+				launched = 1
+			}
+			return launchProgressMsg{launched: launched, total: launched}
+		}
 	}
 
 	return func() tea.Msg {

--- a/internal/tui/views/nmap/status_test.go
+++ b/internal/tui/views/nmap/status_test.go
@@ -15,6 +15,8 @@ type mockSubmitter struct {
 	launchErr     error
 	spotLaunchErr error
 	spotIDs       []string
+	launchCalls   int
+	spotCalls     int
 }
 
 func (s *mockSubmitter) EnqueueTargets(_ context.Context, _ string, _ []worker.Task) error {
@@ -22,10 +24,12 @@ func (s *mockSubmitter) EnqueueTargets(_ context.Context, _ string, _ []worker.T
 }
 
 func (s *mockSubmitter) LaunchWorkers(_ context.Context, _ cloud.ContainerOpts) (string, error) {
+	s.launchCalls++
 	return "arn:task:1", s.launchErr
 }
 
 func (s *mockSubmitter) LaunchSpotWorkers(_ context.Context, _ cloud.SpotOpts) ([]string, error) {
+	s.spotCalls++
 	if s.spotIDs == nil {
 		s.spotIDs = []string{"i-spot1", "i-spot2"}
 	}
@@ -314,6 +318,9 @@ func TestStatusModel_SelfhostedUsesLaunchWorkers(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected launchProgressMsg (not spotLaunchMsg), got %T", msg)
 	}
+	if sub.launchCalls != 1 {
+		t.Fatalf("expected LaunchWorkers to be called once, got %d", sub.launchCalls)
+	}
 }
 
 func TestStatusModel_SelfhostedNeverUsesSpot(t *testing.T) {
@@ -339,6 +346,31 @@ func TestStatusModel_SelfhostedDestroyAfterSkipped(t *testing.T) {
 	}
 	if !strings.Contains(m.cleanupWarning, "selfhosted does not support auto-destroy") {
 		t.Fatalf("expected selfhosted destroy warning, got %q", m.cleanupWarning)
+	}
+}
+
+func TestStatusModel_ProviderNativeSkipsLaunchWorkers(t *testing.T) {
+	infra := testInfra()
+	infra.Cloud = cloud.KindHetzner
+	infra.FleetWorkerCount = 3
+
+	sub := &mockSubmitter{}
+	m := NewStatusWithDeps(infra, sub, &mockTracker{})
+	m.Init()
+
+	_, cmd := m.Update(enqueueProgressMsg{sent: 2, total: 2})
+	if cmd == nil {
+		t.Fatal("expected launch command")
+	}
+	msg := cmd()
+	if _, ok := msg.(launchProgressMsg); !ok {
+		t.Fatalf("expected launchProgressMsg, got %T", msg)
+	}
+	if sub.launchCalls != 0 {
+		t.Fatalf("expected provider-native path to skip LaunchWorkers, got %d calls", sub.launchCalls)
+	}
+	if sub.spotCalls != 0 {
+		t.Fatalf("expected provider-native path to skip LaunchSpotWorkers, got %d calls", sub.spotCalls)
 	}
 }
 
@@ -537,6 +569,25 @@ func TestStatusModel_ExportComplete_SetsExported(t *testing.T) {
 	}
 	if cmd == nil {
 		t.Fatal("expected navigate command")
+	}
+}
+
+func TestStatusModel_ProviderNativeExportComplete_TriggersDestroy(t *testing.T) {
+	infra := testInfra()
+	infra.Cloud = cloud.KindHetzner
+	infra.CleanupPolicy = "destroy-after"
+	infra.OutputDir = "/tmp/export"
+
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{})
+	m.phase = phaseExporting
+	m.destroyer = &mockDestroyer{}
+
+	_, cmd := m.Update(exportCompleteMsg{dir: "/tmp/export/nmap/job-123", count: 5})
+	if m.phase != phaseDestroying {
+		t.Fatalf("expected phaseDestroying, got %d", m.phase)
+	}
+	if cmd == nil {
+		t.Fatal("expected destroy command")
 	}
 }
 


### PR DESCRIPTION
## Summary                                                                                  
   
  - First polished provider-native VPS path via `--cloud hetzner` — Terraform provisions controller + worker VMs, workers self register via NATS heartbeats, fleet manager reconciles desired vs actual state                                                                    
  - New `internal/fleet/` package with typed fleet state, NATS heartbeat subscription, health tracking (90s timeout), IPv6 validation from inside the worker container, and
  `WaitForWorkers` for ready-gating                                                           
  - New `deployments/hetzner/` Terraform module: controller VM (NATS + MinIO + registry via cloud-init), N worker VMs with systemd-managed worker service, private networking (10.0.1.0/24), firewall rules (SSH + internal + IPv6 egress), generation ID for ownership tracking                                                                                    
  - Generic worker binary now publishes fleet heartbeats when `FLEET_HEARTBEAT=true` — reports worker ID, public IPv4/IPv6, IPv6 readiness (probed via UDP6 dial from inside the container), version, and generation                                                         
  - `heph infra deploy --cloud hetzner` and `heph scan --cloud hetzner` work end-to-end through both CLI and TUI; `manual` stays expert mode; AWS unchanged                         
                                          
  ## What changed                                                                             
                                                                                              
  **Terraform (`deployments/hetzner/`)**      
  Composes the existing selfhosted controller module. Pre-allocates a Hetzner primary IP so the controller address is known at plan time. Workers boot via cloud-init that installs Docker, configures the controller's insecure registry, pulls the worker image, and starts a systemd service with all NATS/S3/fleet env vars.
                                                                                              
  **Fleet manager (`internal/fleet/`)**                     
  `NATSFleetManager` subscribes to `heph.fleet.heartbeat`, maintains an in-memory worker map, marks workers unhealthy after heartbeat timeout, and exposes `Reconcile()` / `WaitForWorkers()`. Types: `WorkerInfo`, `FleetState`, `FleetSummary`, `HeartbeatMessage`.

  **Provider plumbing**                                                                       
  - `kind.go`: `RuntimeFamily()` returns `KindHetzner` (not `KindManual`) so the factory
  routes correctly; `IsProviderNative()` distinguishes Hetzner from manual                    
  - `factory.go`: separate `Build` branch for Hetzner (queue+storage only, no ad-hoc SSH
  compute); `SelfhostedConfigFromOutputs` for provider-native paths
  - `toolconfig.go`: `ResolveToolConfig` accepts variadic `cloud.Kind`, returns               
  `deployments/hetzner` for Hetzner           
  - `pipeline.go`: `EnsureInfra` reads `cfg.Cloud` instead of hard-coding AWS                 
  - `runtime.go`: `HetznerRequiredOutputKeys` for lifecycle probing
                                                                                              
  **CLI/TUI**                                               
  - `cloud.go`: `requireDeploySupport` allows `IsProviderNative()`                            
  - `cmd_scan.go` / `cmd_nmap.go`: three-way branch (provider-native / manual selfhosted / AWS); fleet wait instead of SSH launch for Hetzner                                          
  - TUI config views: Hetzner goes through deploy view; manual bypasses to status             
  - `--destroy-after` works for Hetzner (has Terraform)                                       
                                                                                              
  **Worker**                                                                                  
  New `heartbeat.go` in generic worker: background goroutine publishes to NATS every 30s with IPv6 probe at startup.                                                                      
                                                                                              
  **Doctor**                                                                                  
  `checkHetznerToken` (HCLOUD_TOKEN) and `checkHetznerSSHKey` (~/.ssh/) — both warn, not fail, since Hetzner is optional.                 
                                                                                              
  ## Test plan                                              
                                                                                              
  - [X] `go test ./cmd/heph/...` — CLI flag routing, deploy/destroy policy, cloud validation
  - [X] `go test ./internal/cloud/...` — kind routing, factory build, selfhosted compute      
  - [X] `go test ./internal/infra/...` — lifecycle probing, required output keys, toolconfig resolution                                                                                  
  - [X] `go test ./internal/tui/...` — config→deploy navigation, status view launch paths
  - [X] `go test ./internal/fleet/...` — heartbeat roundtrip, multi-worker registration, health timeout, WaitForWorkers                                                              
  - [X] `go test ./internal/doctor/...` — Hetzner token and SSH key checks                    
  - [X] `go test ./internal/operator/...` — operator config unchanged