### PR TITLE
feat(security): add registry trust installer

### DIFF
--- a/cmd/heph/cmd_infra.go
+++ b/cmd/heph/cmd_infra.go
@@ -26,7 +26,7 @@ func resolveToolConfig(tool, backend string, kind ...cloud.Kind) (*infra.ToolCon
 
 func runInfra(args []string, log logger.Logger) error {
 	if len(args) == 0 {
-		return fmt.Errorf("infra requires a subcommand: deploy, destroy, backup, recover")
+		return fmt.Errorf("infra requires a subcommand: deploy, destroy, backup, recover, trust")
 	}
 
 	sub := args[0]
@@ -39,8 +39,10 @@ func runInfra(args []string, log logger.Logger) error {
 		return runInfraBackup(args[1:], log)
 	case "recover":
 		return runInfraRecover(args[1:], log)
+	case "trust":
+		return runInfraTrust(args[1:], log)
 	default:
-		return fmt.Errorf("infra: unknown subcommand %q (expected deploy, destroy, backup, or recover)", sub)
+		return fmt.Errorf("infra: unknown subcommand %q (expected deploy, destroy, backup, recover, or trust)", sub)
 	}
 }
 
@@ -272,6 +274,130 @@ func runInfraRecover(args []string, log logger.Logger) error {
 		mode = "redeployed"
 	}
 	if _, err := fmt.Fprintf(os.Stdout, "Recovered %s infrastructure for %s from %s (%s)\n", cloudKind.Canonical(), *tool, *inputPath, mode); err != nil {
+		return err
+	}
+	return nil
+}
+
+func runInfraTrust(args []string, log logger.Logger) error {
+	if len(args) == 0 {
+		return fmt.Errorf("infra trust requires a subcommand: install")
+	}
+	sub := args[0]
+	switch sub {
+	case "install":
+		return runInfraTrustInstall(args[1:], log)
+	default:
+		return fmt.Errorf("infra trust: unknown subcommand %q (expected install)", sub)
+	}
+}
+
+func runInfraTrustInstall(args []string, log logger.Logger) error {
+	fs := flag.NewFlagSet("infra trust install", flag.ContinueOnError)
+	tool := fs.String("tool", "", "Tool whose provider-native controller trust should be installed")
+	cloudFlag := fs.String("cloud", "", "Cloud provider: "+cloud.SupportedKindsText()+" (default: from config or aws)")
+	autoApprove := fs.Bool("auto-approve", false, "Skip interactive approval prompt")
+	dryRun := fs.Bool("dry-run", false, "Show trust paths and validation without writing files")
+	trustDir := fs.String("trust-dir", "", "Directory for Heph's local controller CA trust cache")
+	dockerCertsDir := fs.String("docker-certs-dir", "", "Docker registry certs directory (default: /etc/docker/certs.d or HEPH_DOCKER_CERTS_DIR)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *tool == "" {
+		return fmt.Errorf("--tool flag is required")
+	}
+
+	opCfg, _ := operator.LoadConfig()
+	cloudKind, err := resolveCLICloud(*cloudFlag, opCfg)
+	if err != nil {
+		return err
+	}
+	if !cloudKind.IsProviderNative() {
+		return fmt.Errorf("infra trust install only supports provider-native clouds, got %q", cloudKind.Canonical())
+	}
+
+	cfg, err := infra.ResolveToolConfig(*tool, cloudKind)
+	if err != nil {
+		return err
+	}
+	outputs, err := infra.NewTerraformClient(log).ReadOutputs(mainContext(), cfg.TerraformDir)
+	if err != nil {
+		return err
+	}
+	installCfg := infra.RegistryTrustInstallConfig{
+		RegistryTrustConfig: infra.RegistryTrustConfig{
+			RegistryURL:                   outputs["registry_url"],
+			ControllerCAPEM:               outputs["controller_ca_pem"],
+			ControllerCAFingerprintSHA256: outputs["controller_ca_fingerprint_sha256"],
+			ControllerCertNotAfter:        outputs["controller_cert_not_after"],
+			TrustDir:                      *trustDir,
+			DockerCertsDir:                *dockerCertsDir,
+		},
+		DryRun: *dryRun,
+	}
+
+	plan, err := infra.InstallRegistryTrust(infra.RegistryTrustInstallConfig{
+		RegistryTrustConfig: installCfg.RegistryTrustConfig,
+		DryRun:              true,
+	})
+	if err != nil {
+		return err
+	}
+	if *dryRun {
+		return outputRegistryTrustInstallResult(plan, true)
+	}
+	if !*autoApprove {
+		question := fmt.Sprintf("Install controller CA for Docker registry %s at %s?", plan.RegistryHost, plan.DockerCAPath)
+		if !cliPrompt(question) {
+			fmt.Fprintln(os.Stderr, "Cancelled.")
+			return nil
+		}
+	}
+
+	result, err := infra.InstallRegistryTrust(installCfg)
+	if err != nil {
+		return err
+	}
+	return outputRegistryTrustInstallResult(result, false)
+}
+
+func outputRegistryTrustInstallResult(result *infra.RegistryTrustResult, dryRun bool) error {
+	if _, err := fmt.Fprintf(os.Stdout, "Registry:      %s\n", result.RegistryHost); err != nil {
+		return err
+	}
+	if result.FingerprintSHA256 != "" {
+		if _, err := fmt.Fprintf(os.Stdout, "CA fingerprint: sha256:%s\n", result.FingerprintSHA256); err != nil {
+			return err
+		}
+	}
+	if result.CertNotAfter != "" {
+		if _, err := fmt.Fprintf(os.Stdout, "Cert expires:  %s\n", result.CertNotAfter); err != nil {
+			return err
+		}
+	}
+	if dryRun {
+		if _, err := fmt.Fprintf(os.Stdout, "Would cache CA: %s\n", result.LocalCAPath); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(os.Stdout, "Would install:  %s\n", result.DockerCAPath); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(os.Stdout, "Dry run: no files written."); err != nil {
+			return err
+		}
+		return nil
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Cached CA:     %s\n", result.LocalCAPath); err != nil {
+		return err
+	}
+	status := "already trusted"
+	if result.Installed {
+		status = "installed"
+	}
+	if _, err := fmt.Fprintf(os.Stdout, "Docker CA:     %s (%s)\n", result.DockerCAPath, status); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(os.Stdout, "Restart Docker before pushing to this registry: sudo systemctl restart docker"); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/heph/main.go
+++ b/cmd/heph/main.go
@@ -21,7 +21,7 @@ const usage = `Usage: heph <command> [options]
 Commands:
   nmap     Run an nmap scan (auto-deploys infrastructure if needed)
   scan     Run a generic tool scan (e.g. httpx, nuclei, ffuf; auto-deploys if needed)
-  infra    Manage cloud infrastructure explicitly (deploy/destroy/backup/recover)
+  infra    Manage cloud infrastructure explicitly (deploy/destroy/backup/recover/trust)
   fleet    Inspect and manage provider-native fleet state
   bench    Run provider-native fleet benchmark probes
   status   Check job status (--job-id required)

--- a/cmd/heph/main_test.go
+++ b/cmd/heph/main_test.go
@@ -234,6 +234,36 @@ func TestInfraUnknownSubcommand(t *testing.T) {
 	}
 }
 
+func TestInfraTrustRequiresSubcommand(t *testing.T) {
+	err := run([]string{"infra", "trust"}, testLogger())
+	if err == nil {
+		t.Fatal("expected error for infra trust without subcommand")
+	}
+	if !strings.Contains(err.Error(), "infra trust requires a subcommand") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestInfraTrustInstallMissingTool(t *testing.T) {
+	err := run([]string{"infra", "trust", "install"}, testLogger())
+	if err == nil {
+		t.Fatal("expected error for trust install without --tool")
+	}
+	if !strings.Contains(err.Error(), "--tool flag is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestInfraTrustInstallRejectsAWS(t *testing.T) {
+	err := run([]string{"infra", "trust", "install", "--tool", "nmap", "--cloud", "aws", "--dry-run"}, testLogger())
+	if err == nil {
+		t.Fatal("expected error for AWS trust install")
+	}
+	if !strings.Contains(err.Error(), "only supports provider-native clouds") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestInfraDeployMissingTool(t *testing.T) {
 	err := run([]string{"infra", "deploy"}, testLogger())
 	if err == nil {

--- a/internal/infra/registry_trust.go
+++ b/internal/infra/registry_trust.go
@@ -1,12 +1,15 @@
 package infra
 
 import (
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/pem"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"heph4estus/internal/cloud"
 )
@@ -19,20 +22,35 @@ const (
 // RegistryTrustConfig describes the operator-side Docker registry CA trust
 // needed when provider-native controllers expose the registry over TLS.
 type RegistryTrustConfig struct {
-	RegistryURL     string
-	ControllerCAPEM string
-	TrustDir        string
-	DockerCertsDir  string
+	RegistryURL                    string
+	ControllerCAPEM                string
+	ControllerCAFingerprintSHA256  string
+	ControllerCertNotAfter         string
+	TrustDir                       string
+	DockerCertsDir                 string
+	RequireControllerTrustMetadata bool
 }
 
 // RegistryTrustResult reports whether registry trust was required and where
 // the local and Docker daemon CA files are expected to live.
 type RegistryTrustResult struct {
-	Required     bool
-	RegistryHost string
-	LocalCAPath  string
-	DockerCAPath string
-	Trusted      bool
+	Required          bool
+	RegistryHost      string
+	LocalCAPath       string
+	DockerCAPath      string
+	FingerprintSHA256 string
+	CertNotAfter      string
+	Trusted           bool
+	Installed         bool
+	Instructions      string
+}
+
+// RegistryTrustInstallConfig configures explicit operator-side Docker trust
+// installation. Unlike deploy preflight checks, install requires complete
+// controller CA metadata and may write to Docker's registry trust directory.
+type RegistryTrustInstallConfig struct {
+	RegistryTrustConfig
+	DryRun bool
 }
 
 // EnsureProviderRegistryTrust checks Docker daemon trust for provider-native
@@ -50,18 +68,105 @@ func EnsureProviderRegistryTrust(kind cloud.Kind, outputs map[string]string) (*R
 // EnsureRegistryTrust saves the controller CA into Heph's local trust cache and
 // verifies that Docker daemon registry trust is installed for HTTPS registries.
 func EnsureRegistryTrust(cfg RegistryTrustConfig) (*RegistryTrustResult, error) {
+	result, caPEM, err := planRegistryTrust(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if !result.Required {
+		return result, nil
+	}
+	if err := writeRegistryCACache(result.LocalCAPath, caPEM); err != nil {
+		return nil, err
+	}
+	return verifyDockerRegistryTrust(result, caPEM)
+}
+
+// InstallRegistryTrust installs a controller registry CA into Docker daemon
+// trust after validating the provider outputs. Callers own confirmation before
+// invoking this function.
+func InstallRegistryTrust(cfg RegistryTrustInstallConfig) (*RegistryTrustResult, error) {
+	base := cfg.RegistryTrustConfig
+	base.RequireControllerTrustMetadata = true
+	result, caPEM, err := planRegistryTrust(base)
+	if err != nil {
+		return nil, err
+	}
+	if !result.Required {
+		return nil, fmt.Errorf("registry_url %q is not an HTTPS registry endpoint", base.RegistryURL)
+	}
+	if cfg.DryRun {
+		return result, nil
+	}
+	if err := writeRegistryCACache(result.LocalCAPath, caPEM); err != nil {
+		return nil, err
+	}
+
+	dockerCA, err := os.ReadFile(result.DockerCAPath)
+	if err == nil && normalizeCertificatePEM(string(dockerCA)) == caPEM {
+		result.Trusted = true
+		return result, nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return result, fmt.Errorf("read Docker registry CA trust at %s: %w\n\n%s", result.DockerCAPath, err, result.Instructions)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(result.DockerCAPath), 0o755); err != nil {
+		return result, fmt.Errorf("create Docker registry trust directory: %w\n\n%s", err, result.Instructions)
+	}
+	if err := os.WriteFile(result.DockerCAPath, []byte(caPEM), 0o644); err != nil {
+		return result, fmt.Errorf("install Docker registry CA trust at %s: %w\n\n%s", result.DockerCAPath, err, result.Instructions)
+	}
+	result.Installed = true
+	result.Trusted = true
+	return result, nil
+}
+
+func planRegistryTrust(cfg RegistryTrustConfig) (*RegistryTrustResult, string, error) {
 	registryURL := strings.TrimSpace(cfg.RegistryURL)
 	caPEM := normalizeCertificatePEM(cfg.ControllerCAPEM)
-	if registryURL == "" || !strings.HasPrefix(strings.ToLower(registryURL), "https://") || caPEM == "" {
-		return &RegistryTrustResult{}, nil
+	if registryURL == "" {
+		if cfg.RequireControllerTrustMetadata {
+			return nil, "", fmt.Errorf("registry_url output is required for registry trust install")
+		}
+		return &RegistryTrustResult{}, "", nil
 	}
-	if err := validateCertificatePEM(caPEM); err != nil {
-		return nil, fmt.Errorf("controller registry CA PEM is invalid: %w", err)
+	if !strings.HasPrefix(strings.ToLower(registryURL), "https://") {
+		return &RegistryTrustResult{}, "", nil
+	}
+	if caPEM == "" {
+		if cfg.RequireControllerTrustMetadata {
+			return nil, "", fmt.Errorf("controller_ca_pem output is required for registry trust install")
+		}
+		return &RegistryTrustResult{}, "", nil
+	}
+	if _, err := parseCertificatePEM(caPEM); err != nil {
+		return nil, "", fmt.Errorf("controller registry CA PEM is invalid: %w", err)
+	}
+	fingerprint := sha256PEM(caPEM)
+	if expected := strings.TrimSpace(cfg.ControllerCAFingerprintSHA256); expected != "" {
+		if normalizeFingerprint(expected) != fingerprint {
+			return nil, "", fmt.Errorf("controller CA fingerprint mismatch: output sha256:%s does not match CA PEM sha256:%s", normalizeFingerprint(expected), fingerprint)
+		}
+	} else if cfg.RequireControllerTrustMetadata {
+		return nil, "", fmt.Errorf("controller_ca_fingerprint_sha256 output is required for registry trust install")
+	}
+	certNotAfter := ""
+	if raw := strings.TrimSpace(cfg.ControllerCertNotAfter); raw != "" {
+		expiresAt, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			return nil, "", fmt.Errorf("controller_cert_not_after output %q is not RFC3339: %w", raw, err)
+		}
+		if !expiresAt.After(time.Now().UTC()) {
+			return nil, "", fmt.Errorf("controller certificate expired at %s", expiresAt.Format(time.RFC3339))
+		}
+		certNotAfter = expiresAt.Format(time.RFC3339)
+	} else if cfg.RequireControllerTrustMetadata {
+		return nil, "", fmt.Errorf("controller_cert_not_after output is required for registry trust install")
 	}
 
 	registryHost := dockerRegistryHost(registryURL)
 	if registryHost == "" {
-		return nil, fmt.Errorf("registry_url %q does not include a registry host", registryURL)
+		return nil, "", fmt.Errorf("registry_url %q does not include a registry host", registryURL)
 	}
 
 	trustDir := strings.TrimSpace(cfg.TrustDir)
@@ -69,16 +174,10 @@ func EnsureRegistryTrust(cfg RegistryTrustConfig) (*RegistryTrustResult, error) 
 		var err error
 		trustDir, err = defaultRegistryTrustDir()
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
 	}
 	localCAPath := filepath.Join(trustDir, "registry", sanitizeRegistryHost(registryHost), "ca.crt")
-	if err := os.MkdirAll(filepath.Dir(localCAPath), 0o700); err != nil {
-		return nil, fmt.Errorf("create registry trust cache: %w", err)
-	}
-	if err := os.WriteFile(localCAPath, []byte(caPEM), 0o644); err != nil {
-		return nil, fmt.Errorf("write registry CA trust cache: %w", err)
-	}
 
 	dockerCertsDir := strings.TrimSpace(cfg.DockerCertsDir)
 	if dockerCertsDir == "" {
@@ -89,12 +188,28 @@ func EnsureRegistryTrust(cfg RegistryTrustConfig) (*RegistryTrustResult, error) 
 	}
 
 	result := &RegistryTrustResult{
-		Required:     true,
-		RegistryHost: registryHost,
-		LocalCAPath:  localCAPath,
-		DockerCAPath: filepath.Join(dockerCertsDir, registryHost, "ca.crt"),
+		Required:          true,
+		RegistryHost:      registryHost,
+		LocalCAPath:       localCAPath,
+		DockerCAPath:      filepath.Join(dockerCertsDir, registryHost, "ca.crt"),
+		FingerprintSHA256: fingerprint,
+		CertNotAfter:      certNotAfter,
 	}
+	result.Instructions = registryTrustInstallInstructions(result)
+	return result, caPEM, nil
+}
 
+func writeRegistryCACache(localCAPath, caPEM string) error {
+	if err := os.MkdirAll(filepath.Dir(localCAPath), 0o700); err != nil {
+		return fmt.Errorf("create registry trust cache: %w", err)
+	}
+	if err := os.WriteFile(localCAPath, []byte(caPEM), 0o644); err != nil {
+		return fmt.Errorf("write registry CA trust cache: %w", err)
+	}
+	return nil
+}
+
+func verifyDockerRegistryTrust(result *RegistryTrustResult, caPEM string) (*RegistryTrustResult, error) {
 	dockerCA, err := os.ReadFile(result.DockerCAPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -140,19 +255,27 @@ func normalizeCertificatePEM(certPEM string) string {
 	return certPEM + "\n"
 }
 
-func validateCertificatePEM(certPEM string) error {
+func parseCertificatePEM(certPEM string) (*x509.Certificate, error) {
 	rest := []byte(certPEM)
 	for {
 		block, remaining := pem.Decode(rest)
 		if block == nil {
-			return fmt.Errorf("no certificate PEM block found")
+			return nil, fmt.Errorf("no certificate PEM block found")
 		}
 		if block.Type == "CERTIFICATE" {
-			if _, err := x509.ParseCertificate(block.Bytes); err != nil {
-				return err
-			}
-			return nil
+			return x509.ParseCertificate(block.Bytes)
 		}
 		rest = remaining
 	}
+}
+
+func sha256PEM(certPEM string) string {
+	sum := sha256.Sum256([]byte(certPEM))
+	return hex.EncodeToString(sum[:])
+}
+
+func normalizeFingerprint(fingerprint string) string {
+	fingerprint = strings.TrimSpace(strings.ToLower(fingerprint))
+	fingerprint = strings.TrimPrefix(fingerprint, "sha256:")
+	return strings.ReplaceAll(fingerprint, ":", "")
 }

--- a/internal/infra/registry_trust_test.go
+++ b/internal/infra/registry_trust_test.go
@@ -167,6 +167,165 @@ func TestEnsureRegistryTrustRejectsInvalidCAPEM(t *testing.T) {
 	}
 }
 
+func TestInstallRegistryTrustDryRunDoesNotWriteFiles(t *testing.T) {
+	caPEM := testCAPEM(t, "controller")
+	trustDir := t.TempDir()
+	dockerCertsDir := t.TempDir()
+
+	result, err := InstallRegistryTrust(RegistryTrustInstallConfig{
+		RegistryTrustConfig: RegistryTrustConfig{
+			RegistryURL:                   "https://10.0.1.5:5000",
+			ControllerCAPEM:               caPEM,
+			ControllerCAFingerprintSHA256: sha256PEM(caPEM),
+			ControllerCertNotAfter:        time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+			TrustDir:                      trustDir,
+			DockerCertsDir:                dockerCertsDir,
+		},
+		DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Required || result.Installed || result.Trusted {
+		t.Fatalf("unexpected dry-run result: %+v", result)
+	}
+	if result.FingerprintSHA256 != sha256PEM(caPEM) {
+		t.Fatalf("fingerprint = %q, want %q", result.FingerprintSHA256, sha256PEM(caPEM))
+	}
+	if _, err := os.Stat(result.LocalCAPath); !os.IsNotExist(err) {
+		t.Fatalf("dry run should not write local CA, stat err=%v", err)
+	}
+	if _, err := os.Stat(result.DockerCAPath); !os.IsNotExist(err) {
+		t.Fatalf("dry run should not write Docker CA, stat err=%v", err)
+	}
+}
+
+func TestInstallRegistryTrustWritesCacheAndDockerCA(t *testing.T) {
+	caPEM := testCAPEM(t, "controller")
+	trustDir := t.TempDir()
+	dockerCertsDir := t.TempDir()
+
+	result, err := InstallRegistryTrust(RegistryTrustInstallConfig{
+		RegistryTrustConfig: RegistryTrustConfig{
+			RegistryURL:                   "https://heph-controller:5000",
+			ControllerCAPEM:               caPEM,
+			ControllerCAFingerprintSHA256: "sha256:" + sha256PEM(caPEM),
+			ControllerCertNotAfter:        time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+			TrustDir:                      trustDir,
+			DockerCertsDir:                dockerCertsDir,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Required || !result.Installed || !result.Trusted {
+		t.Fatalf("expected installed and trusted result, got %+v", result)
+	}
+	localCA, err := os.ReadFile(result.LocalCAPath)
+	if err != nil {
+		t.Fatalf("read local CA: %v", err)
+	}
+	if string(localCA) != caPEM {
+		t.Fatal("local CA does not match controller CA")
+	}
+	dockerCA, err := os.ReadFile(result.DockerCAPath)
+	if err != nil {
+		t.Fatalf("read Docker CA: %v", err)
+	}
+	if string(dockerCA) != caPEM {
+		t.Fatal("Docker CA does not match controller CA")
+	}
+}
+
+func TestInstallRegistryTrustExistingMatchIsTrusted(t *testing.T) {
+	caPEM := testCAPEM(t, "controller")
+	trustDir := t.TempDir()
+	dockerCertsDir := t.TempDir()
+	dockerCAPath := filepath.Join(dockerCertsDir, "10.0.1.5:5000", "ca.crt")
+	if err := os.MkdirAll(filepath.Dir(dockerCAPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dockerCAPath, []byte(caPEM), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := InstallRegistryTrust(RegistryTrustInstallConfig{
+		RegistryTrustConfig: RegistryTrustConfig{
+			RegistryURL:                   "https://10.0.1.5:5000",
+			ControllerCAPEM:               caPEM,
+			ControllerCAFingerprintSHA256: sha256PEM(caPEM),
+			ControllerCertNotAfter:        time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+			TrustDir:                      trustDir,
+			DockerCertsDir:                dockerCertsDir,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Trusted || result.Installed {
+		t.Fatalf("expected already trusted without reinstall, got %+v", result)
+	}
+}
+
+func TestInstallRegistryTrustRejectsFingerprintMismatch(t *testing.T) {
+	caPEM := testCAPEM(t, "controller")
+	_, err := InstallRegistryTrust(RegistryTrustInstallConfig{
+		RegistryTrustConfig: RegistryTrustConfig{
+			RegistryURL:                   "https://10.0.1.5:5000",
+			ControllerCAPEM:               caPEM,
+			ControllerCAFingerprintSHA256: strings.Repeat("0", 64),
+			ControllerCertNotAfter:        time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339),
+			TrustDir:                      t.TempDir(),
+			DockerCertsDir:                t.TempDir(),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected fingerprint mismatch error")
+	}
+	if !strings.Contains(err.Error(), "controller CA fingerprint mismatch") {
+		t.Fatalf("expected fingerprint mismatch error, got %q", err.Error())
+	}
+}
+
+func TestInstallRegistryTrustRequiresCertExpiry(t *testing.T) {
+	caPEM := testCAPEM(t, "controller")
+	_, err := InstallRegistryTrust(RegistryTrustInstallConfig{
+		RegistryTrustConfig: RegistryTrustConfig{
+			RegistryURL:                   "https://10.0.1.5:5000",
+			ControllerCAPEM:               caPEM,
+			ControllerCAFingerprintSHA256: sha256PEM(caPEM),
+			TrustDir:                      t.TempDir(),
+			DockerCertsDir:                t.TempDir(),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected missing expiry error")
+	}
+	if !strings.Contains(err.Error(), "controller_cert_not_after output is required") {
+		t.Fatalf("expected missing expiry error, got %q", err.Error())
+	}
+}
+
+func TestInstallRegistryTrustRejectsExpiredCert(t *testing.T) {
+	caPEM := testCAPEM(t, "controller")
+	_, err := InstallRegistryTrust(RegistryTrustInstallConfig{
+		RegistryTrustConfig: RegistryTrustConfig{
+			RegistryURL:                   "https://10.0.1.5:5000",
+			ControllerCAPEM:               caPEM,
+			ControllerCAFingerprintSHA256: sha256PEM(caPEM),
+			ControllerCertNotAfter:        time.Now().Add(-24 * time.Hour).UTC().Format(time.RFC3339),
+			TrustDir:                      t.TempDir(),
+			DockerCertsDir:                t.TempDir(),
+		},
+	})
+	if err == nil {
+		t.Fatal("expected expired certificate error")
+	}
+	if !strings.Contains(err.Error(), "controller certificate expired") {
+		t.Fatalf("expected expired certificate error, got %q", err.Error())
+	}
+}
+
 func testCAPEM(t *testing.T, commonName string) string {
 	t.Helper()
 	pub, priv, err := ed25519.GenerateKey(rand.Reader)


### PR DESCRIPTION
## Summary

  Adds an explicit operator workflow for installing provider-native controller registry trust.

  This introduces `heph infra trust install`, which reads Terraform outputs for a provider-native fleet, validates the controller TLS trust metadata, caches the controller CA locally, and
  installs it into Docker registry trust only after explicit operator confirmation.

  ## Changes

  - Add `heph infra trust install --tool <tool> --cloud <provider>`
  - Support `--dry-run`, `--auto-approve`, `--trust-dir`, and `--docker-certs-dir`
  - Validate:
    - HTTPS `registry_url`
    - parseable `controller_ca_pem`
    - matching `controller_ca_fingerprint_sha256`
    - valid, unexpired `controller_cert_not_after`
  - Install Docker registry CA trust at:
    - `/etc/docker/certs.d/<registry-host>/ca.crt`
  - Keep deploy preflight non-mutating while allowing this explicit install command to write Docker trust
  - Add focused tests for dry-run behavior, install behavior, existing trust, fingerprint mismatch, expiry validation, and CLI guardrails

  ## Testing

  - `go test -count=1 ./...`
  - `git diff --check`