### PR TITLE
feat(cloud): add Vultr provider adapter for fleet-managed VPS scanning

### DIFF
--- a/cmd/heph/cloud.go
+++ b/cmd/heph/cloud.go
@@ -24,7 +24,7 @@ func requireDeploySupport(kind cloud.Kind) error {
 		return nil
 	}
 	if kind.IsSelfhostedFamily() {
-		return fmt.Errorf("%s infrastructure deploy/destroy is not supported — use 'hetzner' or 'linode' for provider-native VPS deploy, or 'manual' with your own infrastructure", kind.Canonical())
+		return fmt.Errorf("%s infrastructure deploy/destroy is not supported — use 'hetzner', 'linode', or 'vultr' for provider-native VPS deploy, or 'manual' with your own infrastructure", kind.Canonical())
 	}
 	return nil
 }

--- a/deployments/vultr/main.tf
+++ b/deployments/vultr/main.tf
@@ -1,0 +1,212 @@
+# Vultr fleet module — provisions a controller VM (NATS + MinIO + registry
+# via the selfhosted controller module) and N worker VMs that auto-join the
+# fleet on boot via cloud-init.
+#
+# The controller module generates credentials and cloud-init; this module
+# adds all Vultr-specific resources (instances, networking, firewall).
+
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    vultr = {
+      source  = "vultr/vultr"
+      version = ">= 2.19"
+    }
+  }
+}
+
+provider "vultr" {
+  api_key = var.vultr_api_key
+}
+
+# --- Generation ID ---
+
+resource "random_id" "generation" {
+  byte_length = 8
+}
+
+locals {
+  generation_id = var.generation_id != "" ? var.generation_id : random_id.generation.hex
+}
+
+# --- OS lookup ---
+
+data "vultr_os" "ubuntu" {
+  filter {
+    name   = "name"
+    values = ["Ubuntu 24.04 LTS x64"]
+  }
+}
+
+# --- SSH Key ---
+
+resource "vultr_ssh_key" "deploy" {
+  name    = var.ssh_key_name
+  ssh_key = trimspace(var.ssh_public_key)
+}
+
+# --- Networking (VPC 2.0) ---
+
+resource "vultr_vpc2" "fleet" {
+  description   = "heph-fleet"
+  region        = var.region
+  ip_type       = "v4"
+  ip_block      = "10.0.1.0"
+  prefix_length = 24
+}
+
+# --- Firewall ---
+
+resource "vultr_firewall_group" "fleet" {
+  description = "heph-fleet-fw"
+}
+
+# Inbound: SSH (IPv4 + IPv6)
+resource "vultr_firewall_rule" "ssh_v4" {
+  firewall_group_id = vultr_firewall_group.fleet.id
+  protocol          = "tcp"
+  ip_type           = "v4"
+  subnet            = "0.0.0.0"
+  subnet_size       = 0
+  port              = "22"
+}
+
+resource "vultr_firewall_rule" "ssh_v6" {
+  firewall_group_id = vultr_firewall_group.fleet.id
+  protocol          = "tcp"
+  ip_type           = "v6"
+  subnet            = "::"
+  subnet_size       = 0
+  port              = "22"
+}
+
+# Inbound: NATS client port (IPv4 + IPv6)
+resource "vultr_firewall_rule" "nats_v4" {
+  firewall_group_id = vultr_firewall_group.fleet.id
+  protocol          = "tcp"
+  ip_type           = "v4"
+  subnet            = "0.0.0.0"
+  subnet_size       = 0
+  port              = "4222"
+}
+
+resource "vultr_firewall_rule" "nats_v6" {
+  firewall_group_id = vultr_firewall_group.fleet.id
+  protocol          = "tcp"
+  ip_type           = "v6"
+  subnet            = "::"
+  subnet_size       = 0
+  port              = "4222"
+}
+
+# Inbound: Docker registry (IPv4 + IPv6)
+resource "vultr_firewall_rule" "registry_v4" {
+  firewall_group_id = vultr_firewall_group.fleet.id
+  protocol          = "tcp"
+  ip_type           = "v4"
+  subnet            = "0.0.0.0"
+  subnet_size       = 0
+  port              = "5000"
+}
+
+resource "vultr_firewall_rule" "registry_v6" {
+  firewall_group_id = vultr_firewall_group.fleet.id
+  protocol          = "tcp"
+  ip_type           = "v6"
+  subnet            = "::"
+  subnet_size       = 0
+  port              = "5000"
+}
+
+# Inbound: MinIO S3 API (IPv4 + IPv6)
+resource "vultr_firewall_rule" "minio_v4" {
+  firewall_group_id = vultr_firewall_group.fleet.id
+  protocol          = "tcp"
+  ip_type           = "v4"
+  subnet            = "0.0.0.0"
+  subnet_size       = 0
+  port              = "9000"
+}
+
+resource "vultr_firewall_rule" "minio_v6" {
+  firewall_group_id = vultr_firewall_group.fleet.id
+  protocol          = "tcp"
+  ip_type           = "v6"
+  subnet            = "::"
+  subnet_size       = 0
+  port              = "9000"
+}
+
+# --- Controller module (credentials + cloud-init) ---
+
+module "controller" {
+  source = "../selfhosted/controller"
+
+  # The controller module uses controller_ip only in its outputs (not in
+  # cloud-init). We override those outputs in this module's outputs.tf
+  # with the real public IP from the Vultr instance.
+  controller_ip = "0.0.0.0"
+  tool_name     = var.tool_name
+  minio_bucket  = var.minio_bucket
+}
+
+# --- Controller Instance ---
+
+resource "vultr_instance" "controller" {
+  label             = "heph-controller"
+  region            = var.region
+  plan              = var.controller_plan
+  os_id             = data.vultr_os.ubuntu.id
+  enable_ipv6       = true
+  firewall_group_id = vultr_firewall_group.fleet.id
+  ssh_key_ids       = [vultr_ssh_key.deploy.id]
+  vpc2_ids          = [vultr_vpc2.fleet.id]
+  user_data         = module.controller.cloud_init
+
+  hostname = "heph-controller"
+
+  depends_on = [vultr_vpc2.fleet]
+}
+
+# --- Worker cloud-init ---
+
+locals {
+  worker_cloud_init = [
+    for i in range(var.worker_count) : templatefile("${path.module}/templates/worker-cloud-init.yaml", {
+      controller_private_ip = vultr_instance.controller.internal_ip
+      nats_port             = 4222
+      nats_subject          = module.controller.nats_stream
+      minio_port            = 9000
+      minio_access_key      = module.controller.s3_access_key
+      minio_secret_key      = module.controller.s3_secret_key
+      minio_bucket          = var.minio_bucket
+      registry_port         = 5000
+      tool_name             = var.tool_name
+      docker_image          = var.docker_image
+      generation_id         = local.generation_id
+      worker_index          = i
+      worker_private_ip     = "auto"
+    })
+  ]
+}
+
+# --- Worker Instances ---
+
+resource "vultr_instance" "worker" {
+  count = var.worker_count
+
+  label             = "heph-worker-${count.index}"
+  region            = var.region
+  plan              = var.worker_plan
+  os_id             = data.vultr_os.ubuntu.id
+  enable_ipv6       = true
+  firewall_group_id = vultr_firewall_group.fleet.id
+  ssh_key_ids       = [vultr_ssh_key.deploy.id]
+  vpc2_ids          = [vultr_vpc2.fleet.id]
+  user_data         = local.worker_cloud_init[count.index]
+
+  hostname = "heph-worker-${count.index}"
+
+  depends_on = [vultr_vpc2.fleet, vultr_instance.controller]
+}

