### PR TITLE
feat: harden private fleet recovery, benchmarking, and rollout health

### DIFF
--- a/cmd/heph/cmd_bench.go
+++ b/cmd/heph/cmd_bench.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,6 +39,7 @@ func runBench(args []string, log logger.Logger) error {
 func runBenchFleet(args []string, log logger.Logger) error {
 	fs := flag.NewFlagSet("bench fleet", flag.ContinueOnError)
 	tool := fs.String("tool", "", "Tool whose provider-native fleet should be benchmarked")
+	jobID := fs.String("job-id", "", "Optional job ID to enrich the report with real workload throughput metrics")
 	format := fs.String("format", "text", "Output format: text or json")
 	outputPath := fs.String("output", "", "Optional path to also write the benchmark report as JSON")
 	noSave := fs.Bool("no-save", false, "Do not persist the benchmark run in the local benchmark history store")
@@ -159,6 +161,11 @@ func runBenchFleet(args []string, log logger.Logger) error {
 		RolloutPhase:            summary.RolloutPhase,
 		RollbackReason:          summary.RollbackReason,
 	}
+	if strings.TrimSpace(*jobID) != "" {
+		if err := applyJobBenchmarkMetrics(mainContext(), &report, *jobID, kind, log); err != nil {
+			return err
+		}
+	}
 
 	var savedPath string
 	if !*noSave {
@@ -186,24 +193,8 @@ func runBenchFleet(args []string, log logger.Logger) error {
 		}
 		return nil
 	}
-	_, _ = fmt.Fprintf(os.Stdout, "Tool:                 %s\n", report.Tool)
-	_, _ = fmt.Fprintf(os.Stdout, "Cloud:                %s\n", report.Cloud)
-	_, _ = fmt.Fprintf(os.Stdout, "Deploy:               %s\n", report.DeployDuration)
-	_, _ = fmt.Fprintf(os.Stdout, "First registered:     %s\n", report.FirstRegisteredDuration)
-	_, _ = fmt.Fprintf(os.Stdout, "First admitted:       %s\n", report.FirstAdmittedDuration)
-	_, _ = fmt.Fprintf(os.Stdout, "Steady state:         %s\n", report.SteadyStateDuration)
-	_, _ = fmt.Fprintf(os.Stdout, "Placement:            %s\n", report.Placement)
-	_, _ = fmt.Fprintf(os.Stdout, "Workers:              %d desired\n", report.DesiredWorkers)
-	_, _ = fmt.Fprintf(os.Stdout, "IPv4 / IPv6:          %d unique / %d ready\n", report.UniqueIPv4Count, report.IPv6ReadyCount)
-	_, _ = fmt.Fprintf(os.Stdout, "Admission capacity:   diversity=%d throughput=%d\n", report.DiversityEligible, report.ThroughputEligible)
-	if reasons := fleetSummaryReasons(report.ExcludedByReason); reasons != "" {
-		_, _ = fmt.Fprintf(os.Stdout, "Excluded:             %s\n", reasons)
-	}
-	if report.RolloutPhase != "" {
-		_, _ = fmt.Fprintf(os.Stdout, "Rollout:              %s\n", report.RolloutPhase)
-	}
-	if savedPath != "" {
-		_, _ = fmt.Fprintf(os.Stdout, "Saved:                %s\n", savedPath)
+	if err := outputBenchFleetText(report, savedPath); err != nil {
+		return err
 	}
 	return writeBenchReport(*outputPath, report)
 }
@@ -244,7 +235,7 @@ func runBenchHistory(args []string, log logger.Logger) error {
 		return nil
 	}
 	for _, report := range reports {
-		_, _ = fmt.Fprintf(os.Stdout, "%s %-8s %-12s deploy=%s admitted=%s steady=%s ipv4=%d ipv6=%d\n",
+		line := fmt.Sprintf("%s %-8s %-12s deploy=%s admitted=%s steady=%s ipv4=%d ipv6=%d",
 			report.GeneratedAt.Format(time.RFC3339),
 			report.Cloud,
 			report.Tool,
@@ -254,6 +245,10 @@ func runBenchHistory(args []string, log logger.Logger) error {
 			report.UniqueIPv4Count,
 			report.IPv6ReadyCount,
 		)
+		if report.JobID != "" {
+			line += fmt.Sprintf(" job=%s done=%d/%d tpm=%.2f", report.JobID, report.CompletedTasks, report.TotalTasks, report.TasksPerMinute)
+		}
+		_, _ = fmt.Fprintln(os.Stdout, line)
 	}
 	return nil
 }
@@ -314,26 +309,243 @@ func runBenchCompare(args []string, log logger.Logger) error {
 	return outputBenchComparisonText(comparison)
 }
 
+func outputBenchFleetText(report bench.FleetReport, savedPath string) error {
+	if _, err := fmt.Fprintf(os.Stdout, "Tool:                 %s\n", report.Tool); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Cloud:                %s\n", report.Cloud); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Deploy:               %s\n", report.DeployDuration); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "First registered:     %s\n", report.FirstRegisteredDuration); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "First admitted:       %s\n", report.FirstAdmittedDuration); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Steady state:         %s\n", report.SteadyStateDuration); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Placement:            %s\n", report.Placement); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Workers:              %d desired\n", report.DesiredWorkers); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "IPv4 / IPv6:          %d unique / %d ready\n", report.UniqueIPv4Count, report.IPv6ReadyCount); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Admission capacity:   diversity=%d throughput=%d\n", report.DiversityEligible, report.ThroughputEligible); err != nil {
+		return err
+	}
+	if reasons := fleetSummaryReasons(report.ExcludedByReason); reasons != "" {
+		if _, err := fmt.Fprintf(os.Stdout, "Excluded:             %s\n", reasons); err != nil {
+			return err
+		}
+	}
+	if report.RolloutPhase != "" {
+		if _, err := fmt.Fprintf(os.Stdout, "Rollout:              %s\n", report.RolloutPhase); err != nil {
+			return err
+		}
+	}
+	if report.JobID != "" {
+		if _, err := fmt.Fprintf(os.Stdout, "Job:                  %s (%s)\n", report.JobID, report.JobPhase); err != nil {
+			return err
+		}
+		if report.TotalTasks > 0 {
+			if _, err := fmt.Fprintf(os.Stdout, "Completion:           %d / %d (%.1f%%)\n", report.CompletedTasks, report.TotalTasks, report.CompletionPercent); err != nil {
+				return err
+			}
+		}
+		if report.ActiveRuntime > 0 {
+			if _, err := fmt.Fprintf(os.Stdout, "Active runtime:       %s\n", report.ActiveRuntime); err != nil {
+				return err
+			}
+		}
+		if report.TasksPerMinute > 0 {
+			if _, err := fmt.Fprintf(os.Stdout, "Tasks/minute:         %.2f\n", report.TasksPerMinute); err != nil {
+				return err
+			}
+		}
+	}
+	if savedPath != "" {
+		if _, err := fmt.Fprintf(os.Stdout, "Saved:                %s\n", savedPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func outputBenchComparisonText(comparison bench.FleetComparison) error {
-	_, _ = fmt.Fprintf(os.Stdout, "Baseline:   %s %s/%s\n",
+	if _, err := fmt.Fprintf(os.Stdout, "Baseline:   %s %s/%s\n",
 		comparison.Baseline.GeneratedAt.Format(time.RFC3339),
 		comparison.Baseline.Cloud,
 		comparison.Baseline.Tool,
-	)
-	_, _ = fmt.Fprintf(os.Stdout, "Candidate:  %s %s/%s\n\n",
+	); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Candidate:  %s %s/%s\n\n",
 		comparison.Candidate.GeneratedAt.Format(time.RFC3339),
 		comparison.Candidate.Cloud,
 		comparison.Candidate.Tool,
-	)
-	_, _ = fmt.Fprintf(os.Stdout, "Deploy:     %s\n", comparison.Delta.DeployDuration)
-	_, _ = fmt.Fprintf(os.Stdout, "Registered: %s\n", comparison.Delta.FirstRegisteredDuration)
-	_, _ = fmt.Fprintf(os.Stdout, "Admitted:   %s\n", comparison.Delta.FirstAdmittedDuration)
-	_, _ = fmt.Fprintf(os.Stdout, "Steady:     %s\n", comparison.Delta.SteadyStateDuration)
-	_, _ = fmt.Fprintf(os.Stdout, "IPv4:       %+d\n", comparison.Delta.UniqueIPv4Count)
-	_, _ = fmt.Fprintf(os.Stdout, "IPv6:       %+d\n", comparison.Delta.IPv6ReadyCount)
-	_, _ = fmt.Fprintf(os.Stdout, "Diversity:  %+d\n", comparison.Delta.DiversityEligible)
-	_, _ = fmt.Fprintf(os.Stdout, "Throughput: %+d\n", comparison.Delta.ThroughputEligible)
+	); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Deploy:     %s\n", comparison.Delta.DeployDuration); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Registered: %s\n", comparison.Delta.FirstRegisteredDuration); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Admitted:   %s\n", comparison.Delta.FirstAdmittedDuration); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Steady:     %s\n", comparison.Delta.SteadyStateDuration); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "IPv4:       %+d\n", comparison.Delta.UniqueIPv4Count); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "IPv6:       %+d\n", comparison.Delta.IPv6ReadyCount); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Diversity:  %+d\n", comparison.Delta.DiversityEligible); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Throughput: %+d\n", comparison.Delta.ThroughputEligible); err != nil {
+		return err
+	}
+	if comparison.Baseline.JobID != "" || comparison.Candidate.JobID != "" || comparison.Delta.CompletedTasks != 0 || comparison.Delta.TasksPerMinute != 0 {
+		if _, err := fmt.Fprintf(os.Stdout, "Completed:  %+d\n", comparison.Delta.CompletedTasks); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(os.Stdout, "Runtime:    %s\n", comparison.Delta.ActiveRuntime); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(os.Stdout, "Tasks/min:  %+.2f\n", comparison.Delta.TasksPerMinute); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+func applyJobBenchmarkMetrics(ctx context.Context, report *bench.FleetReport, jobID string, kind cloud.Kind, log logger.Logger) error {
+	store, err := operator.NewJobStore()
+	if err != nil {
+		return err
+	}
+	rec, err := store.Load(jobID)
+	if err != nil {
+		return err
+	}
+	if report.Tool != "" && rec.ToolName != "" && report.Tool != rec.ToolName {
+		return fmt.Errorf("job %s belongs to tool %s, not %s", rec.JobID, rec.ToolName, report.Tool)
+	}
+	if report.Cloud != "" && rec.Cloud != "" && report.Cloud != rec.Cloud {
+		return fmt.Errorf("job %s belongs to cloud %s, not %s", rec.JobID, rec.Cloud, report.Cloud)
+	}
+	completed, err := benchmarkCompletedTasks(ctx, rec, kind, log)
+	if err != nil {
+		return err
+	}
+	report.JobID = rec.JobID
+	report.JobPhase = string(rec.Phase)
+	report.TotalTasks = rec.TotalTasks
+	report.CompletedTasks = completed
+	report.ActiveRuntime = benchmarkJobRuntime(rec, time.Now().UTC())
+	if report.Placement == "" && rec.Placement.Mode != "" {
+		report.Placement = rec.Placement.Summary()
+	}
+	if rec.TotalTasks > 0 {
+		completion := float64(completed) / float64(rec.TotalTasks) * 100
+		if completion > 100 {
+			completion = 100
+		}
+		report.CompletionPercent = roundBenchFloat(completion, 1)
+	}
+	if report.ActiveRuntime > 0 {
+		report.TasksPerMinute = roundBenchFloat(float64(completed)/report.ActiveRuntime.Minutes(), 2)
+	}
+	return nil
+}
+
+func benchmarkCompletedTasks(ctx context.Context, rec *operator.JobRecord, kind cloud.Kind, log logger.Logger) (int, error) {
+	if rec == nil {
+		return 0, fmt.Errorf("job record is required")
+	}
+	if rec.Phase == operator.PhaseComplete && rec.TotalTasks > 0 {
+		return rec.TotalTasks, nil
+	}
+	if strings.TrimSpace(rec.Bucket) == "" || strings.TrimSpace(rec.ResultPrefix) == "" {
+		if isTerminalPhase(rec.Phase) {
+			return rec.TotalTasks, nil
+		}
+		return 0, fmt.Errorf("job %s has no result prefix for live throughput benchmarking", rec.JobID)
+	}
+	provider, err := buildBenchmarkProvider(ctx, rec, kind, log)
+	if err != nil {
+		if rec.Phase == operator.PhaseComplete && rec.TotalTasks > 0 {
+			return rec.TotalTasks, nil
+		}
+		return 0, err
+	}
+	count, err := provider.Storage().Count(ctx, rec.Bucket, rec.ResultPrefix)
+	if err != nil {
+		if rec.Phase == operator.PhaseComplete && rec.TotalTasks > 0 {
+			return rec.TotalTasks, nil
+		}
+		return 0, err
+	}
+	if rec.TotalTasks > 0 && count > rec.TotalTasks {
+		count = rec.TotalTasks
+	}
+	return count, nil
+}
+
+func buildBenchmarkProvider(ctx context.Context, rec *operator.JobRecord, kind cloud.Kind, log logger.Logger) (cloud.Provider, error) {
+	if kind.IsProviderNative() {
+		cfg, err := infra.ResolveToolConfig(rec.ToolName, kind)
+		if err != nil {
+			return nil, err
+		}
+		outputs, err := infra.NewTerraformClient(log).ReadOutputs(ctx, cfg.TerraformDir)
+		if err != nil {
+			return nil, err
+		}
+		return buildRuntimeProvider(ctx, kind, outputs, log)
+	}
+	return buildRuntimeProvider(ctx, kind, nil, log)
+}
+
+func benchmarkJobRuntime(rec *operator.JobRecord, now time.Time) time.Duration {
+	if rec == nil {
+		return 0
+	}
+	start := rec.StartedAt
+	if start.IsZero() {
+		start = rec.CreatedAt
+	}
+	if start.IsZero() {
+		return 0
+	}
+	end := now.UTC()
+	if isTerminalPhase(rec.Phase) && !rec.UpdatedAt.IsZero() {
+		end = rec.UpdatedAt
+	}
+	if end.Before(start) {
+		return 0
+	}
+	return end.Sub(start).Truncate(time.Second)
+}
+
+func roundBenchFloat(v float64, decimals int) float64 {
+	if decimals < 0 {
+		return v
+	}
+	factor := math.Pow10(decimals)
+	return math.Round(v*factor) / factor
 }
 
 func writeBenchReport(path string, report bench.FleetReport) error {

--- a/cmd/heph/cmd_bench.go
+++ b/cmd/heph/cmd_bench.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
+	"heph4estus/internal/bench"
 	"heph4estus/internal/cloud"
 	"heph4estus/internal/fleet"
 	"heph4estus/internal/fleetstate"
@@ -17,34 +19,17 @@ import (
 	"heph4estus/internal/operator"
 )
 
-type fleetBenchReport struct {
-	Tool                    string         `json:"tool"`
-	Cloud                   string         `json:"cloud"`
-	GeneratedAt             time.Time      `json:"generated_at"`
-	DeployDuration          time.Duration  `json:"deploy_duration"`
-	FirstRegisteredDuration time.Duration  `json:"first_registered_duration"`
-	FirstAdmittedDuration   time.Duration  `json:"first_admitted_duration"`
-	SteadyStateDuration     time.Duration  `json:"steady_state_duration"`
-	Placement               string         `json:"placement"`
-	DesiredWorkers          int            `json:"desired_workers"`
-	ControllerCount         int            `json:"controller_count"`
-	UniqueIPv4Count         int            `json:"unique_ipv4_count"`
-	IPv6ReadyCount          int            `json:"ipv6_ready_count"`
-	DiversityEligible       int            `json:"diversity_eligible"`
-	ThroughputEligible      int            `json:"throughput_eligible"`
-	ExcludedByReason        map[string]int `json:"excluded_by_reason,omitempty"`
-	VersionCounts           map[string]int `json:"version_counts,omitempty"`
-	RolloutPhase            string         `json:"rollout_phase,omitempty"`
-	RollbackReason          string         `json:"rollback_reason,omitempty"`
-}
-
 func runBench(args []string, log logger.Logger) error {
 	if len(args) == 0 {
-		return fmt.Errorf("bench requires a subcommand: fleet")
+		return fmt.Errorf("bench requires a subcommand: fleet, history, compare")
 	}
 	switch args[0] {
 	case "fleet":
 		return runBenchFleet(args[1:], log)
+	case "history":
+		return runBenchHistory(args[1:], log)
+	case "compare":
+		return runBenchCompare(args[1:], log)
 	default:
 		return fmt.Errorf("bench: unknown subcommand %q", args[0])
 	}
@@ -55,6 +40,7 @@ func runBenchFleet(args []string, log logger.Logger) error {
 	tool := fs.String("tool", "", "Tool whose provider-native fleet should be benchmarked")
 	format := fs.String("format", "text", "Output format: text or json")
 	outputPath := fs.String("output", "", "Optional path to also write the benchmark report as JSON")
+	noSave := fs.Bool("no-save", false, "Do not persist the benchmark run in the local benchmark history store")
 	autoApprove := fs.Bool("auto-approve", false, "Skip interactive approval prompt")
 	cloudFlag := fs.String("cloud", "", "Cloud provider: "+cloud.SupportedKindsText()+" (required)")
 	timeoutFlag := fs.String("timeout", "10m", "How long to wait for steady-state fleet readiness")
@@ -153,7 +139,7 @@ func runBenchFleet(args []string, log logger.Logger) error {
 	summary := finalState.Summarize()
 	diversitySummary := fleet.EvaluatePlacement(finalState, fleet.PlacementPolicy{Mode: fleet.PlacementModeDiversity})
 	throughputSummary := fleet.EvaluatePlacement(finalState, fleet.PlacementPolicy{Mode: fleet.PlacementModeThroughput})
-	report := fleetBenchReport{
+	report := bench.FleetReport{
 		Tool:                    *tool,
 		Cloud:                   string(kind.Canonical()),
 		GeneratedAt:             time.Now().UTC(),
@@ -174,13 +160,31 @@ func runBenchFleet(args []string, log logger.Logger) error {
 		RollbackReason:          summary.RollbackReason,
 	}
 
+	var savedPath string
+	if !*noSave {
+		store, err := bench.NewStore()
+		if err != nil {
+			return err
+		}
+		savedPath, err = store.Save(report)
+		if err != nil {
+			return err
+		}
+	}
+
 	if *format == "json" {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(report); err != nil {
 			return err
 		}
-		return writeBenchReport(*outputPath, report)
+		if err := writeBenchReport(*outputPath, report); err != nil {
+			return err
+		}
+		if savedPath != "" {
+			_, _ = fmt.Fprintf(os.Stderr, "Saved benchmark history to %s\n", savedPath)
+		}
+		return nil
 	}
 	_, _ = fmt.Fprintf(os.Stdout, "Tool:                 %s\n", report.Tool)
 	_, _ = fmt.Fprintf(os.Stdout, "Cloud:                %s\n", report.Cloud)
@@ -198,10 +202,141 @@ func runBenchFleet(args []string, log logger.Logger) error {
 	if report.RolloutPhase != "" {
 		_, _ = fmt.Fprintf(os.Stdout, "Rollout:              %s\n", report.RolloutPhase)
 	}
+	if savedPath != "" {
+		_, _ = fmt.Fprintf(os.Stdout, "Saved:                %s\n", savedPath)
+	}
 	return writeBenchReport(*outputPath, report)
 }
 
-func writeBenchReport(path string, report fleetBenchReport) error {
+func runBenchHistory(args []string, log logger.Logger) error {
+	fs := flag.NewFlagSet("bench history", flag.ContinueOnError)
+	tool := fs.String("tool", "", "Optional tool filter")
+	cloudFlag := fs.String("cloud", "", "Optional cloud filter")
+	format := fs.String("format", "text", "Output format: text or json")
+	limit := fs.Int("limit", 10, "Maximum number of reports to show")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	store, err := bench.NewStore()
+	if err != nil {
+		return err
+	}
+	cloudValue := ""
+	if *cloudFlag != "" {
+		opCfg, _ := operator.LoadConfig()
+		kind, err := resolveCLICloud(*cloudFlag, opCfg)
+		if err != nil {
+			return err
+		}
+		cloudValue = string(kind.Canonical())
+	}
+	reports, err := store.List(*tool, cloudValue, *limit)
+	if err != nil {
+		return err
+	}
+	if *format == "json" {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(reports)
+	}
+	if len(reports) == 0 {
+		_, _ = fmt.Fprintln(os.Stdout, "No benchmark history.")
+		return nil
+	}
+	for _, report := range reports {
+		_, _ = fmt.Fprintf(os.Stdout, "%s %-8s %-12s deploy=%s admitted=%s steady=%s ipv4=%d ipv6=%d\n",
+			report.GeneratedAt.Format(time.RFC3339),
+			report.Cloud,
+			report.Tool,
+			report.DeployDuration,
+			report.FirstAdmittedDuration,
+			report.SteadyStateDuration,
+			report.UniqueIPv4Count,
+			report.IPv6ReadyCount,
+		)
+	}
+	return nil
+}
+
+func runBenchCompare(args []string, log logger.Logger) error {
+	fs := flag.NewFlagSet("bench compare", flag.ContinueOnError)
+	tool := fs.String("tool", "", "Tool filter when comparing from stored history")
+	cloudFlag := fs.String("cloud", "", "Cloud filter when comparing from stored history")
+	format := fs.String("format", "text", "Output format: text or json")
+	baselinePath := fs.String("baseline", "", "Optional path to a baseline benchmark report JSON")
+	candidatePath := fs.String("candidate", "", "Optional path to a candidate benchmark report JSON")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	store, err := bench.NewStore()
+	if err != nil {
+		return err
+	}
+	var comparison bench.FleetComparison
+	switch {
+	case *baselinePath != "" || *candidatePath != "":
+		if strings.TrimSpace(*baselinePath) == "" || strings.TrimSpace(*candidatePath) == "" {
+			return fmt.Errorf("--baseline and --candidate must be provided together")
+		}
+		baseline, err := store.Load(*baselinePath)
+		if err != nil {
+			return err
+		}
+		candidate, err := store.Load(*candidatePath)
+		if err != nil {
+			return err
+		}
+		comparison = bench.CompareFleetReports(*baseline, *candidate)
+	default:
+		cloudValue := ""
+		if *cloudFlag != "" {
+			opCfg, _ := operator.LoadConfig()
+			kind, err := resolveCLICloud(*cloudFlag, opCfg)
+			if err != nil {
+				return err
+			}
+			cloudValue = string(kind.Canonical())
+		}
+		reports, err := store.List(*tool, cloudValue, 2)
+		if err != nil {
+			return err
+		}
+		if len(reports) < 2 {
+			return fmt.Errorf("need at least two benchmark reports to compare")
+		}
+		comparison = bench.CompareFleetReports(reports[1], reports[0])
+	}
+	if *format == "json" {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(comparison)
+	}
+	return outputBenchComparisonText(comparison)
+}
+
+func outputBenchComparisonText(comparison bench.FleetComparison) error {
+	_, _ = fmt.Fprintf(os.Stdout, "Baseline:   %s %s/%s\n",
+		comparison.Baseline.GeneratedAt.Format(time.RFC3339),
+		comparison.Baseline.Cloud,
+		comparison.Baseline.Tool,
+	)
+	_, _ = fmt.Fprintf(os.Stdout, "Candidate:  %s %s/%s\n\n",
+		comparison.Candidate.GeneratedAt.Format(time.RFC3339),
+		comparison.Candidate.Cloud,
+		comparison.Candidate.Tool,
+	)
+	_, _ = fmt.Fprintf(os.Stdout, "Deploy:     %s\n", comparison.Delta.DeployDuration)
+	_, _ = fmt.Fprintf(os.Stdout, "Registered: %s\n", comparison.Delta.FirstRegisteredDuration)
+	_, _ = fmt.Fprintf(os.Stdout, "Admitted:   %s\n", comparison.Delta.FirstAdmittedDuration)
+	_, _ = fmt.Fprintf(os.Stdout, "Steady:     %s\n", comparison.Delta.SteadyStateDuration)
+	_, _ = fmt.Fprintf(os.Stdout, "IPv4:       %+d\n", comparison.Delta.UniqueIPv4Count)
+	_, _ = fmt.Fprintf(os.Stdout, "IPv6:       %+d\n", comparison.Delta.IPv6ReadyCount)
+	_, _ = fmt.Fprintf(os.Stdout, "Diversity:  %+d\n", comparison.Delta.DiversityEligible)
+	_, _ = fmt.Fprintf(os.Stdout, "Throughput: %+d\n", comparison.Delta.ThroughputEligible)
+	return nil
+}
+
+func writeBenchReport(path string, report bench.FleetReport) error {
 	if path == "" {
 		return nil
 	}

--- a/cmd/heph/cmd_fleet.go
+++ b/cmd/heph/cmd_fleet.go
@@ -357,6 +357,10 @@ func runFleetRolloutStatus(args []string, log logger.Logger) error {
 		}
 		return nil
 	}
+	outcomes, err := loadRolloutOutcomeSummary(*tool, kind, rollout.DesiredGeneration, rollout.TargetVersion, rolloutOutcomeLookback)
+	if err != nil {
+		return err
+	}
 	_, _ = fmt.Fprintf(os.Stdout, "Phase:      %s\n", rollout.Phase)
 	_, _ = fmt.Fprintf(os.Stdout, "Target:     %s\n", rollout.TargetVersion)
 	if rollout.PreviousVersion != "" {
@@ -370,6 +374,9 @@ func runFleetRolloutStatus(args []string, log logger.Logger) error {
 	}
 	if rollout.RollbackReason != "" {
 		_, _ = fmt.Fprintf(os.Stdout, "Rollback:   %s\n", rollout.RollbackReason)
+	}
+	if line := outcomeSummaryLine(outcomes); line != "" {
+		_, _ = fmt.Fprintf(os.Stdout, "Outcomes:   %s (last %s)\n", line, rolloutOutcomeLookback)
 	}
 	return nil
 }
@@ -467,8 +474,15 @@ func runFleetRolloutStart(args []string, log logger.Logger) error {
 		_ = replaceWorkerIndexes(mainContext(), fctx.ToolConfig, kind, canaryIndexes, map[string]string{"docker_image": previousVersion}, log)
 		return fmt.Errorf("canary failed and rollback was attempted: %w", err)
 	}
+	outcomes, err := loadRolloutOutcomeSummary(*tool, kind, rollout.DesiredGeneration, rollout.TargetVersion, rolloutOutcomeLookback)
+	if err != nil {
+		return err
+	}
+	if err := validateRolloutOutcomeSummary(outcomes); err != nil {
+		return rollbackCanaryOutcomeFailure(mainContext(), fctx, rollout, outcomes, log)
+	}
 	if !*autoPromote {
-		if _, err := fmt.Fprintf(os.Stdout, "Canary healthy for %v. Run `heph fleet rollout promote --tool %s --cloud %s` to continue.\n", canaryIndexes, *tool, kind.Canonical()); err != nil {
+		if _, err := fmt.Fprintf(os.Stdout, "Canary healthy for %v with outcomes %s. Run `heph fleet rollout promote --tool %s --cloud %s` to continue.\n", canaryIndexes, outcomes.String(), *tool, kind.Canonical()); err != nil {
 			return err
 		}
 		return nil
@@ -512,6 +526,13 @@ func runFleetRolloutPromote(args []string, log logger.Logger) error {
 }
 
 func promoteRollout(ctx context.Context, fctx *providerFleetContext, rollout *fleetstate.RolloutRecord, remaining []int, timeout time.Duration, log logger.Logger) error {
+	outcomes, err := loadRolloutOutcomeSummary(fctx.ToolConfig.ToolName, fctx.Cloud, rollout.DesiredGeneration, rollout.TargetVersion, rolloutOutcomeLookback)
+	if err != nil {
+		return err
+	}
+	if err := validateRolloutOutcomeSummary(outcomes); err != nil {
+		return rollbackCanaryOutcomeFailure(ctx, fctx, rollout, outcomes, log)
+	}
 	rollout.Phase = fleetstate.RolloutPhasePromoting
 	if err := fctx.RolloutStore.Save(rollout); err != nil {
 		return err

--- a/cmd/heph/cmd_infra.go
+++ b/cmd/heph/cmd_infra.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -61,7 +62,6 @@ func runInfraDeploy(args []string, log logger.Logger) error {
 		return fmt.Errorf("--backend must be generic (got %q)", *backend)
 	}
 
-	// Resolve region from operator config when not explicitly set.
 	opCfg, _ := operator.LoadConfig()
 	*region = operator.ResolveRegion(*region, opCfg)
 
@@ -131,6 +131,10 @@ func runInfraDestroy(args []string, log logger.Logger) error {
 }
 
 func runInfraBackup(args []string, log logger.Logger) error {
+	if len(args) > 0 && args[0] == "inspect" {
+		return runInfraBackupInspect(args[1:], log)
+	}
+
 	fs := flag.NewFlagSet("infra backup", flag.ContinueOnError)
 	tool := fs.String("tool", "", "Tool whose provider-native infrastructure should be backed up")
 	cloudFlag := fs.String("cloud", "", "Cloud provider: "+cloud.SupportedKindsText()+" (required)")
@@ -158,13 +162,7 @@ func runInfraBackup(args []string, log logger.Logger) error {
 	if err != nil {
 		return err
 	}
-	manifest := &fleetstate.RecoveryManifest{
-		ToolName:   *tool,
-		Cloud:      string(cloudKind.Canonical()),
-		Outputs:    fctx.Outputs,
-		Rollout:    fctx.Rollout,
-		Reputation: fctx.Reputation,
-	}
+	manifest := fleetstate.BuildRecoveryManifest(*tool, string(cloudKind.Canonical()), fctx.Outputs, fctx.Rollout, fctx.Reputation)
 	if err := fleetstate.WriteRecoveryManifest(*outputPath, manifest); err != nil {
 		return err
 	}
@@ -174,12 +172,35 @@ func runInfraBackup(args []string, log logger.Logger) error {
 	return nil
 }
 
+func runInfraBackupInspect(args []string, log logger.Logger) error {
+	fs := flag.NewFlagSet("infra backup inspect", flag.ContinueOnError)
+	inputPath := fs.String("from", "", "Path to a recovery manifest (required)")
+	format := fs.String("format", "text", "Output format: text or json")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*inputPath) == "" {
+		return fmt.Errorf("--from flag is required")
+	}
+	manifest, err := fleetstate.ReadRecoveryManifest(*inputPath)
+	if err != nil {
+		return err
+	}
+	if *format == "json" {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(manifest)
+	}
+	return outputRecoveryManifestText(manifest)
+}
+
 func runInfraRecover(args []string, log logger.Logger) error {
 	fs := flag.NewFlagSet("infra recover", flag.ContinueOnError)
 	tool := fs.String("tool", "", "Tool whose provider-native infrastructure should be recovered")
 	cloudFlag := fs.String("cloud", "", "Cloud provider: "+cloud.SupportedKindsText()+" (required)")
 	inputPath := fs.String("from", "", "Path to a recovery manifest created by infra backup (required)")
 	autoApprove := fs.Bool("auto-approve", false, "Skip interactive approval prompt")
+	dryRun := fs.Bool("dry-run", false, "Show the recovery plan without deploying or restoring state")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -201,25 +222,32 @@ func runInfraRecover(args []string, log logger.Logger) error {
 	if err != nil {
 		return err
 	}
-	if manifest.ToolName != *tool {
-		return fmt.Errorf("recovery manifest tool mismatch: %q != %q", manifest.ToolName, *tool)
-	}
-	if manifest.Cloud != "" && manifest.Cloud != string(cloudKind.Canonical()) {
-		return fmt.Errorf("recovery manifest cloud mismatch: %q != %q", manifest.Cloud, cloudKind.Canonical())
+	if err := manifest.Validate(*tool, string(cloudKind.Canonical())); err != nil {
+		return err
 	}
 	cfg, err := infra.ResolveToolConfig(*tool, cloudKind)
 	if err != nil {
 		return err
 	}
-	_, err = infra.RunDeploy(mainContext(), infra.DeployOpts{
-		ToolConfig:  cfg,
-		Cloud:       cloudKind,
-		AutoApprove: *autoApprove,
-		Stream:      os.Stderr,
-		PromptFunc:  deployPrompt,
-	}, log)
+	tf := infra.NewTerraformClient(log)
+	probe := infra.Probe(mainContext(), tf, cloudKind, cfg.TerraformDir, *tool)
+	shouldDeploy, action, reason, err := planRecoveryAction(manifest, probe, *autoApprove)
 	if err != nil {
 		return err
+	}
+	if *dryRun {
+		return outputRecoveryPlanText(manifest, probe, action, reason, shouldDeploy)
+	}
+	if shouldDeploy {
+		if _, err := infra.RunDeploy(mainContext(), infra.DeployOpts{
+			ToolConfig:  cfg,
+			Cloud:       cloudKind,
+			AutoApprove: *autoApprove,
+			Stream:      os.Stderr,
+			PromptFunc:  deployPrompt,
+		}, log); err != nil {
+			return err
+		}
 	}
 	repStore, err := fleetstate.NewReputationStore()
 	if err != nil {
@@ -239,7 +267,82 @@ func runInfraRecover(args []string, log logger.Logger) error {
 			return err
 		}
 	}
-	if _, err := fmt.Fprintf(os.Stdout, "Recovered %s infrastructure for %s from %s\n", cloudKind.Canonical(), *tool, *inputPath); err != nil {
+	mode := "reused"
+	if shouldDeploy {
+		mode = "redeployed"
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Recovered %s infrastructure for %s from %s (%s)\n", cloudKind.Canonical(), *tool, *inputPath, mode); err != nil {
+		return err
+	}
+	return nil
+}
+
+func planRecoveryAction(manifest *fleetstate.RecoveryManifest, probe infra.ProbeResult, autoApprove bool) (bool, string, string, error) {
+	if probe.Status == infra.StatusReady {
+		if mismatch := recoveryProbeMismatch(manifest, probe.Outputs); mismatch != "" {
+			return true, "redeploy infrastructure and restore local recovery state", mismatch, nil
+		}
+		return false, "reuse current infrastructure and restore local recovery state", "", nil
+	}
+	decision := infra.Decide(probe, infra.LifecyclePolicy{AutoApprove: autoApprove})
+	if decision.Decision == infra.DecisionBlock {
+		return false, "", "", fmt.Errorf("recovery blocked: %s", decision.Message)
+	}
+	return decision.Decision == infra.DecisionDeploy, decision.Message, "", nil
+}
+
+func recoveryProbeMismatch(manifest *fleetstate.RecoveryManifest, outputs map[string]string) string {
+	if manifest == nil || outputs == nil {
+		return ""
+	}
+	if manifest.ControllerGeneration != "" && outputs["generation_id"] != "" && outputs["generation_id"] != manifest.ControllerGeneration {
+		return fmt.Sprintf("generation mismatch: current=%s backup=%s", outputs["generation_id"], manifest.ControllerGeneration)
+	}
+	if manifest.WorkerCount > 0 && outputs["worker_count"] != "" && outputs["worker_count"] != fmt.Sprint(manifest.WorkerCount) {
+		return fmt.Sprintf("worker count mismatch: current=%s backup=%d", outputs["worker_count"], manifest.WorkerCount)
+	}
+	return ""
+}
+
+func outputRecoveryManifestText(manifest *fleetstate.RecoveryManifest) error {
+	for _, line := range manifest.SummaryLines() {
+		if _, err := fmt.Fprintln(os.Stdout, line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func outputRecoveryPlanText(manifest *fleetstate.RecoveryManifest, probe infra.ProbeResult, action, reason string, shouldDeploy bool) error {
+	for _, line := range manifest.SummaryLines() {
+		if _, err := fmt.Fprintln(os.Stdout, line); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Current:     %s\n", probe.Status); err != nil {
+		return err
+	}
+	if probe.Outputs != nil {
+		if generation := probe.Outputs["generation_id"]; generation != "" {
+			if _, err := fmt.Fprintf(os.Stdout, "Current Gen: %s\n", generation); err != nil {
+				return err
+			}
+		}
+		if workers := probe.Outputs["worker_count"]; workers != "" {
+			if _, err := fmt.Fprintf(os.Stdout, "Current Workers: %s\n", workers); err != nil {
+				return err
+			}
+		}
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Action:      %s\n", action); err != nil {
+		return err
+	}
+	if reason != "" {
+		if _, err := fmt.Fprintf(os.Stdout, "Reason:      %s\n", reason); err != nil {
+			return err
+		}
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Deploy:      %t\n", shouldDeploy); err != nil {
 		return err
 	}
 	return nil
@@ -249,7 +352,6 @@ func deployPrompt(_ string) bool {
 	return cliPrompt("Apply these changes?")
 }
 
-// cliPrompt asks the operator a yes/no question on stderr/stdin.
 func cliPrompt(question string) bool {
 	if strings.TrimSpace(question) == "" {
 		question = "Apply these changes?"

--- a/cmd/heph/cmd_pr68_test.go
+++ b/cmd/heph/cmd_pr68_test.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"heph4estus/internal/bench"
 )
 
 func TestRunFleetNoSubcommand(t *testing.T) {
@@ -24,6 +27,17 @@ func TestRunBenchNoSubcommand(t *testing.T) {
 		t.Fatal("expected error for bench without subcommand")
 	}
 	if !strings.Contains(err.Error(), "requires a subcommand") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunBenchCompareRequiresTwoReports(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	err := runBenchCompare([]string{}, testLogger())
+	if err == nil {
+		t.Fatal("expected compare error without enough history")
+	}
+	if !strings.Contains(err.Error(), "at least two benchmark reports") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
@@ -67,7 +81,7 @@ func TestRunFleetReputationFlagsWithoutListSubcommand(t *testing.T) {
 
 func TestWriteBenchReport(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "reports", "fleet.json")
-	err := writeBenchReport(path, fleetBenchReport{
+	err := writeBenchReport(path, bench.FleetReport{
 		Tool:        "httpx",
 		Cloud:       "hetzner",
 		GeneratedAt: time.Now().UTC(),
@@ -81,5 +95,75 @@ func TestWriteBenchReport(t *testing.T) {
 	}
 	if !strings.Contains(string(data), `"tool": "httpx"`) {
 		t.Fatalf("expected report JSON, got:\n%s", string(data))
+	}
+}
+
+func TestOutputBenchComparisonText(t *testing.T) {
+	comparison := bench.CompareFleetReports(
+		bench.FleetReport{
+			Tool:                "httpx",
+			Cloud:               "hetzner",
+			GeneratedAt:         time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC),
+			SteadyStateDuration: 3 * time.Minute,
+			UniqueIPv4Count:     10,
+		},
+		bench.FleetReport{
+			Tool:                "httpx",
+			Cloud:               "hetzner",
+			GeneratedAt:         time.Date(2026, 5, 2, 11, 0, 0, 0, time.UTC),
+			SteadyStateDuration: 2 * time.Minute,
+			UniqueIPv4Count:     12,
+		},
+	)
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	err := outputBenchComparisonText(comparison)
+	_ = w.Close()
+	os.Stdout = old
+	if err != nil {
+		t.Fatalf("outputBenchComparisonText: %v", err)
+	}
+	buf := make([]byte, 2048)
+	n, _ := r.Read(buf)
+	out := string(buf[:n])
+	for _, want := range []string{"Baseline:", "Candidate:", "Steady:     -1m0s", "IPv4:       +2"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunBenchHistoryJSON(t *testing.T) {
+	cfg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	store, err := bench.NewStore()
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if _, err := store.Save(bench.FleetReport{
+		Tool:        "httpx",
+		Cloud:       "hetzner",
+		GeneratedAt: time.Date(2026, 5, 2, 11, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	err = runBenchHistory([]string{"--tool", "httpx", "--cloud", "hetzner", "--format", "json"}, testLogger())
+	_ = w.Close()
+	os.Stdout = old
+	if err != nil {
+		t.Fatalf("runBenchHistory: %v", err)
+	}
+	var reports []bench.FleetReport
+	if err := json.NewDecoder(r).Decode(&reports); err != nil {
+		t.Fatalf("decode history: %v", err)
+	}
+	if len(reports) != 1 || reports[0].Tool != "httpx" {
+		t.Fatalf("unexpected reports: %+v", reports)
 	}
 }

--- a/cmd/heph/cmd_pr68_test.go
+++ b/cmd/heph/cmd_pr68_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,8 +10,11 @@ import (
 	"time"
 
 	"heph4estus/internal/bench"
+	"heph4estus/internal/cloud"
+	"heph4estus/internal/fleet"
 	"heph4estus/internal/fleetstate"
 	"heph4estus/internal/infra"
+	"heph4estus/internal/operator"
 )
 
 func TestRunFleetNoSubcommand(t *testing.T) {
@@ -118,6 +122,10 @@ func TestOutputBenchComparisonText(t *testing.T) {
 			GeneratedAt:         time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC),
 			SteadyStateDuration: 3 * time.Minute,
 			UniqueIPv4Count:     10,
+			JobID:               "job-a",
+			CompletedTasks:      100,
+			ActiveRuntime:       10 * time.Minute,
+			TasksPerMinute:      10,
 		},
 		bench.FleetReport{
 			Tool:                "httpx",
@@ -125,6 +133,10 @@ func TestOutputBenchComparisonText(t *testing.T) {
 			GeneratedAt:         time.Date(2026, 5, 2, 11, 0, 0, 0, time.UTC),
 			SteadyStateDuration: 2 * time.Minute,
 			UniqueIPv4Count:     12,
+			JobID:               "job-b",
+			CompletedTasks:      120,
+			ActiveRuntime:       8 * time.Minute,
+			TasksPerMinute:      15,
 		},
 	)
 
@@ -140,7 +152,7 @@ func TestOutputBenchComparisonText(t *testing.T) {
 	buf := make([]byte, 2048)
 	n, _ := r.Read(buf)
 	out := string(buf[:n])
-	for _, want := range []string{"Baseline:", "Candidate:", "Steady:     -1m0s", "IPv4:       +2"} {
+	for _, want := range []string{"Baseline:", "Candidate:", "Steady:     -1m0s", "IPv4:       +2", "Completed:  +20", "Tasks/min:  +5.00"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("expected output to contain %q, got:\n%s", want, out)
 		}
@@ -177,6 +189,46 @@ func TestRunBenchHistoryJSON(t *testing.T) {
 	}
 	if len(reports) != 1 || reports[0].Tool != "httpx" {
 		t.Fatalf("unexpected reports: %+v", reports)
+	}
+}
+
+func TestApplyJobBenchmarkMetricsCompleteJob(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	store, err := operator.NewJobStore()
+	if err != nil {
+		t.Fatalf("NewJobStore: %v", err)
+	}
+	started := time.Now().UTC().Add(-10 * time.Minute)
+	rec := &operator.JobRecord{
+		JobID:        "job-123",
+		ToolName:     "httpx",
+		Cloud:        "hetzner",
+		Phase:        operator.PhaseComplete,
+		CreatedAt:    started.Add(-1 * time.Minute),
+		StartedAt:    started,
+		TotalTasks:   40,
+		Placement:    fleet.PlacementPolicy{Mode: fleet.PlacementModeThroughput},
+		Bucket:       "ignored",
+		ResultPrefix: "scans/httpx/job-123/results/",
+	}
+	if err := store.Create(rec); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	report := bench.FleetReport{Tool: "httpx", Cloud: "hetzner"}
+	if err := applyJobBenchmarkMetrics(mainContext(), &report, "job-123", cloud.KindHetzner, testLogger()); err != nil {
+		t.Fatalf("applyJobBenchmarkMetrics: %v", err)
+	}
+	if report.JobID != "job-123" || report.CompletedTasks != 40 || report.TotalTasks != 40 {
+		t.Fatalf("unexpected report task fields: %+v", report)
+	}
+	if report.ActiveRuntime < 9*time.Minute+59*time.Second || report.ActiveRuntime > 10*time.Minute+1*time.Second {
+		t.Fatalf("ActiveRuntime = %s, want about 10m", report.ActiveRuntime)
+	}
+	if math.Abs(report.TasksPerMinute-4.0) > 0.0001 {
+		t.Fatalf("TasksPerMinute = %.2f, want 4.00", report.TasksPerMinute)
+	}
+	if report.Placement != rec.Placement.Summary() {
+		t.Fatalf("unexpected placement summary: %q", report.Placement)
 	}
 }
 

--- a/cmd/heph/cmd_pr68_test.go
+++ b/cmd/heph/cmd_pr68_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"heph4estus/internal/bench"
+	"heph4estus/internal/fleetstate"
+	"heph4estus/internal/infra"
 )
 
 func TestRunFleetNoSubcommand(t *testing.T) {
@@ -54,6 +56,16 @@ func TestRunInfraBackupRequiresOutput(t *testing.T) {
 
 func TestRunInfraRecoverRequiresFrom(t *testing.T) {
 	err := runInfraRecover([]string{"--tool", "httpx", "--cloud", "hetzner"}, testLogger())
+	if err == nil {
+		t.Fatal("expected missing --from error")
+	}
+	if !strings.Contains(err.Error(), "--from flag is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunInfraBackupInspectRequiresFrom(t *testing.T) {
+	err := runInfraBackup([]string{"inspect"}, testLogger())
 	if err == nil {
 		t.Fatal("expected missing --from error")
 	}
@@ -165,5 +177,41 @@ func TestRunBenchHistoryJSON(t *testing.T) {
 	}
 	if len(reports) != 1 || reports[0].Tool != "httpx" {
 		t.Fatalf("unexpected reports: %+v", reports)
+	}
+}
+
+func TestOutputRecoveryManifestText(t *testing.T) {
+	manifest := fleetstate.BuildRecoveryManifest("httpx", "hetzner", map[string]string{"generation_id": "gen-1", "worker_count": "4"}, nil, nil)
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	err := outputRecoveryManifestText(manifest)
+	_ = w.Close()
+	os.Stdout = old
+	if err != nil {
+		t.Fatalf("outputRecoveryManifestText: %v", err)
+	}
+	buf := make([]byte, 2048)
+	n, _ := r.Read(buf)
+	out := string(buf[:n])
+	for _, want := range []string{"Manifest:", "Tool:        httpx", "Generation:  gen-1", "Workers:     4"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestPlanRecoveryActionReadyMismatchForcesDeploy(t *testing.T) {
+	manifest := fleetstate.BuildRecoveryManifest("httpx", "hetzner", map[string]string{"generation_id": "gen-new", "worker_count": "8", "nats_url": "nats://x"}, nil, nil)
+	probe := infra.ProbeResult{Status: infra.StatusReady, Outputs: map[string]string{"generation_id": "gen-old", "worker_count": "8"}}
+	shouldDeploy, action, reason, err := planRecoveryAction(manifest, probe, false)
+	if err != nil {
+		t.Fatalf("planRecoveryAction: %v", err)
+	}
+	if !shouldDeploy {
+		t.Fatal("expected deploy when generation mismatches")
+	}
+	if !strings.Contains(action, "redeploy") || !strings.Contains(reason, "generation mismatch") {
+		t.Fatalf("unexpected action=%q reason=%q", action, reason)
 	}
 }

--- a/cmd/heph/rollout_health.go
+++ b/cmd/heph/rollout_health.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"heph4estus/internal/cloud"
+	"heph4estus/internal/fleetstate"
+	"heph4estus/internal/logger"
+	"heph4estus/internal/operator"
+)
+
+const rolloutOutcomeLookback = 6 * time.Hour
+
+type rolloutOutcomeSummary struct {
+	CompletedJobs   int
+	FailedJobs      int
+	ActiveJobs      int
+	MostRecentEvent time.Time
+}
+
+func (s rolloutOutcomeSummary) TotalJobs() int {
+	return s.CompletedJobs + s.FailedJobs + s.ActiveJobs
+}
+
+func (s rolloutOutcomeSummary) String() string {
+	return fmt.Sprintf("complete=%d failed=%d active=%d", s.CompletedJobs, s.FailedJobs, s.ActiveJobs)
+}
+
+func loadRolloutOutcomeSummary(tool string, kind cloud.Kind, generation, version string, lookback time.Duration) (rolloutOutcomeSummary, error) {
+	store, err := operator.NewJobStore()
+	if err != nil {
+		return rolloutOutcomeSummary{}, err
+	}
+	ids, err := store.List()
+	if err != nil {
+		return rolloutOutcomeSummary{}, err
+	}
+	cutoff := time.Time{}
+	if lookback > 0 {
+		cutoff = time.Now().UTC().Add(-lookback)
+	}
+	var summary rolloutOutcomeSummary
+	for _, id := range ids {
+		rec, err := store.Load(id)
+		if err != nil {
+			return rolloutOutcomeSummary{}, err
+		}
+		if rec.ToolName != tool || rec.Cloud != string(kind.Canonical()) {
+			continue
+		}
+		if generation != "" {
+			if rec.GenerationID == "" || rec.GenerationID != generation {
+				continue
+			}
+		}
+		if version != "" {
+			if rec.ExpectedWorkerVersion == "" || rec.ExpectedWorkerVersion != version {
+				continue
+			}
+		}
+		ts := rec.UpdatedAt
+		if ts.IsZero() {
+			ts = rec.CreatedAt
+		}
+		if !cutoff.IsZero() && ts.Before(cutoff) {
+			continue
+		}
+		if summary.MostRecentEvent.IsZero() || ts.After(summary.MostRecentEvent) {
+			summary.MostRecentEvent = ts
+		}
+		switch rec.Phase {
+		case operator.PhaseComplete:
+			summary.CompletedJobs++
+		case operator.PhaseFailed:
+			summary.FailedJobs++
+		default:
+			summary.ActiveJobs++
+		}
+	}
+	return summary, nil
+}
+
+func validateRolloutOutcomeSummary(summary rolloutOutcomeSummary) error {
+	if summary.FailedJobs > 0 && summary.CompletedJobs == 0 {
+		return fmt.Errorf("recent task failures detected for canary (%s)", summary.String())
+	}
+	return nil
+}
+
+func rollbackCanaryOutcomeFailure(ctx context.Context, fctx *providerFleetContext, rollout *fleetstate.RolloutRecord, summary rolloutOutcomeSummary, log logger.Logger) error {
+	reason := fmt.Sprintf("recent task failures detected for canary (%s)", summary.String())
+	rollout.Phase = fleetstate.RolloutPhaseRolledBack
+	rollout.RollbackReason = reason
+	_ = fctx.RolloutStore.Save(rollout)
+	_ = replaceWorkerIndexes(ctx, fctx.ToolConfig, fctx.Cloud, rollout.CanaryWorkerIndexes, map[string]string{"docker_image": rollout.PreviousVersion}, log)
+	return fmt.Errorf("%s", reason)
+}
+
+func outcomeSummaryLine(summary rolloutOutcomeSummary) string {
+	if summary.TotalJobs() == 0 {
+		return ""
+	}
+	parts := []string{summary.String()}
+	if !summary.MostRecentEvent.IsZero() {
+		parts = append(parts, fmt.Sprintf("last=%s", summary.MostRecentEvent.Format(time.RFC3339)))
+	}
+	return strings.Join(parts, " ")
+}

--- a/cmd/heph/rollout_health_test.go
+++ b/cmd/heph/rollout_health_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"heph4estus/internal/cloud"
+	"heph4estus/internal/operator"
+)
+
+func TestLoadRolloutOutcomeSummaryFiltersByVersionAndGeneration(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	store, err := operator.NewJobStore()
+	if err != nil {
+		t.Fatalf("NewJobStore: %v", err)
+	}
+	now := time.Now().UTC()
+	fixtures := []*operator.JobRecord{
+		{
+			JobID:                 "ok-1",
+			ToolName:              "httpx",
+			Cloud:                 "hetzner",
+			Phase:                 operator.PhaseComplete,
+			CreatedAt:             now.Add(-30 * time.Minute),
+			UpdatedAt:             now.Add(-25 * time.Minute),
+			GenerationID:          "gen-2",
+			ExpectedWorkerVersion: "registry/heph-httpx:2",
+		},
+		{
+			JobID:                 "fail-1",
+			ToolName:              "httpx",
+			Cloud:                 "hetzner",
+			Phase:                 operator.PhaseFailed,
+			CreatedAt:             now.Add(-20 * time.Minute),
+			UpdatedAt:             now.Add(-15 * time.Minute),
+			GenerationID:          "gen-2",
+			ExpectedWorkerVersion: "registry/heph-httpx:2",
+		},
+		{
+			JobID:                 "other-version",
+			ToolName:              "httpx",
+			Cloud:                 "hetzner",
+			Phase:                 operator.PhaseFailed,
+			CreatedAt:             now.Add(-10 * time.Minute),
+			UpdatedAt:             now.Add(-9 * time.Minute),
+			GenerationID:          "gen-2",
+			ExpectedWorkerVersion: "registry/heph-httpx:3",
+		},
+		{
+			JobID:                 "other-cloud",
+			ToolName:              "httpx",
+			Cloud:                 "linode",
+			Phase:                 operator.PhaseComplete,
+			CreatedAt:             now.Add(-10 * time.Minute),
+			UpdatedAt:             now.Add(-9 * time.Minute),
+			GenerationID:          "gen-2",
+			ExpectedWorkerVersion: "registry/heph-httpx:2",
+		},
+	}
+	for _, rec := range fixtures {
+		if err := store.Create(rec); err != nil {
+			t.Fatalf("Create(%s): %v", rec.JobID, err)
+		}
+	}
+	summary, err := loadRolloutOutcomeSummary("httpx", cloud.KindHetzner, "gen-2", "registry/heph-httpx:2", 2*time.Hour)
+	if err != nil {
+		t.Fatalf("loadRolloutOutcomeSummary: %v", err)
+	}
+	if summary.CompletedJobs != 1 || summary.FailedJobs != 1 || summary.ActiveJobs != 0 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+}
+
+func TestValidateRolloutOutcomeSummaryRequiresSuccessWhenFailuresExist(t *testing.T) {
+	err := validateRolloutOutcomeSummary(rolloutOutcomeSummary{FailedJobs: 2})
+	if err == nil {
+		t.Fatal("expected validation failure")
+	}
+	if !strings.Contains(err.Error(), "recent task failures") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/bench/report.go
+++ b/internal/bench/report.go
@@ -1,0 +1,65 @@
+package bench
+
+import "time"
+
+// FleetReport captures a single provider-native fleet benchmark run.
+type FleetReport struct {
+	Tool                    string         `json:"tool"`
+	Cloud                   string         `json:"cloud"`
+	GeneratedAt             time.Time      `json:"generated_at"`
+	DeployDuration          time.Duration  `json:"deploy_duration"`
+	FirstRegisteredDuration time.Duration  `json:"first_registered_duration"`
+	FirstAdmittedDuration   time.Duration  `json:"first_admitted_duration"`
+	SteadyStateDuration     time.Duration  `json:"steady_state_duration"`
+	Placement               string         `json:"placement"`
+	DesiredWorkers          int            `json:"desired_workers"`
+	ControllerCount         int            `json:"controller_count"`
+	UniqueIPv4Count         int            `json:"unique_ipv4_count"`
+	IPv6ReadyCount          int            `json:"ipv6_ready_count"`
+	DiversityEligible       int            `json:"diversity_eligible"`
+	ThroughputEligible      int            `json:"throughput_eligible"`
+	ExcludedByReason        map[string]int `json:"excluded_by_reason,omitempty"`
+	VersionCounts           map[string]int `json:"version_counts,omitempty"`
+	RolloutPhase            string         `json:"rollout_phase,omitempty"`
+	RollbackReason          string         `json:"rollback_reason,omitempty"`
+}
+
+// FleetComparison describes the delta between two benchmark runs.
+type FleetComparison struct {
+	Baseline  FleetReport          `json:"baseline"`
+	Candidate FleetReport          `json:"candidate"`
+	Delta     FleetComparisonDelta `json:"delta"`
+}
+
+type FleetComparisonDelta struct {
+	DeployDuration          time.Duration `json:"deploy_duration"`
+	FirstRegisteredDuration time.Duration `json:"first_registered_duration"`
+	FirstAdmittedDuration   time.Duration `json:"first_admitted_duration"`
+	SteadyStateDuration     time.Duration `json:"steady_state_duration"`
+	DesiredWorkers          int           `json:"desired_workers"`
+	ControllerCount         int           `json:"controller_count"`
+	UniqueIPv4Count         int           `json:"unique_ipv4_count"`
+	IPv6ReadyCount          int           `json:"ipv6_ready_count"`
+	DiversityEligible       int           `json:"diversity_eligible"`
+	ThroughputEligible      int           `json:"throughput_eligible"`
+}
+
+// CompareFleetReports computes the candidate-minus-baseline delta.
+func CompareFleetReports(baseline, candidate FleetReport) FleetComparison {
+	return FleetComparison{
+		Baseline:  baseline,
+		Candidate: candidate,
+		Delta: FleetComparisonDelta{
+			DeployDuration:          candidate.DeployDuration - baseline.DeployDuration,
+			FirstRegisteredDuration: candidate.FirstRegisteredDuration - baseline.FirstRegisteredDuration,
+			FirstAdmittedDuration:   candidate.FirstAdmittedDuration - baseline.FirstAdmittedDuration,
+			SteadyStateDuration:     candidate.SteadyStateDuration - baseline.SteadyStateDuration,
+			DesiredWorkers:          candidate.DesiredWorkers - baseline.DesiredWorkers,
+			ControllerCount:         candidate.ControllerCount - baseline.ControllerCount,
+			UniqueIPv4Count:         candidate.UniqueIPv4Count - baseline.UniqueIPv4Count,
+			IPv6ReadyCount:          candidate.IPv6ReadyCount - baseline.IPv6ReadyCount,
+			DiversityEligible:       candidate.DiversityEligible - baseline.DiversityEligible,
+			ThroughputEligible:      candidate.ThroughputEligible - baseline.ThroughputEligible,
+		},
+	}
+}

--- a/internal/bench/report.go
+++ b/internal/bench/report.go
@@ -18,6 +18,13 @@ type FleetReport struct {
 	IPv6ReadyCount          int            `json:"ipv6_ready_count"`
 	DiversityEligible       int            `json:"diversity_eligible"`
 	ThroughputEligible      int            `json:"throughput_eligible"`
+	JobID                   string         `json:"job_id,omitempty"`
+	JobPhase                string         `json:"job_phase,omitempty"`
+	CompletedTasks          int            `json:"completed_tasks,omitempty"`
+	TotalTasks              int            `json:"total_tasks,omitempty"`
+	CompletionPercent       float64        `json:"completion_percent,omitempty"`
+	ActiveRuntime           time.Duration  `json:"active_runtime,omitempty"`
+	TasksPerMinute          float64        `json:"tasks_per_minute,omitempty"`
 	ExcludedByReason        map[string]int `json:"excluded_by_reason,omitempty"`
 	VersionCounts           map[string]int `json:"version_counts,omitempty"`
 	RolloutPhase            string         `json:"rollout_phase,omitempty"`
@@ -42,6 +49,11 @@ type FleetComparisonDelta struct {
 	IPv6ReadyCount          int           `json:"ipv6_ready_count"`
 	DiversityEligible       int           `json:"diversity_eligible"`
 	ThroughputEligible      int           `json:"throughput_eligible"`
+	CompletedTasks          int           `json:"completed_tasks"`
+	TotalTasks              int           `json:"total_tasks"`
+	CompletionPercent       float64       `json:"completion_percent"`
+	ActiveRuntime           time.Duration `json:"active_runtime"`
+	TasksPerMinute          float64       `json:"tasks_per_minute"`
 }
 
 // CompareFleetReports computes the candidate-minus-baseline delta.
@@ -60,6 +72,11 @@ func CompareFleetReports(baseline, candidate FleetReport) FleetComparison {
 			IPv6ReadyCount:          candidate.IPv6ReadyCount - baseline.IPv6ReadyCount,
 			DiversityEligible:       candidate.DiversityEligible - baseline.DiversityEligible,
 			ThroughputEligible:      candidate.ThroughputEligible - baseline.ThroughputEligible,
+			CompletedTasks:          candidate.CompletedTasks - baseline.CompletedTasks,
+			TotalTasks:              candidate.TotalTasks - baseline.TotalTasks,
+			CompletionPercent:       candidate.CompletionPercent - baseline.CompletionPercent,
+			ActiveRuntime:           candidate.ActiveRuntime - baseline.ActiveRuntime,
+			TasksPerMinute:          candidate.TasksPerMinute - baseline.TasksPerMinute,
 		},
 	}
 }

--- a/internal/bench/store.go
+++ b/internal/bench/store.go
@@ -1,0 +1,114 @@
+package bench
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const appName = "heph4estus"
+
+type Store struct {
+	dir string
+}
+
+func NewStore() (*Store, error) {
+	base, err := os.UserConfigDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolving user config dir: %w", err)
+	}
+	return NewStoreAt(filepath.Join(base, appName, "benchmarks")), nil
+}
+
+func NewStoreAt(dir string) *Store {
+	return &Store{dir: dir}
+}
+
+func (s *Store) Save(report FleetReport) (string, error) {
+	if report.Tool == "" {
+		return "", fmt.Errorf("benchmark report tool is required")
+	}
+	if report.Cloud == "" {
+		return "", fmt.Errorf("benchmark report cloud is required")
+	}
+	if report.GeneratedAt.IsZero() {
+		report.GeneratedAt = time.Now().UTC()
+	}
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return "", fmt.Errorf("creating benchmark store dir: %w", err)
+	}
+	filename := fmt.Sprintf("%s-%s-%s.json",
+		report.GeneratedAt.UTC().Format("20060102T150405Z"),
+		sanitizePathToken(report.Cloud),
+		sanitizePathToken(report.Tool),
+	)
+	path := filepath.Join(s.dir, filename)
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshaling benchmark report: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return "", fmt.Errorf("writing benchmark report: %w", err)
+	}
+	return path, nil
+}
+
+func (s *Store) Load(path string) (*FleetReport, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading benchmark report: %w", err)
+	}
+	var report FleetReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		return nil, fmt.Errorf("parsing benchmark report: %w", err)
+	}
+	return &report, nil
+}
+
+func (s *Store) List(tool, cloud string, limit int) ([]FleetReport, error) {
+	entries, err := os.ReadDir(s.dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("listing benchmark reports: %w", err)
+	}
+	var reports []FleetReport
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		report, err := s.Load(filepath.Join(s.dir, entry.Name()))
+		if err != nil {
+			return nil, err
+		}
+		if tool != "" && report.Tool != tool {
+			continue
+		}
+		if cloud != "" && report.Cloud != cloud {
+			continue
+		}
+		reports = append(reports, *report)
+	}
+	sort.Slice(reports, func(i, j int) bool {
+		return reports[i].GeneratedAt.After(reports[j].GeneratedAt)
+	})
+	if limit > 0 && len(reports) > limit {
+		reports = reports[:limit]
+	}
+	return reports, nil
+}
+
+func sanitizePathToken(raw string) string {
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	raw = strings.ReplaceAll(raw, "/", "-")
+	raw = strings.ReplaceAll(raw, " ", "-")
+	if raw == "" {
+		return "unknown"
+	}
+	return raw
+}

--- a/internal/bench/store_test.go
+++ b/internal/bench/store_test.go
@@ -1,6 +1,7 @@
 package bench
 
 import (
+	"math"
 	"path/filepath"
 	"testing"
 	"time"
@@ -21,11 +22,20 @@ func TestStoreSaveLoadListAndCompare(t *testing.T) {
 		IPv6ReadyCount:          8,
 		DiversityEligible:       10,
 		ThroughputEligible:      14,
+		CompletedTasks:          120,
+		TotalTasks:              120,
+		CompletionPercent:       100,
+		ActiveRuntime:           12 * time.Minute,
+		TasksPerMinute:          10,
 	}
 	next := base
 	next.GeneratedAt = base.GeneratedAt.Add(10 * time.Minute)
 	next.SteadyStateDuration = 2*time.Minute + 30*time.Second
 	next.UniqueIPv4Count = 12
+	next.CompletedTasks = 150
+	next.TotalTasks = 150
+	next.ActiveRuntime = 10 * time.Minute
+	next.TasksPerMinute = 15
 
 	basePath, err := store.Save(base)
 	if err != nil {
@@ -63,5 +73,14 @@ func TestStoreSaveLoadListAndCompare(t *testing.T) {
 	}
 	if comparison.Delta.UniqueIPv4Count != 2 {
 		t.Fatalf("unique IPv4 delta = %d, want 2", comparison.Delta.UniqueIPv4Count)
+	}
+	if comparison.Delta.CompletedTasks != 30 {
+		t.Fatalf("completed task delta = %d, want 30", comparison.Delta.CompletedTasks)
+	}
+	if comparison.Delta.ActiveRuntime != -2*time.Minute {
+		t.Fatalf("active runtime delta = %s, want -2m", comparison.Delta.ActiveRuntime)
+	}
+	if math.Abs(comparison.Delta.TasksPerMinute-5) > 0.0001 {
+		t.Fatalf("tasks/min delta = %.2f, want 5.00", comparison.Delta.TasksPerMinute)
 	}
 }

--- a/internal/bench/store_test.go
+++ b/internal/bench/store_test.go
@@ -1,0 +1,67 @@
+package bench
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStoreSaveLoadListAndCompare(t *testing.T) {
+	store := NewStoreAt(t.TempDir())
+	base := FleetReport{
+		Tool:                    "httpx",
+		Cloud:                   "hetzner",
+		GeneratedAt:             time.Date(2026, 5, 2, 10, 0, 0, 0, time.UTC),
+		DeployDuration:          2 * time.Minute,
+		FirstRegisteredDuration: 30 * time.Second,
+		FirstAdmittedDuration:   45 * time.Second,
+		SteadyStateDuration:     3 * time.Minute,
+		DesiredWorkers:          10,
+		UniqueIPv4Count:         10,
+		IPv6ReadyCount:          8,
+		DiversityEligible:       10,
+		ThroughputEligible:      14,
+	}
+	next := base
+	next.GeneratedAt = base.GeneratedAt.Add(10 * time.Minute)
+	next.SteadyStateDuration = 2*time.Minute + 30*time.Second
+	next.UniqueIPv4Count = 12
+
+	basePath, err := store.Save(base)
+	if err != nil {
+		t.Fatalf("Save(base): %v", err)
+	}
+	if filepath.Ext(basePath) != ".json" {
+		t.Fatalf("expected json path, got %q", basePath)
+	}
+	if _, err := store.Save(next); err != nil {
+		t.Fatalf("Save(next): %v", err)
+	}
+
+	reports, err := store.List("httpx", "hetzner", 0)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(reports) != 2 {
+		t.Fatalf("expected 2 reports, got %d", len(reports))
+	}
+	if !reports[0].GeneratedAt.After(reports[1].GeneratedAt) {
+		t.Fatal("expected reports sorted newest-first")
+	}
+
+	loaded, err := store.Load(basePath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.Tool != "httpx" || loaded.Cloud != "hetzner" {
+		t.Fatalf("unexpected loaded report: %+v", loaded)
+	}
+
+	comparison := CompareFleetReports(base, next)
+	if comparison.Delta.SteadyStateDuration != -30*time.Second {
+		t.Fatalf("steady-state delta = %s, want -30s", comparison.Delta.SteadyStateDuration)
+	}
+	if comparison.Delta.UniqueIPv4Count != 2 {
+		t.Fatalf("unique IPv4 delta = %d, want 2", comparison.Delta.UniqueIPv4Count)
+	}
+}

--- a/internal/fleetstate/recovery.go
+++ b/internal/fleetstate/recovery.go
@@ -5,17 +5,114 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 )
 
 type RecoveryManifest struct {
-	Version    int                `json:"version"`
-	CreatedAt  time.Time          `json:"created_at"`
-	ToolName   string             `json:"tool_name"`
-	Cloud      string             `json:"cloud"`
-	Outputs    map[string]string  `json:"outputs"`
-	Rollout    *RolloutRecord     `json:"rollout,omitempty"`
-	Reputation []ReputationRecord `json:"reputation,omitempty"`
+	Version              int                `json:"version"`
+	CreatedAt            time.Time          `json:"created_at"`
+	ToolName             string             `json:"tool_name"`
+	Cloud                string             `json:"cloud"`
+	ControllerGeneration string             `json:"controller_generation,omitempty"`
+	WorkerCount          int                `json:"worker_count,omitempty"`
+	Outputs              map[string]string  `json:"outputs"`
+	OutputKeys           []string           `json:"output_keys,omitempty"`
+	RecoverableArtifacts []string           `json:"recoverable_artifacts,omitempty"`
+	Warnings             []string           `json:"warnings,omitempty"`
+	Rollout              *RolloutRecord     `json:"rollout,omitempty"`
+	Reputation           []ReputationRecord `json:"reputation,omitempty"`
+}
+
+func BuildRecoveryManifest(tool, cloud string, outputs map[string]string, rollout *RolloutRecord, reputation []ReputationRecord) *RecoveryManifest {
+	manifest := &RecoveryManifest{
+		Version:    1,
+		CreatedAt:  time.Now().UTC(),
+		ToolName:   strings.TrimSpace(tool),
+		Cloud:      strings.TrimSpace(cloud),
+		Outputs:    copyOutputs(outputs),
+		Rollout:    rollout,
+		Reputation: append([]ReputationRecord(nil), reputation...),
+		Warnings: []string{
+			"backup captures local recovery metadata only; it does not restore live NATS messages or MinIO object contents",
+		},
+	}
+	if generation := strings.TrimSpace(manifest.Outputs["generation_id"]); generation != "" {
+		manifest.ControllerGeneration = generation
+	} else if rollout != nil && rollout.DesiredGeneration != "" {
+		manifest.ControllerGeneration = rollout.DesiredGeneration
+	}
+	if rawWorkers := strings.TrimSpace(manifest.Outputs["worker_count"]); rawWorkers != "" {
+		if workers, err := strconv.Atoi(rawWorkers); err == nil {
+			manifest.WorkerCount = workers
+		}
+	}
+	for key := range manifest.Outputs {
+		manifest.OutputKeys = append(manifest.OutputKeys, key)
+	}
+	sort.Strings(manifest.OutputKeys)
+	manifest.RecoverableArtifacts = []string{"terraform_outputs"}
+	if rollout != nil {
+		manifest.RecoverableArtifacts = append(manifest.RecoverableArtifacts, "rollout_state")
+	}
+	if len(reputation) > 0 {
+		manifest.RecoverableArtifacts = append(manifest.RecoverableArtifacts, "reputation_state")
+	}
+	return manifest
+}
+
+func (m *RecoveryManifest) Validate(expectedTool, expectedCloud string) error {
+	if m == nil {
+		return fmt.Errorf("recovery manifest is required")
+	}
+	if strings.TrimSpace(m.ToolName) == "" {
+		return fmt.Errorf("recovery manifest missing tool name")
+	}
+	if strings.TrimSpace(m.Cloud) == "" {
+		return fmt.Errorf("recovery manifest missing cloud")
+	}
+	if expectedTool != "" && m.ToolName != expectedTool {
+		return fmt.Errorf("recovery manifest tool mismatch: %q != %q", m.ToolName, expectedTool)
+	}
+	if expectedCloud != "" && m.Cloud != expectedCloud {
+		return fmt.Errorf("recovery manifest cloud mismatch: %q != %q", m.Cloud, expectedCloud)
+	}
+	if len(m.Outputs) == 0 {
+		return fmt.Errorf("recovery manifest contains no terraform outputs")
+	}
+	return nil
+}
+
+func (m *RecoveryManifest) SummaryLines() []string {
+	if m == nil {
+		return nil
+	}
+	lines := []string{
+		fmt.Sprintf("Manifest:    v%d", m.Version),
+		fmt.Sprintf("Created:     %s", m.CreatedAt.Format(time.RFC3339)),
+		fmt.Sprintf("Tool:        %s", m.ToolName),
+		fmt.Sprintf("Cloud:       %s", m.Cloud),
+	}
+	if m.ControllerGeneration != "" {
+		lines = append(lines, fmt.Sprintf("Generation:  %s", m.ControllerGeneration))
+	}
+	if m.WorkerCount > 0 {
+		lines = append(lines, fmt.Sprintf("Workers:     %d", m.WorkerCount))
+	}
+	if len(m.OutputKeys) > 0 {
+		lines = append(lines, fmt.Sprintf("Outputs:     %s", strings.Join(m.OutputKeys, ", ")))
+	}
+	if len(m.RecoverableArtifacts) > 0 {
+		lines = append(lines, fmt.Sprintf("Restores:    %s", strings.Join(m.RecoverableArtifacts, ", ")))
+	}
+	if len(m.Warnings) > 0 {
+		for _, warning := range m.Warnings {
+			lines = append(lines, fmt.Sprintf("Warning:     %s", warning))
+		}
+	}
+	return lines
 }
 
 func WriteRecoveryManifest(path string, manifest *RecoveryManifest) error {
@@ -48,4 +145,15 @@ func ReadRecoveryManifest(path string) (*RecoveryManifest, error) {
 		return nil, fmt.Errorf("parsing recovery manifest: %w", err)
 	}
 	return &manifest, nil
+}
+
+func copyOutputs(src map[string]string) map[string]string {
+	if src == nil {
+		return map[string]string{}
+	}
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
 }

--- a/internal/fleetstate/recovery_test.go
+++ b/internal/fleetstate/recovery_test.go
@@ -1,0 +1,44 @@
+package fleetstate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildRecoveryManifestAndValidate(t *testing.T) {
+	manifest := BuildRecoveryManifest("httpx", "hetzner", map[string]string{
+		"generation_id": "gen-1",
+		"worker_count":  "12",
+		"nats_url":      "nats://controller:4222",
+	}, &RolloutRecord{ToolName: "httpx", Cloud: "hetzner"}, []ReputationRecord{{Cloud: "hetzner", PublicIPv4: "203.0.113.10"}})
+
+	if err := manifest.Validate("httpx", "hetzner"); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if manifest.ControllerGeneration != "gen-1" {
+		t.Fatalf("ControllerGeneration = %q, want gen-1", manifest.ControllerGeneration)
+	}
+	if manifest.WorkerCount != 12 {
+		t.Fatalf("WorkerCount = %d, want 12", manifest.WorkerCount)
+	}
+	if len(manifest.OutputKeys) != 3 {
+		t.Fatalf("expected 3 output keys, got %d", len(manifest.OutputKeys))
+	}
+	if got := strings.Join(manifest.RecoverableArtifacts, ","); !strings.Contains(got, "rollout_state") || !strings.Contains(got, "reputation_state") {
+		t.Fatalf("unexpected recoverable artifacts: %s", got)
+	}
+	lines := manifest.SummaryLines()
+	if len(lines) == 0 {
+		t.Fatal("expected summary lines")
+	}
+}
+
+func TestRecoveryManifestValidateMismatch(t *testing.T) {
+	manifest := BuildRecoveryManifest("httpx", "hetzner", map[string]string{"nats_url": "nats://x"}, nil, nil)
+	if err := manifest.Validate("nmap", "hetzner"); err == nil {
+		t.Fatal("expected tool mismatch error")
+	}
+	if err := manifest.Validate("httpx", "linode"); err == nil {
+		t.Fatal("expected cloud mismatch error")
+	}
+}


### PR DESCRIPTION
## Summary

  This PR extends the private Phase 6 follow-on work with three operator-focused slices:

  1. deeper controller recovery planning
  2. job-backed benchmark workload metrics
  3. rollout gating based on recent job outcomes

  The goal is to make the fleet platform more recovery-oriented, more measurable under real
  runs, and less willing to promote bad canaries based only on heartbeat/version health.

  ## What Changed

  ### Controller recovery planning
  - expanded recovery manifests with:
    - controller generation
    - worker count
    - output key inventory
    - recoverable artifact list
    - explicit warnings about backup boundaries
  - added recovery manifest validation and human-readable summaries
  - added `heph infra backup inspect`
  - added `heph infra recover --dry-run`
  - recovery planning now distinguishes between:
    - safe reuse of matching infra
    - forced redeploy when manifest generation/worker shape mismatches current infra

  ### Benchmark workload metrics
  - extended `heph bench fleet` with optional `--job-id`
  - benchmark reports can now include real job-backed metrics:
    - job phase
    - completed tasks
    - total tasks
    - completion percent
    - active runtime
    - tasks per minute
  - benchmark history output includes saved job-backed workload metrics
  - benchmark compare output now includes workload deltas, not just fleet-admission deltas

  ### Rollout health from real outcomes
  - added recent job-outcome assessment for rollout health
  - rollout status now surfaces recent matching outcomes for the active canary generation/
  version
  - canary promotion is no longer gated only by heartbeat/version readiness
  - rollouts now stop and roll back when recent matching canary jobs show failures without
  successful completions

  ## Why

  Before this PR:
  - recovery manifests were valid but not very inspectable or planning-oriented
  - fleet benchmarks measured infra readiness but not actual run throughput
  - canary rollout decisions were still too dependent on infrastructure health alone

  This PR moves the private follow-on closer to the intended Phase 6 end state:
  - stronger recovery posture
  - more meaningful competitive measurement
  - better rollout trust

  ## Testing

  - `env GOCACHE=/tmp/heph-go-build go test ./cmd/heph ./internal/fleetstate ./internal/bench`
  - `env GOCACHE=/tmp/heph-go-build go test ./cmd/heph`

  ## Commits

  - `ad98480` `feat: deepen controller recovery planning`
  - `0c8d9bb` `test: cover recovery manifest planning`
  - `05f199f` `feat: add job-backed benchmark throughput metrics`
  - `c0cba24` `test: cover benchmark workload metrics`
  - `792bd1f` `feat: gate rollouts on recent job outcomes`
  - `8bdcae1` `test: cover rollout outcome health`

  ## Remaining Boundaries

  Still intentionally not addressed here:
  - live restoration of controller data services
  - autonomous background healing
  - task-content-aware rollout scoring beyond recent job success/failure state
  - multi-controller HA