### PR TITLE
test: stabilize embedded NATS harness

### DIFF
--- a/internal/cloud/selfhosted/nats_test.go
+++ b/internal/cloud/selfhosted/nats_test.go
@@ -3,45 +3,15 @@ package selfhosted
 import (
 	"context"
 	"testing"
-	"time"
 
 	"heph4estus/internal/logger"
-
-	natsserver "github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
+	"heph4estus/internal/testutil/natstest"
 )
-
-func startEmbeddedNATS(t *testing.T) *natsserver.Server {
-	t.Helper()
-	opts := &natsserver.Options{
-		Host:      "127.0.0.1",
-		Port:      -1,
-		HTTPHost:  "127.0.0.1",
-		HTTPPort:  -1,
-		NoSigs:    true,
-		NoLog:     true,
-		JetStream: true,
-		StoreDir:  t.TempDir(),
-	}
-	srv, err := natsserver.NewServer(opts)
-	if err != nil {
-		t.Fatalf("embedded nats: %v", err)
-	}
-	srv.Start()
-	if !srv.ReadyForConnections(5 * time.Second) {
-		t.Fatal("embedded nats not ready")
-	}
-	t.Cleanup(srv.Shutdown)
-	return srv
-}
 
 func newTestQueue(t *testing.T) *Queue {
 	t.Helper()
-	srv := startEmbeddedNATS(t)
-	nc, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("nats connect: %v", err)
-	}
+	srv := natstest.Start(t, natstest.Options{JetStream: true})
+	nc := natstest.Connect(t, srv)
 	t.Cleanup(nc.Close)
 	q, err := NewQueueFromConn(nc, QueueConfig{
 		StreamName:     "test",

--- a/internal/fleet/fleet_test.go
+++ b/internal/fleet/fleet_test.go
@@ -9,32 +9,8 @@ import (
 
 	"heph4estus/internal/fleetstate"
 	"heph4estus/internal/logger"
-
-	natsserver "github.com/nats-io/nats-server/v2/server"
-	"github.com/nats-io/nats.go"
+	"heph4estus/internal/testutil/natstest"
 )
-
-func startEmbeddedNATS(t *testing.T) *natsserver.Server {
-	t.Helper()
-	opts := &natsserver.Options{
-		Host:     "127.0.0.1",
-		Port:     -1,
-		HTTPHost: "127.0.0.1",
-		HTTPPort: -1,
-		NoSigs:   true,
-		NoLog:    true,
-	}
-	srv, err := natsserver.NewServer(opts)
-	if err != nil {
-		t.Fatalf("embedded nats: %v", err)
-	}
-	srv.Start()
-	if !srv.ReadyForConnections(5 * time.Second) {
-		t.Fatal("embedded nats not ready")
-	}
-	t.Cleanup(srv.Shutdown)
-	return srv
-}
 
 func TestHeartbeatMessage_Roundtrip(t *testing.T) {
 	orig := HeartbeatMessage{
@@ -203,12 +179,9 @@ func TestApplyAdmissionPolicy_RolloutCanaryRestrictsAdmission(t *testing.T) {
 }
 
 func TestNATSFleetManager_Heartbeat(t *testing.T) {
-	srv := startEmbeddedNATS(t)
+	srv := natstest.Start(t, natstest.Options{})
 
-	nc, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("nats connect: %v", err)
-	}
+	nc := natstest.Connect(t, srv)
 	t.Cleanup(nc.Close)
 
 	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
@@ -224,10 +197,7 @@ func TestNATSFleetManager_Heartbeat(t *testing.T) {
 	defer func() { _ = mgr.Close() }()
 
 	// Publish a heartbeat from a separate connection to simulate a worker.
-	pub, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("pub connect: %v", err)
-	}
+	pub := natstest.Connect(t, srv)
 	defer pub.Close()
 
 	hb := HeartbeatMessage{
@@ -275,12 +245,9 @@ func TestNATSFleetManager_Heartbeat(t *testing.T) {
 }
 
 func TestNATSFleetManager_MultipleWorkers(t *testing.T) {
-	srv := startEmbeddedNATS(t)
+	srv := natstest.Start(t, natstest.Options{})
 
-	nc, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("nats connect: %v", err)
-	}
+	nc := natstest.Connect(t, srv)
 	t.Cleanup(nc.Close)
 
 	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
@@ -293,10 +260,7 @@ func TestNATSFleetManager_MultipleWorkers(t *testing.T) {
 	}
 	defer func() { _ = mgr.Close() }()
 
-	pub, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("pub connect: %v", err)
-	}
+	pub := natstest.Connect(t, srv)
 	defer pub.Close()
 
 	for i := range 3 {
@@ -321,12 +285,9 @@ func TestNATSFleetManager_MultipleWorkers(t *testing.T) {
 }
 
 func TestNATSFleetManager_HeartbeatUpdate(t *testing.T) {
-	srv := startEmbeddedNATS(t)
+	srv := natstest.Start(t, natstest.Options{})
 
-	nc, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("nats connect: %v", err)
-	}
+	nc := natstest.Connect(t, srv)
 	t.Cleanup(nc.Close)
 
 	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
@@ -339,10 +300,7 @@ func TestNATSFleetManager_HeartbeatUpdate(t *testing.T) {
 	}
 	defer func() { _ = mgr.Close() }()
 
-	pub, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("pub connect: %v", err)
-	}
+	pub := natstest.Connect(t, srv)
 	defer pub.Close()
 
 	// First heartbeat: not ready yet.
@@ -412,12 +370,9 @@ func TestNATSFleetManager_HeartbeatUpdate(t *testing.T) {
 }
 
 func TestWorkerHealthTimeout(t *testing.T) {
-	srv := startEmbeddedNATS(t)
+	srv := natstest.Start(t, natstest.Options{})
 
-	nc, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("nats connect: %v", err)
-	}
+	nc := natstest.Connect(t, srv)
 	t.Cleanup(nc.Close)
 
 	// Use a very short health timeout for testing.
@@ -431,10 +386,7 @@ func TestWorkerHealthTimeout(t *testing.T) {
 	}
 	defer func() { _ = mgr.Close() }()
 
-	pub, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("pub connect: %v", err)
-	}
+	pub := natstest.Connect(t, srv)
 	defer pub.Close()
 
 	hb := HeartbeatMessage{
@@ -475,12 +427,9 @@ func TestWorkerHealthTimeout(t *testing.T) {
 }
 
 func TestNATSFleetManager_WaitForWorkers(t *testing.T) {
-	srv := startEmbeddedNATS(t)
+	srv := natstest.Start(t, natstest.Options{})
 
-	nc, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("nats connect: %v", err)
-	}
+	nc := natstest.Connect(t, srv)
 	t.Cleanup(nc.Close)
 
 	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
@@ -493,10 +442,7 @@ func TestNATSFleetManager_WaitForWorkers(t *testing.T) {
 	}
 	defer func() { _ = mgr.Close() }()
 
-	pub, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("pub connect: %v", err)
-	}
+	pub := natstest.Connect(t, srv)
 	defer pub.Close()
 
 	// Publish 2 ready workers before calling WaitForWorkers.
@@ -530,12 +476,9 @@ func TestNATSFleetManager_WaitForWorkers(t *testing.T) {
 }
 
 func TestNATSFleetManager_WaitForWorkers_DiversityPolicy(t *testing.T) {
-	srv := startEmbeddedNATS(t)
+	srv := natstest.Start(t, natstest.Options{})
 
-	nc, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("nats connect: %v", err)
-	}
+	nc := natstest.Connect(t, srv)
 	t.Cleanup(nc.Close)
 
 	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
@@ -552,10 +495,7 @@ func TestNATSFleetManager_WaitForWorkers_DiversityPolicy(t *testing.T) {
 	}
 	defer func() { _ = mgr.Close() }()
 
-	pub, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("pub connect: %v", err)
-	}
+	pub := natstest.Connect(t, srv)
 	defer pub.Close()
 
 	heartbeats := []HeartbeatMessage{
@@ -579,12 +519,9 @@ func TestNATSFleetManager_WaitForWorkers_DiversityPolicy(t *testing.T) {
 }
 
 func TestNATSFleetManager_WaitForWorkers_ExpectedVersion(t *testing.T) {
-	srv := startEmbeddedNATS(t)
+	srv := natstest.Start(t, natstest.Options{})
 
-	nc, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("nats connect: %v", err)
-	}
+	nc := natstest.Connect(t, srv)
 	t.Cleanup(nc.Close)
 
 	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
@@ -598,10 +535,7 @@ func TestNATSFleetManager_WaitForWorkers_ExpectedVersion(t *testing.T) {
 	}
 	defer func() { _ = mgr.Close() }()
 
-	pub, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("pub connect: %v", err)
-	}
+	pub := natstest.Connect(t, srv)
 	defer pub.Close()
 
 	heartbeats := []HeartbeatMessage{
@@ -647,12 +581,9 @@ func TestFleetState_Summarize_IPv6Policy(t *testing.T) {
 }
 
 func TestNATSFleetManager_WaitForWorkers_ContextCancel(t *testing.T) {
-	srv := startEmbeddedNATS(t)
+	srv := natstest.Start(t, natstest.Options{})
 
-	nc, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("nats connect: %v", err)
-	}
+	nc := natstest.Connect(t, srv)
 	t.Cleanup(nc.Close)
 
 	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
@@ -679,12 +610,9 @@ func TestNATSFleetManager_WaitForWorkers_ContextCancel(t *testing.T) {
 }
 
 func TestNATSFleetManager_InvalidHeartbeat(t *testing.T) {
-	srv := startEmbeddedNATS(t)
+	srv := natstest.Start(t, natstest.Options{})
 
-	nc, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("nats connect: %v", err)
-	}
+	nc := natstest.Connect(t, srv)
 	t.Cleanup(nc.Close)
 
 	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
@@ -697,10 +625,7 @@ func TestNATSFleetManager_InvalidHeartbeat(t *testing.T) {
 	}
 	defer func() { _ = mgr.Close() }()
 
-	pub, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("pub connect: %v", err)
-	}
+	pub := natstest.Connect(t, srv)
 	defer pub.Close()
 
 	// Publish garbage data.
@@ -721,12 +646,9 @@ func TestNATSFleetManager_InvalidHeartbeat(t *testing.T) {
 }
 
 func TestNATSFleetManager_IgnoresMismatchedGeneration(t *testing.T) {
-	srv := startEmbeddedNATS(t)
+	srv := natstest.Start(t, natstest.Options{})
 
-	nc, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("nats connect: %v", err)
-	}
+	nc := natstest.Connect(t, srv)
 	t.Cleanup(nc.Close)
 
 	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
@@ -740,10 +662,7 @@ func TestNATSFleetManager_IgnoresMismatchedGeneration(t *testing.T) {
 	}
 	defer func() { _ = mgr.Close() }()
 
-	pub, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("pub connect: %v", err)
-	}
+	pub := natstest.Connect(t, srv)
 	defer pub.Close()
 
 	hb := HeartbeatMessage{
@@ -771,12 +690,9 @@ func TestNATSFleetManager_IgnoresMismatchedGeneration(t *testing.T) {
 }
 
 func TestNATSFleetManager_Close(t *testing.T) {
-	srv := startEmbeddedNATS(t)
+	srv := natstest.Start(t, natstest.Options{})
 
-	nc, err := nats.Connect(srv.ClientURL())
-	if err != nil {
-		t.Fatalf("nats connect: %v", err)
-	}
+	nc := natstest.Connect(t, srv)
 
 	mgr, err := NewNATSFleetManagerFromConn(nc, NATSFleetManagerConfig{
 		DesiredWorkers: 1,

--- a/internal/testutil/natstest/natstest.go
+++ b/internal/testutil/natstest/natstest.go
@@ -1,0 +1,112 @@
+package natstest
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	natsserver "github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+)
+
+const startupTimeout = 10 * time.Second
+
+type Options struct {
+	JetStream bool
+}
+
+func Start(t *testing.T, opts Options) *natsserver.Server {
+	t.Helper()
+
+	serverOpts := &natsserver.Options{
+		Host:       "127.0.0.1",
+		Port:       -1,
+		DontListen: true,
+		NoSigs:     true,
+		NoLog:      true,
+	}
+	if opts.JetStream {
+		serverOpts.JetStream = true
+		serverOpts.StoreDir = t.TempDir()
+	}
+
+	srv, err := natsserver.NewServer(serverOpts)
+	if err != nil {
+		t.Fatalf("embedded nats: %v", err)
+	}
+
+	log := &memoryLogger{}
+	srv.SetLogger(log, false, false)
+
+	go srv.Start()
+	if !srv.ReadyForConnections(startupTimeout) {
+		srv.Shutdown()
+		srv.WaitForShutdown()
+		t.Fatalf("embedded nats not ready after %s (jetstream=%t, url=%q): %s", startupTimeout, opts.JetStream, srv.ClientURL(), log.String())
+	}
+
+	probe := Connect(t, srv, nats.Name("heph-test-readiness-probe"))
+	probe.Close()
+
+	t.Cleanup(func() {
+		srv.Shutdown()
+		srv.WaitForShutdown()
+	})
+	return srv
+}
+
+func Connect(t *testing.T, srv *natsserver.Server, opts ...nats.Option) *nats.Conn {
+	t.Helper()
+	connectOpts := []nats.Option{
+		nats.SetCustomDialer(inProcessDialer{srv: srv}),
+		nats.NoReconnect(),
+		nats.Timeout(2 * time.Second),
+	}
+	connectOpts = append(connectOpts, opts...)
+	nc, err := nats.Connect("nats://in-process", connectOpts...)
+	if err != nil {
+		t.Fatalf("embedded nats connect: %v", err)
+	}
+	return nc
+}
+
+type inProcessDialer struct {
+	srv *natsserver.Server
+}
+
+func (d inProcessDialer) Dial(_, _ string) (net.Conn, error) {
+	if d.srv == nil {
+		return nil, fmt.Errorf("embedded nats server is nil")
+	}
+	return d.srv.InProcessConn()
+}
+
+type memoryLogger struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *memoryLogger) Noticef(format string, v ...any) { l.append("notice", format, v...) }
+func (l *memoryLogger) Warnf(format string, v ...any)   { l.append("warn", format, v...) }
+func (l *memoryLogger) Fatalf(format string, v ...any)  { l.append("fatal", format, v...) }
+func (l *memoryLogger) Errorf(format string, v ...any)  { l.append("error", format, v...) }
+func (l *memoryLogger) Debugf(format string, v ...any)  { l.append("debug", format, v...) }
+func (l *memoryLogger) Tracef(format string, v ...any)  { l.append("trace", format, v...) }
+
+func (l *memoryLogger) append(level, format string, v ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.lines = append(l.lines, level+": "+fmt.Sprintf(format, v...))
+}
+
+func (l *memoryLogger) String() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(l.lines) == 0 {
+		return "no server logs captured"
+	}
+	return strings.Join(l.lines, "; ")
+}


### PR DESCRIPTION
## Summary

  - Adds a shared `internal/testutil/natstest` helper for embedded NATS tests.
  - Uses NATS `Server.InProcessConn()` with a custom client dialer so tests no longer require local TCP listener
  permissions.
  - Replaces duplicated embedded NATS startup helpers in selfhosted queue and fleet tests.
  - Keeps the NATS-backed tests active; no tests are skipped or weakened.

  ## Testing

  - `env GOCACHE=/tmp/heph-go-build go test -run TestSendThenReceive -count=1 -v ./internal/cloud/selfhosted`
  - `env GOCACHE=/tmp/heph-go-build go test -run TestNATSFleetManager_Heartbeat -count=1 -v ./internal/fleet`
  - `env GOCACHE=/tmp/heph-go-build go test -count=5 ./internal/cloud/selfhosted`
  - `env GOCACHE=/tmp/heph-go-build go test -count=5 ./internal/fleet`
  - `env GOCACHE=/tmp/heph-go-build go test ./...`
  - `git diff --check`