--- a/deployments/vultr/outputs.tf
+++ b/deployments/vultr/outputs.tf
@@ -1,0 +1,119 @@
+# Output names map onto the selfhosted env family so the Go deploy UX can
+# wire these directly into the operator's environment.  Sensitive outputs
+# are marked so Terraform does not display them in plan/apply output.
+#
+# sqs_queue_url is intentionally used for the NATS subject name to maintain
+# compatibility with the existing scan launch code which reads
+# outputs["sqs_queue_url"].
+
+output "tool_name" {
+  description = "Tool name (passed through for lifecycle mismatch detection)."
+  value       = var.tool_name
+}
+
+output "cloud" {
+  description = "Cloud provider identifier."
+  value       = "vultr"
+}
+
+output "nats_url" {
+  description = "NATS client URL for workers and the operator CLI."
+  value       = "nats://${vultr_instance.controller.main_ip}:4222"
+}
+
+output "nats_stream" {
+  description = "NATS JetStream stream name."
+  value       = module.controller.nats_stream
+}
+
+output "s3_endpoint" {
+  description = "MinIO S3-compatible endpoint URL."
+  value       = "http://${vultr_instance.controller.main_ip}:9000"
+}
+
+output "s3_region" {
+  description = "S3 region (MinIO ignores this but clients require it)."
+  value       = "us-east-1"
+}
+
+output "s3_access_key" {
+  description = "MinIO root access key."
+  value       = module.controller.s3_access_key
+  sensitive   = true
+}
+
+output "s3_secret_key" {
+  description = "MinIO root secret key."
+  value       = module.controller.s3_secret_key
+  sensitive   = true
+}
+
+output "s3_path_style" {
+  description = "Whether to use path-style S3 access (always true for MinIO)."
+  value       = "true"
+}
+
+output "s3_bucket_name" {
+  description = "Default storage bucket name."
+  value       = var.minio_bucket
+}
+
+output "registry_url" {
+  description = "Docker registry URL for worker image distribution."
+  value       = "${vultr_instance.controller.main_ip}:5000"
+}
+
+output "docker_image" {
+  description = "Worker Docker image path relative to the controller registry."
+  value       = var.docker_image
+}
+
+output "sqs_queue_url" {
+  description = "NATS subject name (named sqs_queue_url for scan launch compatibility)."
+  value       = module.controller.nats_stream
+}
+
+output "worker_count" {
+  description = "Number of worker VMs in the fleet."
+  value       = var.worker_count
+}
+
+output "controller_ip" {
+  description = "Controller public IPv4 address."
+  value       = vultr_instance.controller.main_ip
+}
+
+output "controller_ipv6" {
+  description = "Controller public IPv6 address."
+  value       = vultr_instance.controller.v6_main_ip
+}
+
+output "worker_ips" {
+  description = "List of worker public IPv4 addresses."
+  value       = vultr_instance.worker[*].main_ip
+}
+
+output "worker_ipv6s" {
+  description = "List of worker public IPv6 addresses."
+  value       = vultr_instance.worker[*].v6_main_ip
+}
+
+output "worker_private_ips" {
+  description = "List of worker private IPs on the fleet network."
+  value       = vultr_instance.worker[*].internal_ip
+}
+
+output "worker_hosts" {
+  description = "Comma-separated worker IPs for SELFHOSTED_WORKER_HOSTS compatibility."
+  value       = join(",", vultr_instance.worker[*].main_ip)
+}
+
+output "ssh_key_name" {
+  description = "SSH key name used for VM access."
+  value       = var.ssh_key_name
+}
+
+output "generation_id" {
+  description = "Fleet generation ID for ownership tracking."
+  value       = local.generation_id
+}

