### PR TITLE
Add per-tool container image build plumbing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
           go-version: "1.26"
       - run: make build
 
+  container-images:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make container-smoke
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,27 @@
-.PHONY: all build test lint docker-build tf-validate clean
+DOCKER ?= docker
+CONTAINER_DOCKERFILE ?= containers/generic/Dockerfile
+CONTAINER_CONTEXT ?= .
+TOOL_IMAGE_PREFIX ?= heph
+TOOL_IMAGE_SUFFIX ?= worker
+TOOL_IMAGE_TAG ?= latest
+
+TOOL_IMAGES := nmap nuclei subfinder httpx masscan
+
+NMAP_INSTALL_CMD := apk add --no-cache nmap nmap-scripts
+NUCLEI_INSTALL_CMD := go install github.com/projectdiscovery/nuclei/v3/cmd/nuclei@v3.7.1
+SUBFINDER_INSTALL_CMD := go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@v2.13.0
+HTTPX_INSTALL_CMD := go install github.com/projectdiscovery/httpx/cmd/httpx@v1.9.0
+MASSCAN_INSTALL_CMD := apk add --no-cache masscan
+
+NMAP_SMOKE_ARGS := --version
+NUCLEI_SMOKE_ARGS := --help
+SUBFINDER_SMOKE_ARGS := --help
+HTTPX_SMOKE_ARGS := --help
+MASSCAN_SMOKE_ARGS := --version
+
+tool_image = $(TOOL_IMAGE_PREFIX)-$(1)-$(TOOL_IMAGE_SUFFIX):$(TOOL_IMAGE_TAG)
+
+.PHONY: all build test lint docker-build docker-build-all docker-build-nmap docker-build-nmap-generic docker-build-nuclei docker-build-subfinder docker-build-httpx docker-build-masscan docker-smoke-all docker-smoke-nmap docker-smoke-nuclei docker-smoke-subfinder docker-smoke-httpx docker-smoke-masscan container-smoke tf-validate clean
 
 all: build test lint
 
@@ -15,15 +38,63 @@ lint:
 	golangci-lint run ./...
 
 docker-build:
-	docker build -t heph-$(TOOL)-worker \
+ifndef TOOL
+	$(error TOOL is required, e.g. make docker-build TOOL=httpx GO_INSTALL_CMD='go install ...')
+endif
+	$(DOCKER) build -t $(call tool_image,$(TOOL)) \
+		--build-arg TOOL_INSTALL_CMD="$(TOOL_INSTALL_CMD)" \
 		--build-arg GO_INSTALL_CMD="$(GO_INSTALL_CMD)" \
 		--build-arg RUNTIME_INSTALL_CMD="$(RUNTIME_INSTALL_CMD)" \
-		-f containers/generic/Dockerfile .
+		-f $(CONTAINER_DOCKERFILE) $(CONTAINER_CONTEXT)
 
-docker-build-nmap-generic:
-	docker build -t heph-nmap-worker \
-		--build-arg RUNTIME_INSTALL_CMD="apk add --no-cache nmap nmap-scripts" \
-		-f containers/generic/Dockerfile .
+docker-build-nmap:
+	$(DOCKER) build -t $(call tool_image,nmap) \
+		--build-arg TOOL_INSTALL_CMD="$(NMAP_INSTALL_CMD)" \
+		-f $(CONTAINER_DOCKERFILE) $(CONTAINER_CONTEXT)
+
+docker-build-nmap-generic: docker-build-nmap
+
+docker-build-nuclei:
+	$(DOCKER) build -t $(call tool_image,nuclei) \
+		--build-arg TOOL_INSTALL_CMD="$(NUCLEI_INSTALL_CMD)" \
+		-f $(CONTAINER_DOCKERFILE) $(CONTAINER_CONTEXT)
+
+docker-build-subfinder:
+	$(DOCKER) build -t $(call tool_image,subfinder) \
+		--build-arg TOOL_INSTALL_CMD="$(SUBFINDER_INSTALL_CMD)" \
+		-f $(CONTAINER_DOCKERFILE) $(CONTAINER_CONTEXT)
+
+docker-build-httpx:
+	$(DOCKER) build -t $(call tool_image,httpx) \
+		--build-arg TOOL_INSTALL_CMD="$(HTTPX_INSTALL_CMD)" \
+		-f $(CONTAINER_DOCKERFILE) $(CONTAINER_CONTEXT)
+
+docker-build-masscan:
+	$(DOCKER) build -t $(call tool_image,masscan) \
+		--build-arg TOOL_INSTALL_CMD="$(MASSCAN_INSTALL_CMD)" \
+		-f $(CONTAINER_DOCKERFILE) $(CONTAINER_CONTEXT)
+
+docker-build-all: $(addprefix docker-build-,$(TOOL_IMAGES))
+
+docker-smoke-nmap:
+	containers/smoke-tool.sh "$(call tool_image,nmap)" nmap $(NMAP_SMOKE_ARGS)
+
+docker-smoke-nuclei:
+	containers/smoke-tool.sh "$(call tool_image,nuclei)" nuclei $(NUCLEI_SMOKE_ARGS)
+
+docker-smoke-subfinder:
+	containers/smoke-tool.sh "$(call tool_image,subfinder)" subfinder $(SUBFINDER_SMOKE_ARGS)
+
+docker-smoke-httpx:
+	containers/smoke-tool.sh "$(call tool_image,httpx)" httpx $(HTTPX_SMOKE_ARGS)
+
+docker-smoke-masscan:
+	SMOKE_ALLOW_NONZERO=1 containers/smoke-tool.sh "$(call tool_image,masscan)" masscan $(MASSCAN_SMOKE_ARGS)
+
+docker-smoke-all: $(addprefix docker-smoke-,$(TOOL_IMAGES))
+
+container-smoke: docker-build-all
+	$(MAKE) docker-smoke-all
 
 tf-validate:
 	cd deployments/aws/generic/environments/dev && terraform init -backend=false && terraform validate

