### PR TITLE
feat(cloud): add Linode provider adapter for provider-native VPS path 

### DIFF
--- a/cmd/heph/cloud.go
+++ b/cmd/heph/cloud.go
@@ -21,10 +21,10 @@ func resolveCLICloud(explicit string, cfg *operator.OperatorConfig) (cloud.Kind,
 // yet support infrastructure deploy/destroy.
 func requireDeploySupport(kind cloud.Kind) error {
 	if kind.IsProviderNative() {
-		return nil // Hetzner has provider-native deploy support
+		return nil
 	}
 	if kind.IsSelfhostedFamily() {
-		return fmt.Errorf("%s infrastructure deploy/destroy is not supported — use 'hetzner' for provider-native VPS deploy, or 'manual' with your own infrastructure", kind.Canonical())
+		return fmt.Errorf("%s infrastructure deploy/destroy is not supported — use 'hetzner' or 'linode' for provider-native VPS deploy, or 'manual' with your own infrastructure", kind.Canonical())
 	}
 	return nil
 }

--- a/cmd/heph/cloud_test.go
+++ b/cmd/heph/cloud_test.go
@@ -60,3 +60,24 @@ func TestRequireDeploySupport_AWSAllowed(t *testing.T) {
 		t.Fatalf("AWS deploy should be allowed: %v", err)
 	}
 }
+
+func TestRequireDeploySupport_LinodeAllowed(t *testing.T) {
+	if err := requireDeploySupport(cloud.KindLinode); err != nil {
+		t.Fatalf("Linode deploy should be allowed (provider-native): %v", err)
+	}
+}
+
+func TestValidateComputeMode_LinodeSpotRejected(t *testing.T) {
+	err := ValidateComputeMode(cloud.KindLinode, "spot")
+	if err == nil {
+		t.Fatal("expected error for linode + spot")
+	}
+}
+
+func TestValidateComputeMode_LinodeAutoAllowed(t *testing.T) {
+	for _, mode := range []string{"", "auto"} {
+		if err := ValidateComputeMode(cloud.KindLinode, mode); err != nil {
+			t.Errorf("linode mode %q should be valid: %v", mode, err)
+		}
+	}
+}

--- a/cmd/heph/main_test.go
+++ b/cmd/heph/main_test.go
@@ -472,6 +472,16 @@ func TestScanCloudNamedProviderAutoAccepted(t *testing.T) {
 	}
 }
 