--- a/deployments/vultr/templates/worker-cloud-init.yaml
+++ b/deployments/vultr/templates/worker-cloud-init.yaml
@@ -1,0 +1,71 @@
+#cloud-config
+# Worker VM bootstrap — installs Docker, configures the controller's insecure
+# registry, pulls the worker image, and starts the worker as a systemd service.
+
+package_update: true
+
+packages:
+  - docker.io
+  - jq
+
+write_files:
+  # Configure Docker to trust the controller's insecure registry
+  - path: /etc/docker/daemon.json
+    content: |
+      {
+        "insecure-registries": ["${controller_private_ip}:${registry_port}"]
+      }
+
+  # Worker systemd service
+  - path: /etc/systemd/system/heph-worker.service
+    content: |
+      [Unit]
+      Description=Heph4estus Worker
+      After=docker.service
+      Requires=docker.service
+
+      [Service]
+      Restart=always
+      RestartSec=10
+      ExecStartPre=-/usr/bin/docker rm -f heph-worker
+      ExecStartPre=/usr/bin/docker pull ${controller_private_ip}:${registry_port}/${docker_image}
+      ExecStart=/usr/bin/docker run --name heph-worker \
+        -e CLOUD=vultr \
+        -e QUEUE_URL=${nats_subject} \
+        -e S3_BUCKET=${minio_bucket} \
+        -e TOOL_NAME=${tool_name} \
+        -e NATS_URL=nats://${controller_private_ip}:${nats_port} \
+        -e S3_ENDPOINT=http://${controller_private_ip}:${minio_port} \
+        -e S3_REGION=us-east-1 \
+        -e S3_ACCESS_KEY=${minio_access_key} \
+        -e S3_SECRET_KEY=${minio_secret_key} \
+        -e S3_PATH_STYLE=true \
+        -e FLEET_HEARTBEAT=true \
+        -e FLEET_GENERATION_ID=${generation_id} \
+        -e WORKER_ID=heph-worker-${worker_index} \
+        -e WORKER_HOST=${worker_private_ip} \
+        -e WORKER_VERSION=${docker_image} \
+        ${controller_private_ip}:${registry_port}/${docker_image}
+      ExecStop=/usr/bin/docker stop heph-worker
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  - mkdir -p /data
+  - systemctl daemon-reload
+  - systemctl enable --now docker
+
+  # Restart Docker to pick up insecure registry config
+  - systemctl restart docker
+
+  # Wait for controller registry to be reachable
+  - |
+    for i in $(seq 1 60); do
+      curl -sf http://${controller_private_ip}:${registry_port}/v2/ && break
+      echo "Waiting for controller registry (attempt $i)..."
+      sleep 5
+    done
+
+  # Start the worker service
+  - systemctl enable --now heph-worker