--- a/containers/generic/Dockerfile
+++ b/containers/generic/Dockerfile
@@ -12,19 +12,33 @@ COPY . .
 # Build the generic worker binary
 RUN CGO_ENABLED=0 GOOS=linux go build -o /app/bin/worker ./cmd/workers/generic
 
-# Install Go-based tools (e.g. nuclei, httpx) into /app/bin
-ARG GO_INSTALL_CMD="true"
+# Install Go-based tools (e.g. nuclei, httpx) into /app/bin.
+# GO_INSTALL_CMD is used by the runtime deploy path; TOOL_INSTALL_CMD is a
+# Makefile-friendly compatibility arg for per-tool image targets.
+ARG GO_INSTALL_CMD=""
+ARG TOOL_INSTALL_CMD=""
 ENV GOBIN=/app/bin
-RUN sh -c "${GO_INSTALL_CMD}"
+RUN if [ -n "${GO_INSTALL_CMD}" ]; then sh -c "${GO_INSTALL_CMD}"; fi; \
+    case "${TOOL_INSTALL_CMD}" in \
+        go\ install\ *) sh -c "${TOOL_INSTALL_CMD}" ;; \
+        *) true ;; \
+    esac
 
 # Create a minimal production image
 FROM alpine:3.19
 
 RUN apk add --no-cache ca-certificates tzdata
 
-# Install system-packaged tools (e.g. nmap, masscan)
-ARG RUNTIME_INSTALL_CMD="true"
-RUN sh -c "${RUNTIME_INSTALL_CMD}"
+# Install system-packaged tools (e.g. nmap, masscan). Runtime deploys use
+# RUNTIME_INSTALL_CMD; per-tool Make targets may pass apk commands through
+# TOOL_INSTALL_CMD.
+ARG RUNTIME_INSTALL_CMD=""
+ARG TOOL_INSTALL_CMD=""
+RUN if [ -n "${RUNTIME_INSTALL_CMD}" ]; then sh -c "${RUNTIME_INSTALL_CMD}"; fi; \
+    case "${TOOL_INSTALL_CMD}" in \
+        ""|go\ install\ *) true ;; \
+        *) sh -c "${TOOL_INSTALL_CMD}" ;; \
+    esac
 
 WORKDIR /app
 

--- a/containers/smoke-tool.sh
+++ b/containers/smoke-tool.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -lt 3 ]; then
+	echo "usage: $0 <image> <binary> <--help|--version> [args...]" >&2
+	exit 2
+fi
+
+image=$1
+binary=$2
+shift 2
+
+smoke_env=
+if [ "${SMOKE_ALLOW_NONZERO:-}" = "1" ]; then
+	smoke_env="-e SMOKE_ALLOW_NONZERO=1"
+fi
+
+"${DOCKER:-docker}" run --rm $smoke_env --entrypoint sh "$image" -c '
+set -eu
+binary=$1
+shift
+command -v "$binary" >/dev/null
+out="${TMPDIR:-/tmp}/heph-tool-smoke.out"
+if "$binary" "$@" >"$out" 2>&1; then
+	exit 0
+fi
+status=$?
+if [ "${SMOKE_ALLOW_NONZERO:-}" = "1" ] && [ -s "$out" ]; then
+	exit 0
+fi
+if [ "$status" -ne 0 ]; then
+	cat "$out" >&2
+	exit "$status"
+fi
+' smoke "$binary" "$@"

--- a/internal/infra/docker.go
+++ b/internal/infra/docker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 
 	"heph4estus/internal/logger"
 )