+func TestScanCloudLinodeAutoAccepted(t *testing.T) {
+	err := run([]string{"scan", "--tool", "httpx", "--file", "/nonexistent/targets.txt", "--cloud", "linode"}, testLogger())
+	if err == nil {
+		t.Fatal("expected error (file not found)")
+	}
+	if strings.Contains(err.Error(), "unsupported cloud") || strings.Contains(err.Error(), `provider "linode" only supports`) {
+		t.Fatalf("linode + auto should pass validation: %v", err)
+	}
+}
+
 func TestNmapCloudProviderRejectsSpot(t *testing.T) {
 	err := run([]string{"nmap", "--file", "targets.txt", "--cloud", "vultr", "--compute-mode", "spot"}, testLogger())
 	if err == nil {

--- a/deployments/linode/main.tf
+++ b/deployments/linode/main.tf
@@ -1,0 +1,204 @@
+# Linode fleet module — provisions a controller VM (NATS + MinIO + registry
+# via the selfhosted controller module) and N worker VMs that auto-join the
+# fleet on boot via cloud-init.
+#
+# The controller module generates credentials and cloud-init; this module
+# adds all Linode-specific resources (instances, networking, firewall).
+
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    linode = {
+      source  = "linode/linode"
+      version = ">= 2.0"
+    }
+  }
+}
+
+provider "linode" {
+  token = var.linode_token
+}
+
+# --- Generation ID ---
+
+resource "random_id" "generation" {
+  byte_length = 8
+}
+
+# --- Random root password (SSH keys are the actual access method) ---
+
+resource "random_password" "root_pass" {
+  length  = 32
+  special = false
+}
+
+locals {
+  generation_id         = var.generation_id != "" ? var.generation_id : random_id.generation.hex
+  controller_private_ip = "10.0.1.2"
+}
+
+# --- Networking (VPC + subnet) ---
+
+resource "linode_vpc" "fleet" {
+  label  = "heph-fleet"
+  region = var.region
+}
+
+resource "linode_vpc_subnet" "nodes" {
+  vpc_id = linode_vpc.fleet.id
+  label  = "heph-nodes"
+  ipv4   = "10.0.1.0/24"
+}
+
+# --- Firewall ---
+
+resource "linode_firewall" "fleet" {
+  label = "heph-fleet-fw"
+
+  # Inbound: SSH from anywhere
+  inbound {
+    label    = "ssh"
+    action   = "ACCEPT"
+    protocol = "TCP"
+    ports    = "22"
+    ipv4     = ["0.0.0.0/0"]
+    ipv6     = ["::/0"]
+  }
+
+  # Inbound: NATS client port (operator + workers via public IP)
+  inbound {
+    label    = "nats"
+    action   = "ACCEPT"
+    protocol = "TCP"
+    ports    = "4222"
+    ipv4     = ["0.0.0.0/0"]
+    ipv6     = ["::/0"]
+  }
+
+  # Inbound: Docker registry
+  inbound {
+    label    = "registry"
+    action   = "ACCEPT"
+    protocol = "TCP"
+    ports    = "5000"
+    ipv4     = ["0.0.0.0/0"]
+    ipv6     = ["::/0"]
+  }
+
+  # Inbound: MinIO S3 API
+  inbound {
+    label    = "minio"
+    action   = "ACCEPT"
+    protocol = "TCP"
+    ports    = "9000"
+    ipv4     = ["0.0.0.0/0"]
+    ipv6     = ["::/0"]
+  }
+
+  # Default policies
+  inbound_policy  = "DROP"
+  outbound_policy = "ACCEPT"
+
+  linodes = concat(
+    [linode_instance.controller.id],
+    linode_instance.worker[*].id,
+  )
+}
+
+# --- Controller module (credentials + cloud-init) ---
+
+module "controller" {
+  source = "../selfhosted/controller"
+
+  # The controller module uses controller_ip only in its outputs (not in
+  # cloud-init). We override those outputs in this module's outputs.tf
+  # with the real public IP from the Linode instance.
+  controller_ip = "0.0.0.0"
+  tool_name     = var.tool_name
+  minio_bucket  = var.minio_bucket
+}
+
+# --- Controller Instance ---
+
+resource "linode_instance" "controller" {
+  label  = "heph-controller"
+  region = var.region
+  type   = var.controller_type
+  image  = "linode/ubuntu24.04"
+
+  root_pass      = random_password.root_pass.result
+  authorized_keys = [trimspace(var.ssh_public_key)]
+
+  metadata {
+    user_data = base64encode(module.controller.cloud_init)
+  }
+
+  interface {
+    purpose = "public"
+  }
+
+  interface {
+    purpose   = "vpc"
+    subnet_id = linode_vpc_subnet.nodes.id
+    ipv4 {
+      vpc = local.controller_private_ip
+    }
+  }
+
+  depends_on = [linode_vpc_subnet.nodes]
+}
+
+# --- Worker cloud-init ---
+
+locals {
+  worker_cloud_init = [
+    for i in range(var.worker_count) : templatefile("${path.module}/templates/worker-cloud-init.yaml", {
+      controller_private_ip = local.controller_private_ip
+      nats_port             = 4222
+      nats_subject          = module.controller.nats_stream
+      minio_port            = 9000
+      minio_access_key      = module.controller.s3_access_key
+      minio_secret_key      = module.controller.s3_secret_key
+      minio_bucket          = var.minio_bucket
+      registry_port         = 5000
+      tool_name             = var.tool_name
+      docker_image          = var.docker_image
+      generation_id         = local.generation_id
+      worker_index          = i
+      worker_private_ip     = "10.0.1.${i + 10}"
+    })
+  ]
+}
+
+# --- Worker Instances ---
+
+resource "linode_instance" "worker" {
+  count = var.worker_count
+
+  label  = "heph-worker-${count.index}"
+  region = var.region
+  type   = var.worker_type
+  image  = "linode/ubuntu24.04"
+
+  root_pass      = random_password.root_pass.result
+  authorized_keys = [trimspace(var.ssh_public_key)]
+
+  metadata {
+    user_data = base64encode(local.worker_cloud_init[count.index])
+  }
+
+  interface {
+    purpose = "public"
+  }
+
+  interface {
+    purpose   = "vpc"
+    subnet_id = linode_vpc_subnet.nodes.id
+    ipv4 {
+      vpc = "10.0.1.${count.index + 10}"
+    }
+  }
+
+  depends_on = [linode_vpc_subnet.nodes, linode_instance.controller]
+}