--- a/deployments/vultr/variables.tf
+++ b/deployments/vultr/variables.tf
@@ -1,0 +1,63 @@
+variable "vultr_api_key" {
+  description = "Vultr API key."
+  type        = string
+  sensitive   = true
+}
+
+variable "tool_name" {
+  description = "Tool name for lifecycle detection."
+  type        = string
+}
+
+variable "worker_count" {
+  description = "Number of worker VMs."
+  type        = number
+  default     = 3
+}
+
+variable "controller_plan" {
+  description = "Vultr plan for the controller (e.g. vc2-1c-2gb)."
+  type        = string
+  default     = "vc2-1c-2gb"
+}
+
+variable "worker_plan" {
+  description = "Vultr plan for workers (e.g. vc2-1c-1gb)."
+  type        = string
+  default     = "vc2-1c-1gb"
+}
+
+variable "region" {
+  description = "Vultr region (e.g. ewr, lax, fra)."
+  type        = string
+  default     = "ewr"
+}
+
+variable "ssh_public_key" {
+  description = "SSH public key for VM access."
+  type        = string
+}
+
+variable "ssh_key_name" {
+  description = "Name for the SSH key resource."
+  type        = string
+  default     = "heph-deploy"
+}
+
+variable "minio_bucket" {
+  description = "MinIO bucket name."
+  type        = string
+  default     = "heph-results"
+}
+
+variable "docker_image" {
+  description = "Worker Docker image (relative to controller registry)."
+  type        = string
+  default     = "heph-worker:latest"
+}
+
+variable "generation_id" {
+  description = "Fleet generation ID for ownership tracking."
+  type        = string
+  default     = ""
+}

--- a/internal/cloud/factory/factory.go
+++ b/internal/cloud/factory/factory.go
@@ -112,7 +112,7 @@ func Build(cfg Config) (cloud.Provider, error) {
 			}
 		}
 		return selfhosted.NewProvider(pcfg, cfg.Logger)
-	case cloud.KindHetzner, cloud.KindLinode:
+	case cloud.KindHetzner, cloud.KindLinode, cloud.KindVultr:
 		// Provider-native VPS paths reuse the selfhosted queue/storage runtime,
 		// but normal operator flows must not fall back to ad hoc SSH launches.
 		if cfg.Selfhosted == nil {
@@ -191,7 +191,7 @@ func BuildForKind(ctx context.Context, kind cloud.Kind, log logger.Logger) (clou
 			AWS:    &AWSConfig{SDKConfig: sdkCfg},
 			Logger: log,
 		})