@@ -37,8 +38,13 @@ func (d *DockerClient) Build(ctx context.Context, dockerfile, buildContext, tag 
 func (d *DockerClient) BuildWithArgs(ctx context.Context, dockerfile, buildContext, tag string, buildArgs map[string]string, stream io.Writer) error {
 	d.logger.Info("Building Docker image %s", tag)
 	args := []string{"docker", "build", "-f", dockerfile, "-t", tag}
-	for k, v := range buildArgs {
-		args = append(args, "--build-arg", k+"="+v)
+	keys := make([]string, 0, len(buildArgs))
+	for k := range buildArgs {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	for _, k := range keys {
+		args = append(args, "--build-arg", k+"="+buildArgs[k])
 	}
 	args = append(args, buildContext)
 	result, err := d.runCmd(ctx, "", stream, args...)

--- a/internal/infra/infra_test.go
+++ b/internal/infra/infra_test.go
@@ -271,6 +271,26 @@ func TestDockerBuild(t *testing.T) {
 	assertArgs(t, cap.calls[0], "docker", "build", "-f", "Dockerfile", "-t", "myimg:latest", ".")
 }
 
+func TestDockerBuildWithArgs(t *testing.T) {
+	cap, exec := newCapturingExecutor("")
+	dc := &DockerClient{runCmd: exec, logger: nopLogger{}}
+
+	err := dc.BuildWithArgs(context.Background(), "Dockerfile", ".", "img:latest", map[string]string{
+		"RUNTIME_INSTALL_CMD": "apk add --no-cache nmap",
+		"GO_INSTALL_CMD":      "go install github.com/example/tool@v1.0.0",
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertArgs(t, cap.calls[0],
+		"docker", "build", "-f", "Dockerfile", "-t", "img:latest",
+		"--build-arg", "GO_INSTALL_CMD=go install github.com/example/tool@v1.0.0",
+		"--build-arg", "RUNTIME_INSTALL_CMD=apk add --no-cache nmap",
+		".",
+	)
+}
+
 func TestDockerBuild_Error(t *testing.T) {
 	dc := &DockerClient{
 		runCmd: newMockExecutor("", "err", 1, errors.New("exit 1")),
@@ -480,4 +500,3 @@ func assertVarFlag(t *testing.T, args []string, key, value string) {
 	}
 	t.Fatalf("expected -var %s in args %v", expected, args)
 }
-

--- a/internal/infra/toolconfig_test.go
+++ b/internal/infra/toolconfig_test.go
@@ -1,6 +1,7 @@
 package infra
 
 import (
+	"fmt"
 	"testing"
 
 	"heph4estus/internal/cloud"
@@ -38,6 +39,41 @@ func TestResolveToolConfig_Httpx(t *testing.T) {
 	}
 	if cfg.ECRRepoName != "heph-dev-httpx" {
 		t.Errorf("ECRRepoName = %q", cfg.ECRRepoName)
+	}
+}
+
+func TestResolveToolConfig_HighPriorityToolImagesUseGenericContainer(t *testing.T) {
+	tests := []struct {
+		tool        string
+		buildArgKey string
+	}{
+		{"nmap", "RUNTIME_INSTALL_CMD"},
+		{"nuclei", "GO_INSTALL_CMD"},
+		{"subfinder", "GO_INSTALL_CMD"},
+		{"httpx", "GO_INSTALL_CMD"},
+		{"masscan", "RUNTIME_INSTALL_CMD"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tool, func(t *testing.T) {
+			cfg, err := ResolveToolConfig(tt.tool)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.Dockerfile != "containers/generic/Dockerfile" {
+				t.Fatalf("Dockerfile = %q, want generic Dockerfile", cfg.Dockerfile)
+			}
+			if cfg.DockerCtx != "." {
+				t.Fatalf("DockerCtx = %q, want .", cfg.DockerCtx)
+			}
+			wantTag := fmt.Sprintf("heph-%s-worker:latest", tt.tool)
+			if cfg.DockerTag != wantTag {
+				t.Fatalf("DockerTag = %q, want %q", cfg.DockerTag, wantTag)
+			}
+			if cfg.BuildArgs[tt.buildArgKey] == "" {
+				t.Fatalf("BuildArgs missing %s", tt.buildArgKey)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

  Adds PR 7.1 per-tool container image plumbing for the high-priority generic-worker tools.

  ## Changes

  - Added per-tool Docker build targets for `nmap`, `nuclei`, `subfinder`, `httpx`, and `masscan`
  - Added `docker-build-all`, `docker-smoke-all`, and `container-smoke` Makefile targets
  - Extended the generic Dockerfile to support `TOOL_INSTALL_CMD` while preserving existing `GO_INSTALL_CMD` and `RUNTIME_INSTALL_CMD` behavior
  - Added `containers/smoke-tool.sh` to verify each image contains the tool binary and can run `--help` or `--version`
  - Added CI coverage for container image build plus smoke validation
  - Made Docker build-arg ordering deterministic and added focused infra tests

  ## Testing

  - `make container-smoke`
  - `GOCACHE=/tmp/heph4estus-gocache go test ./internal/infra ./internal/modules ./cmd/workers/generic`
  - `git diff --check`

  Note: `go test ./...` was attempted, but unrelated existing embedded-NATS tests failed with `embedded nats not ready` in `internal/cloud/selfhosted` and `internal/fleet`.