--- a/deployments/linode/outputs.tf
+++ b/deployments/linode/outputs.tf
@@ -1,0 +1,119 @@
+# Output names map onto the selfhosted env family so the Go deploy UX can
+# wire these directly into the operator's environment.  Sensitive outputs
+# are marked so Terraform does not display them in plan/apply output.
+#
+# sqs_queue_url is intentionally used for the NATS subject name to maintain
+# compatibility with the existing scan launch code which reads
+# outputs["sqs_queue_url"].
+
+output "tool_name" {
+  description = "Tool name (passed through for lifecycle mismatch detection)."
+  value       = var.tool_name
+}
+
+output "cloud" {
+  description = "Cloud provider identifier."
+  value       = "linode"
+}
+
+output "nats_url" {
+  description = "NATS client URL for workers and the operator CLI."
+  value       = "nats://${linode_instance.controller.ip_address}:4222"
+}
+
+output "nats_stream" {
+  description = "NATS JetStream stream name."
+  value       = module.controller.nats_stream
+}
+
+output "s3_endpoint" {
+  description = "MinIO S3-compatible endpoint URL."
+  value       = "http://${linode_instance.controller.ip_address}:9000"
+}
+
+output "s3_region" {
+  description = "S3 region (MinIO ignores this but clients require it)."
+  value       = "us-east-1"
+}
+
+output "s3_access_key" {
+  description = "MinIO root access key."
+  value       = module.controller.s3_access_key
+  sensitive   = true
+}
+
+output "s3_secret_key" {
+  description = "MinIO root secret key."
+  value       = module.controller.s3_secret_key
+  sensitive   = true
+}
+
+output "s3_path_style" {
+  description = "Whether to use path-style S3 access (always true for MinIO)."
+  value       = "true"
+}
+
+output "s3_bucket_name" {
+  description = "Default storage bucket name."
+  value       = var.minio_bucket
+}
+
+output "registry_url" {
+  description = "Docker registry URL for worker image distribution."
+  value       = "${linode_instance.controller.ip_address}:5000"
+}
+
+output "docker_image" {
+  description = "Worker Docker image path relative to the controller registry."
+  value       = var.docker_image
+}
+
+output "sqs_queue_url" {
+  description = "NATS subject name (named sqs_queue_url for scan launch compatibility)."
+  value       = module.controller.nats_stream
+}
+
+output "worker_count" {
+  description = "Number of worker VMs in the fleet."
+  value       = var.worker_count
+}
+
+output "controller_ip" {
+  description = "Controller public IPv4 address."
+  value       = linode_instance.controller.ip_address
+}
+
+output "controller_ipv6" {
+  description = "Controller public IPv6 address."
+  value       = linode_instance.controller.ipv6
+}
+
+output "worker_ips" {
+  description = "List of worker public IPv4 addresses."
+  value       = linode_instance.worker[*].ip_address
+}
+
+output "worker_ipv6s" {
+  description = "List of worker public IPv6 addresses."
+  value       = linode_instance.worker[*].ipv6
+}
+
+output "worker_private_ips" {
+  description = "List of worker private IPs on the fleet network."
+  value       = [for i in range(var.worker_count) : "10.0.1.${i + 10}"]
+}
+
+output "worker_hosts" {
+  description = "Comma-separated worker IPs for SELFHOSTED_WORKER_HOSTS compatibility."
+  value       = join(",", linode_instance.worker[*].ip_address)
+}
+
+output "ssh_key_name" {
+  description = "SSH key name used for VM access."
+  value       = "heph-deploy"
+}
+
+output "generation_id" {
+  description = "Fleet generation ID for ownership tracking."
+  value       = local.generation_id
+}