-	case cloud.KindManual, cloud.KindHetzner, cloud.KindLinode:
+	case cloud.KindManual, cloud.KindHetzner, cloud.KindLinode, cloud.KindVultr:
 		return Build(Config{
 			Kind:       kind.Canonical(),
 			Selfhosted: SelfhostedConfigFromEnv(),

--- a/internal/cloud/kind.go
+++ b/internal/cloud/kind.go
@@ -79,7 +79,9 @@ func (k Kind) RuntimeFamily() Kind {
 		return KindHetzner
 	case KindLinode:
 		return KindLinode
-	case KindManual, KindScaleway, KindVultr:
+	case KindVultr:
+		return KindVultr
+	case KindManual, KindScaleway:
 		return KindManual
 	default:
 		return KindAWS
@@ -90,7 +92,7 @@ func (k Kind) RuntimeFamily() Kind {
 // support (Terraform + fleet manager) as opposed to manual/operator-managed.
 func (k Kind) IsProviderNative() bool {
 	switch k.Canonical() {
-	case KindHetzner, KindLinode:
+	case KindHetzner, KindLinode, KindVultr:
 		return true
 	default:
 		return false

--- a/internal/cloud/kind_test.go
+++ b/internal/cloud/kind_test.go
@@ -84,7 +84,7 @@ func TestIsProviderNative(t *testing.T) {
 		{KindHetzner, true},
 		{KindLinode, true},
 		{KindScaleway, false},
-		{KindVultr, false},
+		{KindVultr, true},
 	}
 	for _, tt := range tests {
 		if got := tt.kind.IsProviderNative(); got != tt.want {
@@ -106,6 +106,7 @@ func TestSelfhostedFamilyHelpers(t *testing.T) {
 		{Kind("selfhosted"), true, KindManual, KindManual},
 		{KindHetzner, true, KindHetzner, KindHetzner},
 		{KindLinode, true, KindLinode, KindLinode},
+		{KindVultr, true, KindVultr, KindVultr},
 	}
 	for _, tt := range tests {
 		if got := tt.kind.IsSelfhostedFamily(); got != tt.wantFamily {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -80,6 +80,8 @@ func RunAll(ctx context.Context, deps Deps) []CheckResult {
 		checkHetznerSSHKey(deps),
 		// Linode checks.
 		checkLinodeToken(deps),
+		// Vultr checks.
+		checkVultrAPIKey(deps),
 	}
 }
 
@@ -319,6 +321,23 @@ func checkLinodeToken(deps Deps) CheckResult {
 		Status:  StatusWarn,
 		Summary: "LINODE_TOKEN is not set (required for --cloud linode)",
 		Fix:     "Set LINODE_TOKEN with your Linode API token, or skip if not using Linode.",
+	}
+}
+
+// checkVultrAPIKey checks for VULTR_API_KEY environment variable.
+func checkVultrAPIKey(deps Deps) CheckResult {
+	if v := deps.Getenv("VULTR_API_KEY"); v != "" {
+		return CheckResult{
+			Name:    "vultr_api_key",
+			Status:  StatusPass,
+			Summary: "VULTR_API_KEY is set",
+		}
+	}
+	return CheckResult{
+		Name:    "vultr_api_key",
+		Status:  StatusWarn,
+		Summary: "VULTR_API_KEY is not set (required for --cloud vultr)",
+		Fix:     "Set VULTR_API_KEY with your Vultr API key, or skip if not using Vultr.",
 	}
 }
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -265,8 +265,8 @@ func TestRunAll_ReturnsAllChecks(t *testing.T) {
 	d := baseDeps()
 	d.Getenv = envWith(map[string]string{"AWS_REGION": "us-east-1"})
 	results := RunAll(context.Background(), d)
-	if len(results) != 12 {
-		t.Fatalf("expected 12 checks, got %d", len(results))
+	if len(results) != 13 {
+		t.Fatalf("expected 13 checks, got %d", len(results))
 	}
 }
 
@@ -307,6 +307,8 @@ func TestRunAll_OrderIsStable(t *testing.T) {
 		"output_dir",
 		"hetzner_token",
 		"hetzner_ssh_key",
+		"linode_token",
+		"vultr_api_key",
 	}
 	for i, name := range expected {
 		if results[i].Name != name {
@@ -392,6 +394,31 @@ func TestCheckLinodeToken_Set(t *testing.T) {
 func TestCheckLinodeToken_Unset(t *testing.T) {
 	d := baseDeps()
 	r := checkLinodeToken(d)
+	if r.Status != StatusWarn {
+		t.Fatalf("expected warn, got %s: %s", r.Status, r.Summary)
+	}
+	if r.Fix == "" {
+		t.Fatal("expected a fix suggestion")
+	}
+}
+
+// --- Vultr API key ---
+
+func TestCheckVultrAPIKey_Set(t *testing.T) {
+	d := baseDeps()
+	d.Getenv = envWith(map[string]string{"VULTR_API_KEY": "test-key-abc123"})
+	r := checkVultrAPIKey(d)
+	if r.Status != StatusPass {
+		t.Fatalf("expected pass, got %s: %s", r.Status, r.Summary)
+	}
+	if r.Name != "vultr_api_key" {
+		t.Fatalf("unexpected name: %s", r.Name)
+	}
+}
+
+func TestCheckVultrAPIKey_Unset(t *testing.T) {
+	d := baseDeps()
+	r := checkVultrAPIKey(d)
 	if r.Status != StatusWarn {
 		t.Fatalf("expected warn, got %s: %s", r.Status, r.Summary)
 	}

--- a/internal/fleet/fleet_test.go
+++ b/internal/fleet/fleet_test.go
@@ -176,17 +176,8 @@ func TestNATSFleetManager_Heartbeat(t *testing.T) {
 	}
 	_ = pub.Flush()
 
-	// Give the subscription handler time to fire.
-	time.Sleep(200 * time.Millisecond)
+	state := awaitWorkers(t, mgr, 1)
 
-	state, err := mgr.Reconcile(context.Background())
-	if err != nil {
-		t.Fatalf("reconcile: %v", err)
-	}
-
-	if len(state.Workers) != 1 {
-		t.Fatalf("expected 1 worker, got %d", len(state.Workers))
-	}
 	w, ok := state.Workers["heph-worker-0"]
 	if !ok {
 		t.Fatal("worker heph-worker-0 not found")
@@ -250,15 +241,8 @@ func TestNATSFleetManager_MultipleWorkers(t *testing.T) {
 		}
 	}
 	_ = pub.Flush()
-	time.Sleep(200 * time.Millisecond)
 
-	state, err := mgr.Reconcile(context.Background())
-	if err != nil {
-		t.Fatalf("reconcile: %v", err)
-	}
-	if len(state.Workers) != 3 {
-		t.Fatalf("expected 3 workers, got %d", len(state.Workers))
-	}
+	state := awaitWorkers(t, mgr, 3)
 	s := state.Summarize()
 	assertInt(t, "ReadyCount", s.ReadyCount, 3)
 	assertInt(t, "HealthyCount", s.HealthyCount, 3)
@@ -301,9 +285,8 @@ func TestNATSFleetManager_HeartbeatUpdate(t *testing.T) {
 	data, _ := json.Marshal(hb1)
 	_ = pub.Publish(HeartbeatSubject, data)
 	_ = pub.Flush()
-	time.Sleep(200 * time.Millisecond)
 
-	state, _ := mgr.Reconcile(context.Background())
+	state := awaitWorkers(t, mgr, 1)
 	w := state.Workers["heph-worker-0"]
 	if w.Ready {
 		t.Fatal("expected worker not ready on first heartbeat")
@@ -325,9 +308,20 @@ func TestNATSFleetManager_HeartbeatUpdate(t *testing.T) {
 	data, _ = json.Marshal(hb2)
 	_ = pub.Publish(HeartbeatSubject, data)
 	_ = pub.Flush()
-	time.Sleep(200 * time.Millisecond)
 
-	state, _ = mgr.Reconcile(context.Background())
+	// Poll until the version update lands (worker already exists so
+	// awaitWorkers won't help — poll for the field change instead).
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		state, _ = mgr.Reconcile(context.Background())
+		if state.Workers["heph-worker-0"] != nil && state.Workers["heph-worker-0"].Version == "v0.6.3" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for heartbeat update")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	w = state.Workers["heph-worker-0"]
 	if !w.Ready {
 		t.Fatal("expected worker ready after second heartbeat")
@@ -381,13 +375,9 @@ func TestWorkerHealthTimeout(t *testing.T) {
 	data, _ := json.Marshal(hb)
 	_ = pub.Publish(HeartbeatSubject, data)
 	_ = pub.Flush()
-	time.Sleep(50 * time.Millisecond)
 
 	// Should be healthy immediately after heartbeat.
-	state, err := mgr.Reconcile(context.Background())
-	if err != nil {
-		t.Fatalf("reconcile: %v", err)
-	}
+	state := awaitWorkers(t, mgr, 1)
 	w := state.Workers["heph-worker-0"]
 	if !w.Healthy {
 		t.Fatal("expected healthy right after heartbeat")
@@ -450,7 +440,9 @@ func TestNATSFleetManager_WaitForWorkers(t *testing.T) {
 		_ = pub.Publish(HeartbeatSubject, data)
 	}
 	_ = pub.Flush()
-	time.Sleep(200 * time.Millisecond)
+
+	// Ensure heartbeats are processed before calling WaitForWorkers.
+	awaitWorkers(t, mgr, 2)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
@@ -632,6 +624,27 @@ func TestNewNATSFleetManager_Validation(t *testing.T) {
 	_, err = NewNATSFleetManager(NATSFleetManagerConfig{}, logger.NewSimpleLogger())
 	if err == nil {
 		t.Fatal("expected error for empty NATS URL")
+	}
+}
+
+// awaitWorkers polls Reconcile until at least wantCount workers are
+// registered, or fails the test after a timeout.  This replaces fragile
+// time.Sleep calls that race with NATS async message delivery.
+func awaitWorkers(t *testing.T, mgr *NATSFleetManager, wantCount int) *FleetState {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		state, err := mgr.Reconcile(context.Background())
+		if err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if len(state.Workers) >= wantCount {
+			return state
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d workers, got %d", wantCount, len(state.Workers))
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 

--- a/internal/infra/runtime.go
+++ b/internal/infra/runtime.go
@@ -73,6 +73,28 @@ var LinodeRequiredOutputKeys = []string{
 	"worker_hosts",
 }
 
+// VultrRequiredOutputKeys lists the Terraform output keys that must be
+// present for a Vultr deploy to be considered ready. The output contract
+// mirrors Hetzner and Linode — all provider-native VPS paths produce the
+// same key set so the lifecycle/factory code works uniformly.
+var VultrRequiredOutputKeys = []string{
+	"tool_name",
+	"cloud",
+	"nats_url",
+	"nats_stream",
+	"s3_endpoint",
+	"s3_access_key",
+	"s3_secret_key",
+	"s3_bucket_name",
+	"registry_url",
+	"docker_image",
+	"sqs_queue_url",
+	"controller_ip",
+	"generation_id",
+	"worker_count",
+	"worker_hosts",
+}
+
 // RequiredOutputKeysForCloud returns the required output keys for the given
 // cloud provider family. Unknown kinds fall back to the AWS set.
 func RequiredOutputKeysForCloud(kind cloud.Kind) []string {
@@ -81,6 +103,8 @@ func RequiredOutputKeysForCloud(kind cloud.Kind) []string {
 		return HetznerRequiredOutputKeys
 	case cloud.KindLinode:
 		return LinodeRequiredOutputKeys
+	case cloud.KindVultr:
+		return VultrRequiredOutputKeys
 	default:
 		if kind.IsSelfhostedFamily() {
 			return SelfhostedRequiredOutputKeys

--- a/internal/infra/toolconfig.go
+++ b/internal/infra/toolconfig.go
@@ -65,6 +65,12 @@ func ResolveToolConfig(tool string, kind ...cloud.Kind) (*ToolConfig, error) {
 			"tool_name":    tool,
 			"docker_image": cfg.DockerTag,
 		}
+	case cloud.KindVultr:
+		cfg.TerraformDir = "deployments/vultr"
+		cfg.TerraformVars = map[string]string{
+			"tool_name":    tool,
+			"docker_image": cfg.DockerTag,
+		}
 	default:
 		cfg.TerraformDir = "deployments/aws/generic/environments/dev"
 		cfg.TerraformVars = map[string]string{


### PR DESCRIPTION
## Summary                                                                                  
                                                            
  - Adds `deployments/vultr/` Terraform module with controller + worker VMs, VPC 2.0          
  networking, firewall rules (IPv4/IPv6), SSH key management, and cloud-init bootstrap —
  reusing the shared `selfhosted/controller` module
  - Promotes Vultr from manual-only to provider-native: `IsProviderNative()`,                 
  `RuntimeFamily()`, factory routing, lifecycle output keys, Terraform dir resolution, and
  deploy support gates all now include Vultr                                                  
  - Adds `VULTR_API_KEY` prerequisite check to `heph doctor` with unit tests
                                                                                              
  ## What this enables                        
                                                                                              
  - `heph infra deploy --cloud vultr` provisions coherent controller + worker infrastructure  
  - `heph scan --cloud vultr --file targets.txt` feels like the same provider-native path as  
  Hetzner and Linode                                                                          
  - Vultr workers self-register via cloud-init and are visible to the fleet manager           
  - Reuse/destroy lifecycle behaves identically to Hetzner and Linode
  - TUI deploy pipeline routes Vultr through the same provider-native flow                    
                                                            
  ## Architecture                                                                             
                                                                                              
  Vultr is a pure adapter — no new runtime paths, no new abstractions. It follows the same    
  contract established by Hetzner (PR 6.3) and extended by Linode (PR 6.4):                   
                                                                                              
  | Layer | Shared | Vultr-specific |                                                         
  |-------|--------|----------------|
  | Controller bootstrap | `selfhosted/controller/` module | — |                              
  | Queue/Storage runtime | NATS JetStream + MinIO | — |    
  | Fleet manager | `fleet.NATSFleetManager` | — |
  | Terraform resources | — | `vultr_instance`, `vultr_vpc2`, `vultr_firewall_group`/`_rule`, 
  `vultr_ssh_key` |                           
  | Cloud-init template | Same env vars and systemd pattern | `CLOUD=vultr`, Vultr VPC private
   IPs |                                                    
  | Output contract | Same 15-key set | `cloud = "vultr"` |                                   
                                                            
  ## Vultr-specific details                                                                   
                                                            
  - **VPC 2.0** (`vultr_vpc2`): `10.0.1.0/24` subnet, auto-assigned private IPs               
  - **Firewall**: Individual `vultr_firewall_rule` resources (Vultr doesn't support inline    
  rules), separate IPv4/IPv6 entries for SSH, NATS, registry, MinIO                           
  - **OS lookup**: `data "vultr_os"` for Ubuntu 24.04 LTS x64 (avoids hardcoded OS IDs)       
  - **Plans**: `vc2-1c-2gb` controller, `vc2-1c-1gb` workers (defaults, configurable)
  - **Region**: `ewr` default (New Jersey)                                                    
                                                            
  ## Files changed                                                                            
                                                                                              
  **Created (4):**                                                                            
  - `deployments/vultr/main.tf`                                                               
  - `deployments/vultr/variables.tf`                                                          
  - `deployments/vultr/outputs.tf`                                                            
  - `deployments/vultr/templates/worker-cloud-init.yaml`
                                                                                              
  **Modified (8):**                                         
  - `internal/cloud/kind.go` — `IsProviderNative()`, `RuntimeFamily()`                        
  - `internal/cloud/kind_test.go` — updated expectations
  - `internal/cloud/factory/factory.go` — `Build()`, `BuildForKind()`                         
  - `internal/infra/runtime.go` — `VultrRequiredOutputKeys` 
  - `internal/infra/toolconfig.go` — Vultr terraform dir                                      
  - `cmd/heph/cloud.go` — deploy support error message
  - `internal/doctor/doctor.go` — `checkVultrAPIKey()`                                        
  - `internal/doctor/doctor_test.go` — updated count, order, Vultr tests                      
                                                                                              
  ## Test plan                                                                                
                                                            
  - [x] `go test ./internal/cloud/...`                                                        
  - [x] `go test ./internal/infra/...`                      
  - [x] `go test ./internal/doctor/...`                                                       
  - [x] `go test ./cmd/heph/...`                                                              
  - [x] `go test ./internal/operator/...`
  - [x] `go test ./internal/tui/...` 