--- a/deployments/linode/templates/worker-cloud-init.yaml
+++ b/deployments/linode/templates/worker-cloud-init.yaml
@@ -1,0 +1,71 @@
+#cloud-config
+# Worker VM bootstrap — installs Docker, configures the controller's insecure
+# registry, pulls the worker image, and starts the worker as a systemd service.
+
+package_update: true
+
+packages:
+  - docker.io
+  - jq
+
+write_files:
+  # Configure Docker to trust the controller's insecure registry
+  - path: /etc/docker/daemon.json
+    content: |
+      {
+        "insecure-registries": ["${controller_private_ip}:${registry_port}"]
+      }
+
+  # Worker systemd service
+  - path: /etc/systemd/system/heph-worker.service
+    content: |
+      [Unit]
+      Description=Heph4estus Worker
+      After=docker.service
+      Requires=docker.service
+
+      [Service]
+      Restart=always
+      RestartSec=10
+      ExecStartPre=-/usr/bin/docker rm -f heph-worker
+      ExecStartPre=/usr/bin/docker pull ${controller_private_ip}:${registry_port}/${docker_image}
+      ExecStart=/usr/bin/docker run --name heph-worker \
+        -e CLOUD=linode \
+        -e QUEUE_URL=${nats_subject} \
+        -e S3_BUCKET=${minio_bucket} \
+        -e TOOL_NAME=${tool_name} \
+        -e NATS_URL=nats://${controller_private_ip}:${nats_port} \
+        -e S3_ENDPOINT=http://${controller_private_ip}:${minio_port} \
+        -e S3_REGION=us-east-1 \
+        -e S3_ACCESS_KEY=${minio_access_key} \
+        -e S3_SECRET_KEY=${minio_secret_key} \
+        -e S3_PATH_STYLE=true \
+        -e FLEET_HEARTBEAT=true \
+        -e FLEET_GENERATION_ID=${generation_id} \
+        -e WORKER_ID=heph-worker-${worker_index} \
+        -e WORKER_HOST=${worker_private_ip} \
+        -e WORKER_VERSION=${docker_image} \
+        ${controller_private_ip}:${registry_port}/${docker_image}
+      ExecStop=/usr/bin/docker stop heph-worker
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  - mkdir -p /data
+  - systemctl daemon-reload
+  - systemctl enable --now docker
+
+  # Restart Docker to pick up insecure registry config
+  - systemctl restart docker
+
+  # Wait for controller registry to be reachable
+  - |
+    for i in $(seq 1 60); do
+      curl -sf http://${controller_private_ip}:${registry_port}/v2/ && break
+      echo "Waiting for controller registry (attempt $i)..."
+      sleep 5
+    done
+
+  # Start the worker service
+  - systemctl enable --now heph-worker

--- a/deployments/linode/variables.tf
+++ b/deployments/linode/variables.tf
@@ -1,0 +1,57 @@
+variable "linode_token" {
+  description = "Linode API token."
+  type        = string
+  sensitive   = true
+}
+
+variable "tool_name" {
+  description = "Tool name for lifecycle detection."
+  type        = string
+}
+
+variable "worker_count" {
+  description = "Number of worker VMs."
+  type        = number
+  default     = 3
+}
+
+variable "controller_type" {
+  description = "Linode instance type for controller (e.g. g6-standard-1)."
+  type        = string
+  default     = "g6-standard-1"
+}
+
+variable "worker_type" {
+  description = "Linode instance type for workers (e.g. g6-nanode-1)."
+  type        = string
+  default     = "g6-nanode-1"
+}
+
+variable "region" {
+  description = "Linode region (e.g. us-east, eu-west)."
+  type        = string
+  default     = "us-east"
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key for VM access."
+  type        = string
+}
+
+variable "minio_bucket" {
+  description = "MinIO bucket name."
+  type        = string
+  default     = "heph-results"
+}
+
+variable "docker_image" {
+  description = "Worker Docker image (relative to controller registry)."
+  type        = string
+  default     = "heph-worker:latest"
+}
+
+variable "generation_id" {
+  description = "Fleet generation ID for ownership tracking."
+  type        = string
+  default     = ""
+}

--- a/internal/cloud/factory/factory.go
+++ b/internal/cloud/factory/factory.go
@@ -112,8 +112,8 @@ func Build(cfg Config) (cloud.Provider, error) {
 			}
 		}
 		return selfhosted.NewProvider(pcfg, cfg.Logger)
-	case cloud.KindHetzner:
-		// Provider-native Hetzner reuses the selfhosted queue/storage runtime,
+	case cloud.KindHetzner, cloud.KindLinode:
+		// Provider-native VPS paths reuse the selfhosted queue/storage runtime,
 		// but normal operator flows must not fall back to ad hoc SSH launches.
 		if cfg.Selfhosted == nil {
 			return nil, fmt.Errorf("factory: selfhosted config is required for cloud %q", cfg.Kind.Canonical())
@@ -191,7 +191,7 @@ func BuildForKind(ctx context.Context, kind cloud.Kind, log logger.Logger) (clou
 			AWS:    &AWSConfig{SDKConfig: sdkCfg},
 			Logger: log,
 		})
-	case cloud.KindManual, cloud.KindHetzner:
+	case cloud.KindManual, cloud.KindHetzner, cloud.KindLinode:
 		return Build(Config{
 			Kind:       kind.Canonical(),
 			Selfhosted: SelfhostedConfigFromEnv(),

--- a/internal/cloud/factory/factory_test.go
+++ b/internal/cloud/factory/factory_test.go
@@ -383,3 +383,32 @@ func TestBuildHetznerDisablesSSHCompute(t *testing.T) {
 		t.Fatalf("unexpected RunContainer error: %v", err)
 	}
 }
+
+func TestBuildLinodeDisablesSSHCompute(t *testing.T) {
+	p, err := Build(Config{
+		Kind: cloud.KindLinode,
+		Selfhosted: &SelfhostedConfig{
+			S3Endpoint:  "http://ctrl:9000",
+			S3Region:    "us-east-1",
+			S3AccessKey: "ak",
+			S3Secret:    "sk",
+			S3PathStyle: true,
+		},
+		Logger: logger.NewSimpleLogger(),
+	})
+	if err != nil {
+		t.Fatalf("Build linode: %v", err)
+	}
+	if _, err := p.Compute().RunContainer(context.Background(), cloud.ContainerOpts{}); err == nil {
+		t.Fatal("expected provider-native Linode compute to reject RunContainer")
+	} else if !strings.Contains(err.Error(), "compute is not configured") {
+		t.Fatalf("unexpected RunContainer error: %v", err)
+	}
+}
+
+func TestBuildLinodeMissingConfig(t *testing.T) {
+	_, err := Build(Config{Kind: cloud.KindLinode, Logger: logger.NewSimpleLogger()})
+	if err == nil {
+		t.Fatal("expected config-required error for linode")
+	}
+}

--- a/internal/cloud/kind.go
+++ b/internal/cloud/kind.go
@@ -77,7 +77,9 @@ func (k Kind) RuntimeFamily() Kind {
 	switch k.Canonical() {
 	case KindHetzner:
 		return KindHetzner
-	case KindManual, KindLinode, KindScaleway, KindVultr:
+	case KindLinode:
+		return KindLinode
+	case KindManual, KindScaleway, KindVultr:
 		return KindManual
 	default:
 		return KindAWS
@@ -88,7 +90,7 @@ func (k Kind) RuntimeFamily() Kind {
 // support (Terraform + fleet manager) as opposed to manual/operator-managed.
 func (k Kind) IsProviderNative() bool {
 	switch k.Canonical() {
-	case KindHetzner:
+	case KindHetzner, KindLinode:
 		return true
 	default:
 		return false

--- a/internal/cloud/kind_test.go
+++ b/internal/cloud/kind_test.go
@@ -74,6 +74,25 @@ func TestSupportedKindsReturnsCanonicalUserFacingKinds(t *testing.T) {
 	}
 }
 
+func TestIsProviderNative(t *testing.T) {
+	tests := []struct {
+		kind Kind
+		want bool
+	}{
+		{KindAWS, false},
+		{KindManual, false},
+		{KindHetzner, true},
+		{KindLinode, true},
+		{KindScaleway, false},
+		{KindVultr, false},
+	}
+	for _, tt := range tests {
+		if got := tt.kind.IsProviderNative(); got != tt.want {
+			t.Errorf("%q IsProviderNative() = %v, want %v", tt.kind, got, tt.want)
+		}
+	}
+}
+
 func TestSelfhostedFamilyHelpers(t *testing.T) {
 	tests := []struct {
 		kind          Kind
@@ -86,7 +105,7 @@ func TestSelfhostedFamilyHelpers(t *testing.T) {
 		{KindSelfhosted, true, KindManual, KindManual},
 		{Kind("selfhosted"), true, KindManual, KindManual},
 		{KindHetzner, true, KindHetzner, KindHetzner},
-		{KindLinode, true, KindManual, KindLinode},
+		{KindLinode, true, KindLinode, KindLinode},
 	}
 	for _, tt := range tests {
 		if got := tt.kind.IsSelfhostedFamily(); got != tt.wantFamily {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -78,6 +78,8 @@ func RunAll(ctx context.Context, deps Deps) []CheckResult {
 		// Hetzner checks.
 		checkHetznerToken(deps),
 		checkHetznerSSHKey(deps),
+		// Linode checks.
+		checkLinodeToken(deps),
 	}
 }
 
@@ -300,6 +302,23 @@ func checkHetznerSSHKey(deps Deps) CheckResult {
 		Status:  StatusWarn,
 		Summary: "No SSH public key found in ~/.ssh/ (needed for Hetzner VM access)",
 		Fix:     "Generate an SSH key with 'ssh-keygen -t ed25519' or skip if not using Hetzner.",
+	}
+}
+
+// checkLinodeToken checks for LINODE_TOKEN environment variable.
+func checkLinodeToken(deps Deps) CheckResult {
+	if v := deps.Getenv("LINODE_TOKEN"); v != "" {
+		return CheckResult{
+			Name:    "linode_token",
+			Status:  StatusPass,
+			Summary: "LINODE_TOKEN is set",
+		}
+	}
+	return CheckResult{
+		Name:    "linode_token",
+		Status:  StatusWarn,
+		Summary: "LINODE_TOKEN is not set (required for --cloud linode)",
+		Fix:     "Set LINODE_TOKEN with your Linode API token, or skip if not using Linode.",
 	}
 }
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -265,8 +265,8 @@ func TestRunAll_ReturnsAllChecks(t *testing.T) {
 	d := baseDeps()
 	d.Getenv = envWith(map[string]string{"AWS_REGION": "us-east-1"})
 	results := RunAll(context.Background(), d)
-	if len(results) != 11 {
-		t.Fatalf("expected 11 checks, got %d", len(results))
+	if len(results) != 12 {
+		t.Fatalf("expected 12 checks, got %d", len(results))
 	}
 }
 
@@ -367,6 +367,31 @@ func TestCheckHetznerSSHKey_Missing(t *testing.T) {
 	d := baseDeps()
 	d.Getenv = envWith(map[string]string{"HOME": tmp})
 	r := checkHetznerSSHKey(d)
+	if r.Status != StatusWarn {
+		t.Fatalf("expected warn, got %s: %s", r.Status, r.Summary)
+	}
+	if r.Fix == "" {
+		t.Fatal("expected a fix suggestion")
+	}
+}
+
+// --- Linode token ---
+
+func TestCheckLinodeToken_Set(t *testing.T) {
+	d := baseDeps()
+	d.Getenv = envWith(map[string]string{"LINODE_TOKEN": "test-token-abc123"})
+	r := checkLinodeToken(d)
+	if r.Status != StatusPass {
+		t.Fatalf("expected pass, got %s: %s", r.Status, r.Summary)
+	}
+	if r.Name != "linode_token" {
+		t.Fatalf("unexpected name: %s", r.Name)
+	}
+}
+
+func TestCheckLinodeToken_Unset(t *testing.T) {
+	d := baseDeps()
+	r := checkLinodeToken(d)
 	if r.Status != StatusWarn {
 		t.Fatalf("expected warn, got %s: %s", r.Status, r.Summary)
 	}

--- a/internal/infra/lifecycle_test.go
+++ b/internal/infra/lifecycle_test.go
@@ -322,6 +322,44 @@ func TestRequiredOutputKeysForCloud_Selfhosted(t *testing.T) {
 	}
 }
 
+func TestRequiredOutputKeysForCloud_Hetzner(t *testing.T) {
+	keys := RequiredOutputKeysForCloud(cloud.KindHetzner)
+	if len(keys) != len(HetznerRequiredOutputKeys) {
+		t.Fatalf("Hetzner keys length = %d, want %d", len(keys), len(HetznerRequiredOutputKeys))
+	}
+	want := map[string]bool{
+		"nats_url":      true,
+		"controller_ip": true,
+		"generation_id": true,
+		"worker_hosts":  true,
+	}
+	for _, k := range keys {
+		delete(want, k)
+	}
+	if len(want) > 0 {
+		t.Fatalf("missing expected Hetzner keys: %v", want)
+	}
+}
+
+func TestRequiredOutputKeysForCloud_Linode(t *testing.T) {
+	keys := RequiredOutputKeysForCloud(cloud.KindLinode)
+	if len(keys) != len(LinodeRequiredOutputKeys) {
+		t.Fatalf("Linode keys length = %d, want %d", len(keys), len(LinodeRequiredOutputKeys))
+	}
+	want := map[string]bool{
+		"nats_url":      true,
+		"controller_ip": true,
+		"generation_id": true,
+		"worker_hosts":  true,
+	}
+	for _, k := range keys {
+		delete(want, k)
+	}
+	if len(want) > 0 {
+		t.Fatalf("missing expected Linode keys: %v", want)
+	}
+}
+
 func TestRequiredOutputKeysForCloud_UnknownFallsToAWS(t *testing.T) {
 	keys := RequiredOutputKeysForCloud("")
 	if len(keys) != len(AWSRequiredOutputKeys) {

--- a/internal/infra/runtime.go
+++ b/internal/infra/runtime.go
@@ -51,12 +51,36 @@ var HetznerRequiredOutputKeys = []string{
 	"worker_hosts",
 }
 
+// LinodeRequiredOutputKeys lists the Terraform output keys that must be
+// present for a Linode deploy to be considered ready. The output contract
+// mirrors Hetzner — both provider-native VPS paths produce the same key
+// set so the lifecycle/factory code works uniformly.
+var LinodeRequiredOutputKeys = []string{
+	"tool_name",
+	"cloud",
+	"nats_url",
+	"nats_stream",
+	"s3_endpoint",
+	"s3_access_key",
+	"s3_secret_key",
+	"s3_bucket_name",
+	"registry_url",
+	"docker_image",
+	"sqs_queue_url",
+	"controller_ip",
+	"generation_id",
+	"worker_count",
+	"worker_hosts",
+}
+
 // RequiredOutputKeysForCloud returns the required output keys for the given
 // cloud provider family. Unknown kinds fall back to the AWS set.
 func RequiredOutputKeysForCloud(kind cloud.Kind) []string {
 	switch kind.Canonical() {
 	case cloud.KindHetzner:
 		return HetznerRequiredOutputKeys
+	case cloud.KindLinode:
+		return LinodeRequiredOutputKeys
 	default:
 		if kind.IsSelfhostedFamily() {
 			return SelfhostedRequiredOutputKeys

--- a/internal/infra/toolconfig.go
+++ b/internal/infra/toolconfig.go
@@ -59,6 +59,12 @@ func ResolveToolConfig(tool string, kind ...cloud.Kind) (*ToolConfig, error) {
 			"tool_name":    tool,
 			"docker_image": cfg.DockerTag,
 		}
+	case cloud.KindLinode:
+		cfg.TerraformDir = "deployments/linode"
+		cfg.TerraformVars = map[string]string{
+			"tool_name":    tool,
+			"docker_image": cfg.DockerTag,
+		}
 	default:
 		cfg.TerraformDir = "deployments/aws/generic/environments/dev"
 		cfg.TerraformVars = map[string]string{

--- a/internal/infra/toolconfig_test.go
+++ b/internal/infra/toolconfig_test.go
@@ -84,3 +84,19 @@ func TestResolveToolConfig_HetznerSetsDockerImageVar(t *testing.T) {
 		t.Fatalf("TerraformVars[docker_image] = %q, want heph-nmap-worker:latest", got)
 	}
 }
+
+func TestResolveToolConfig_LinodeSetsDockerImageVar(t *testing.T) {
+	cfg, err := ResolveToolConfig("nmap", cloud.KindLinode)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.TerraformDir != "deployments/linode" {
+		t.Fatalf("TerraformDir = %q, want deployments/linode", cfg.TerraformDir)
+	}
+	if got := cfg.TerraformVars["docker_image"]; got != "heph-nmap-worker:latest" {
+		t.Fatalf("TerraformVars[docker_image] = %q, want heph-nmap-worker:latest", got)
+	}
+	if cfg.Cloud != cloud.KindLinode {
+		t.Fatalf("Cloud = %q, want linode", cfg.Cloud)
+	}
+}


### PR DESCRIPTION
## Summary                                                                                  
                                                                                              
  - Add `deployments/linode/` Terraform module composing the shared selfhosted controller with
   Linode VPC, cloud firewall, and cloud-init worker bootstrap                                
  - Wire `KindLinode` through `RuntimeFamily()`, `IsProviderNative()`, factory, lifecycle     
  probing, tool config resolution, and deploy-support gating                             
  - Add `LINODE_TOKEN` prerequisite check to `heph doctor`                                    
                                                          
  ## Details                                                                                  
                                                                                              
  Linode becomes the second provider-native VPS path alongside Hetzner. It reuses the same
  shared controller module, fleet-manager contract, output naming convention, and worker      
  self-registration model — no new architecture, just an adapter.                       
                                                                                              
  Key decisions:                                                                              
  - Linode VPC + subnet for private controller-worker networking (same 10.0.1.0/24 layout as
  Hetzner)                                                                                    
  - Controller module receives a placeholder IP since cloud-init doesn't reference it; Linode
  outputs override with real `ip_address`                                                    
  - Worker cloud-init is identical to Hetzner except `CLOUD=linode`
  - `LinodeRequiredOutputKeys` mirrors `HetznerRequiredOutputKeys` so lifecycle/factory code  
  works uniformly                                                                           
  - Default instance types: `g6-standard-1` (controller), `g6-nanode-1` (workers)             
                                                                                 
  ## Test plan                                                                                
                                                                                              
  - [x] `go test ./internal/cloud/...` — kind routing, factory build, compute rejection       
  - [x] `go test ./internal/infra/...` — tool config resolution, required output keys,        
  lifecycle probing                                                                   
  - [x] `go test ./internal/operator` — no regressions                                        
  - [x] `go test ./internal/doctor/...` — Linode token check, check count                     
  - [x] `go test ./internal/fleet/...` — no regressions                  
  - [x] `go test ./internal/tui/...` — no regressions                                         
  - [x] `go test ./cmd/heph` — deploy support, compute mode validation, scan auto-acceptance
  - [x] `go build ./cmd/heph` — clean build 