### PR TITLE
feat(wordlist): scale wordlist distribution for large inputs

### DIFF
--- a/cmd/heph/cmd_lifecycle_test.go
+++ b/cmd/heph/cmd_lifecycle_test.go
@@ -115,7 +115,68 @@ func TestPreflightWordlistFileRejectsEmptyWordlist(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if !strings.Contains(err.Error(), "planning wordlist job") {
+	if !strings.Contains(err.Error(), "no entries found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPreflightWordlistFileAutoSizesOmittedChunks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "words.txt")
+	if err := os.WriteFile(path, []byte("a\nb\nc\n"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	meta, err := preflightWordlistFile("ffuf", path, "https://example.com/FUZZ", "", 0, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if meta.TotalWords != 3 {
+		t.Fatalf("TotalWords = %d, want 3", meta.TotalWords)
+	}
+	if meta.EffectiveChunks != 2 {
+		t.Fatalf("EffectiveChunks = %d, want 2", meta.EffectiveChunks)
+	}
+}
+
+func TestPreflightWordlistFileHonorsExplicitChunks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "words.txt")
+	if err := os.WriteFile(path, []byte("a\nb\nc\n"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	meta, err := preflightWordlistFile("ffuf", path, "https://example.com/FUZZ", "", 3, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if meta.RequestedChunks != 3 || meta.EffectiveChunks != 3 {
+		t.Fatalf("requested/effective chunks = %d/%d, want 3/3", meta.RequestedChunks, meta.EffectiveChunks)
+	}
+}
+
+func TestPreflightWordlistFileRejectsDirectory(t *testing.T) {
+	_, err := preflightWordlistFile("ffuf", t.TempDir(), "https://example.com/FUZZ", "", 0, 2)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPreflightWordlistFileRejectsUnsafeExplicitChunkSizing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "huge-words.txt")
+	if err := os.WriteFile(path, []byte("a\n"), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	if err := os.Truncate(path, 65*1024*1024); err != nil {
+		t.Fatalf("truncate temp file: %v", err)
+	}
+
+	_, err := preflightWordlistFile("ffuf", path, "https://example.com/FUZZ", "", 1, 1)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "increase --chunks") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/cmd/heph/cmd_scan.go
+++ b/cmd/heph/cmd_scan.go
@@ -19,6 +19,7 @@ import (
 	"heph4estus/internal/logger"
 	"heph4estus/internal/modules"
 	"heph4estus/internal/operator"
+	wordlisttool "heph4estus/internal/tools/wordlist"
 	"heph4estus/internal/worker"
 )
 
@@ -28,7 +29,7 @@ func runScan(args []string, log logger.Logger) error {
 	inputFile := fs.String("file", "", "Path to file containing targets (target_list modules)")
 	wordlistFile := fs.String("wordlist", "", "Path to wordlist file (wordlist modules)")
 	runtimeTarget := fs.String("target", "", "Runtime target / URL (wordlist modules, e.g. https://example.com/FUZZ)")
-	chunks := fs.Int("chunks", 0, "Number of wordlist chunks (default: worker count)")
+	chunks := fs.Int("chunks", 0, "Number of wordlist chunks (default: auto-size from file size and workers)")
 	options := fs.String("options", "", "Extra tool-specific options")
 	workers := fs.Int("workers", 0, "Number of worker tasks to launch (default: from config or 10)")
 	computeMode := fs.String("compute-mode", "", "Compute mode: auto, fargate, or spot (default: from config or auto)")
@@ -128,9 +129,9 @@ func runScan(args []string, log logger.Logger) error {
 
 	// Validate local inputs before any lifecycle side effects.
 	var targetContent string
-	var wordlistContent string
+	var wordlistMeta *wordlisttool.Metadata
 	if mod.InputType == modules.InputTypeWordlist {
-		wordlistContent, err = preflightWordlistFile(*tool, *wordlistFile, *runtimeTarget, *options, *chunks, *workers)
+		wordlistMeta, err = preflightWordlistFile(*tool, *wordlistFile, *runtimeTarget, *options, *chunks, *workers)
 		if err != nil {
 			return err
 		}
@@ -249,7 +250,7 @@ func runScan(args []string, log logger.Logger) error {
 		started bool
 	)
 	if mod.InputType == modules.InputTypeWordlist {
-		started, scanErr = runWordlistScan(ctx, *tool, jobID, *wordlistFile, wordlistContent, *runtimeTarget, *options, *chunks, *workers, *computeMode, *format, queue, storage, compute, outputs, bucket, queueURL, tracker, cloudKind, placementPolicy)
+		started, scanErr = runWordlistScan(ctx, *tool, jobID, *wordlistFile, wordlistMeta, *runtimeTarget, *options, *chunks, *workers, *computeMode, *format, queue, storage, compute, outputs, bucket, queueURL, tracker, cloudKind, placementPolicy)
 	} else {
 		started, scanErr = runTargetListScan(ctx, *tool, jobID, *inputFile, targetContent, *options, *workers, *computeMode, *format, queue, storage, compute, outputs, bucket, queueURL, tracker, cloudKind, placementPolicy)
 	}
@@ -360,17 +361,37 @@ func runTargetListScan(ctx context.Context, tool, jobID, inputFile, content, opt
 	return true, pollAndOutput(ctx, storage, bucket, tool, jobID, len(tasks), "targets", format)
 }
 
-func runWordlistScan(ctx context.Context, tool, jobID, wordlistFile, content, runtimeTarget, options string, chunks, workers int, computeMode, format string, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, outputs map[string]string, bucket, queueURL string, tracker *operator.Tracker, cloudKind cloud.Kind, placementPolicy fleet.PlacementPolicy) (bool, error) {
-	if chunks <= 0 {
-		chunks = workers
+func runWordlistScan(ctx context.Context, tool, jobID, wordlistFile string, preflight *wordlisttool.Metadata, runtimeTarget, options string, chunks, workers int, computeMode, format string, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, outputs map[string]string, bucket, queueURL string, tracker *operator.Tracker, cloudKind cloud.Kind, placementPolicy fleet.PlacementPolicy) (bool, error) {
+	tempDir, err := os.MkdirTemp("", "heph-wordlist-*")
+	if err != nil {
+		return false, fmt.Errorf("creating wordlist temp dir: %w", err)
 	}
+	defer os.RemoveAll(tempDir)
 
-	plan, err := jobs.PlanWordlistJob(tool, jobID, runtimeTarget, options, content, chunks)
+	plan, err := jobs.PlanWordlistFile(tool, jobID, runtimeTarget, options, wordlistFile, tempDir, chunks, workers)
 	if err != nil {
 		return false, fmt.Errorf("planning wordlist job: %w", err)
 	}
+	defer plan.Cleanup()
 
-	logStatus("Parsed %d entries from %s, splitting into %d chunks [job %s]", plan.TotalWords, wordlistFile, len(plan.Tasks), jobID)
+	requested := "auto"
+	if chunks > 0 {
+		requested = strconv.Itoa(chunks)
+	}
+	sourceBytes := plan.TotalSourceBytes
+	if preflight != nil && preflight.TotalSourceBytes > 0 {
+		sourceBytes = preflight.TotalSourceBytes
+	}
+	logStatus("Parsed %d entries from %s (%s); chunks requested=%s effective=%d target=%s max=%s [job %s]",
+		plan.TotalWords,
+		wordlistFile,
+		formatByteSize(sourceBytes),
+		requested,
+		plan.EffectiveChunks,
+		formatByteSize(plan.TargetChunkSize),
+		formatByteSize(plan.MaxChunkSize),
+		jobID,
+	)
 	if runtimeTarget != "" {
 		logStatus("Target: %s", runtimeTarget)
 	}
@@ -379,7 +400,7 @@ func runWordlistScan(ctx context.Context, tool, jobID, wordlistFile, content, ru
 	_ = tracker.UpdatePhase(jobID, operator.PhaseUploading)
 	if store := tracker.Store(); store != nil {
 		if rec, loadErr := store.Load(jobID); loadErr == nil {
-			rec.TotalTasks = len(plan.Tasks)
+			rec.TotalTasks = plan.EffectiveChunks
 			rec.TotalWords = plan.TotalWords
 			rec.RuntimeTarget = runtimeTarget
 			_ = store.Update(rec)
@@ -387,7 +408,7 @@ func runWordlistScan(ctx context.Context, tool, jobID, wordlistFile, content, ru
 	}
 
 	// Upload chunks.
-	logStatus("Uploading %d chunks to s3://%s/...", len(plan.Tasks), bucket)
+	logStatus("Uploading %d chunks to s3://%s/...", plan.EffectiveChunks, bucket)
 	uploadCtx, uploadCancel := context.WithTimeout(ctx, enqueueTimeout)
 	defer uploadCancel()
 	if err := jobs.UploadChunks(uploadCtx, storage, bucket, plan); err != nil {
@@ -412,6 +433,9 @@ func runWordlistScan(ctx context.Context, tool, jobID, wordlistFile, content, ru
 		return false, fmt.Errorf("enqueueing chunk tasks: %w", err)
 	}
 	logStatus("Enqueued %d chunk tasks", len(plan.Tasks))
+	if err := plan.Cleanup(); err != nil {
+		logStatus("Warning: failed to clean temporary wordlist chunks: %v", err)
+	}
 
 	_ = tracker.UpdatePhase(jobID, operator.PhaseLaunching)
 
@@ -437,18 +461,23 @@ func preflightTargetListFile(path string) (string, error) {
 	return string(content), nil
 }
 
-func preflightWordlistFile(tool, path, runtimeTarget, options string, chunks, workers int) (string, error) {
-	content, err := os.ReadFile(path)
+func preflightWordlistFile(_, path, _, _ string, chunks, workers int) (*wordlisttool.Metadata, error) {
+	meta, err := wordlisttool.InspectFile(path, wordlisttool.Policy{
+		RequestedChunks: chunks,
+		WorkerCount:     workers,
+	})
 	if err != nil {
-		return "", fmt.Errorf("reading wordlist file: %w", err)
+		return nil, fmt.Errorf("validating wordlist file: %w", err)
 	}
-	if chunks <= 0 {
-		chunks = workers
+	return meta, nil
+}
+
+func formatByteSize(n int64) string {
+	const mib = 1024 * 1024
+	if n%mib == 0 && n >= mib {
+		return fmt.Sprintf("%d MiB", n/mib)
 	}
-	if _, err := jobs.PlanWordlistJob(tool, "preflight", runtimeTarget, options, string(content), chunks); err != nil {
-		return "", fmt.Errorf("planning wordlist job: %w", err)
-	}
-	return string(content), nil
+	return fmt.Sprintf("%d bytes", n)
 }
 
 func launchGenericWorkers(ctx context.Context, tool string, workers int, computeMode string, compute cloud.Compute, outputs map[string]string, queueURL, bucket string, cloudKind cloud.Kind, placementPolicy fleet.PlacementPolicy) error {

--- a/cmd/heph/cmd_scan.go
+++ b/cmd/heph/cmd_scan.go
@@ -366,13 +366,21 @@ func runWordlistScan(ctx context.Context, tool, jobID, wordlistFile string, pref
 	if err != nil {
 		return false, fmt.Errorf("creating wordlist temp dir: %w", err)
 	}
-	defer os.RemoveAll(tempDir)
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			logStatus("Warning: failed to remove wordlist temp dir %s: %v", tempDir, err)
+		}
+	}()
 
 	plan, err := jobs.PlanWordlistFile(tool, jobID, runtimeTarget, options, wordlistFile, tempDir, chunks, workers)
 	if err != nil {
 		return false, fmt.Errorf("planning wordlist job: %w", err)
 	}
-	defer plan.Cleanup()
+	defer func() {
+		if err := plan.Cleanup(); err != nil {
+			logStatus("Warning: failed to clean temporary wordlist chunks: %v", err)
+		}
+	}()
 
 	requested := "auto"
 	if chunks > 0 {

--- a/internal/jobs/wordlist.go
+++ b/internal/jobs/wordlist.go
@@ -4,9 +4,11 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"heph4estus/internal/cloud"
+	wordlisttool "heph4estus/internal/tools/wordlist"
 	"heph4estus/internal/worker"
 )
 
@@ -43,10 +45,40 @@ func ChunkEntries(entries []string, n int) [][]string {
 
 // WordlistPlan holds the prepared chunk tasks and their upload keys.
 type WordlistPlan struct {
-	Tasks      []worker.Task
-	ChunkData  [][]byte  // raw bytes to upload per chunk
-	ChunkKeys  []string  // S3 keys for each chunk
-	TotalWords int
+	Tasks []worker.Task
+
+	// ChunkData is used by the legacy in-memory planner.
+	ChunkData [][]byte
+	// ChunkFiles is used by the streaming file-based planner.
+	ChunkFiles []WordlistChunk
+	ChunkKeys  []string
+
+	TotalWords       int
+	TotalSourceBytes int64
+	EffectiveChunks  int
+	RequestedChunks  int
+	TargetChunkSize  int64
+	MaxChunkSize     int64
+
+	cleanup func() error
+}
+
+// WordlistChunk describes a temporary chunk file prepared for upload.
+type WordlistChunk struct {
+	Path        string
+	Key         string
+	ByteSize    int64
+	WordCount   int
+	Index       int
+	TotalChunks int
+}
+
+// Cleanup removes temporary chunk files for file-based plans.
+func (p *WordlistPlan) Cleanup() error {
+	if p == nil || p.cleanup == nil {
+		return nil
+	}
+	return p.cleanup()
 }
 
 // PlanWordlistJob splits a wordlist into chunks and prepares tasks.
@@ -60,10 +92,11 @@ func PlanWordlistJob(toolName, jobID, runtimeTarget, options string, wordlistCon
 	groupID := SafeTargetStem(runtimeTarget)
 
 	plan := &WordlistPlan{
-		Tasks:      make([]worker.Task, len(chunks)),
-		ChunkData:  make([][]byte, len(chunks)),
-		ChunkKeys:  make([]string, len(chunks)),
-		TotalWords: len(entries),
+		Tasks:           make([]worker.Task, len(chunks)),
+		ChunkData:       make([][]byte, len(chunks)),
+		ChunkKeys:       make([]string, len(chunks)),
+		TotalWords:      len(entries),
+		EffectiveChunks: len(chunks),
 	}
 
 	for i, chunk := range chunks {
@@ -85,11 +118,81 @@ func PlanWordlistJob(toolName, jobID, runtimeTarget, options string, wordlistCon
 	return plan, nil
 }
 
+// PlanWordlistFile splits a wordlist file into temporary chunk files and prepares tasks.
+func PlanWordlistFile(toolName, jobID, runtimeTarget, options, wordlistPath, tempDir string, chunkCount, workerCount int) (*WordlistPlan, error) {
+	result, err := wordlisttool.SplitFile(wordlistPath, tempDir, wordlisttool.Policy{
+		RequestedChunks: chunkCount,
+		WorkerCount:     workerCount,
+	}, func(i int) string {
+		return InputKey(toolName, jobID, i)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	groupID := SafeTargetStem(runtimeTarget)
+	plan := &WordlistPlan{
+		Tasks:            make([]worker.Task, len(result.Chunks)),
+		ChunkFiles:       make([]WordlistChunk, len(result.Chunks)),
+		ChunkKeys:        make([]string, len(result.Chunks)),
+		TotalWords:       result.TotalWords,
+		TotalSourceBytes: result.TotalSourceBytes,
+		EffectiveChunks:  result.EffectiveChunks,
+		RequestedChunks:  result.RequestedChunks,
+		TargetChunkSize:  result.TargetChunkSize,
+		MaxChunkSize:     result.MaxChunkSize,
+		cleanup:          result.Cleanup,
+	}
+
+	for i, chunk := range result.Chunks {
+		plan.ChunkKeys[i] = chunk.Key
+		plan.ChunkFiles[i] = WordlistChunk{
+			Path:        chunk.Path,
+			Key:         chunk.Key,
+			ByteSize:    chunk.ByteSize,
+			WordCount:   chunk.WordCount,
+			Index:       chunk.Index,
+			TotalChunks: chunk.TotalChunks,
+		}
+		plan.Tasks[i] = worker.Task{
+			ToolName:    toolName,
+			JobID:       jobID,
+			Target:      runtimeTarget,
+			InputKey:    chunk.Key,
+			Options:     options,
+			GroupID:     groupID,
+			ChunkIdx:    chunk.Index,
+			TotalChunks: chunk.TotalChunks,
+		}
+	}
+
+	return plan, nil
+}
+
 // UploadChunks uploads all chunk files to storage.
 func UploadChunks(ctx context.Context, storage cloud.Storage, bucket string, plan *WordlistPlan) error {
+	if len(plan.ChunkFiles) > 0 {
+		for _, chunk := range plan.ChunkFiles {
+			if chunk.ByteSize > plan.MaxChunkSize && plan.MaxChunkSize > 0 {
+				return fmt.Errorf("chunk %d (%s) is %d bytes, above max safe chunk size %d", chunk.Index, chunk.Key, chunk.ByteSize, plan.MaxChunkSize)
+			}
+			data, err := os.ReadFile(chunk.Path)
+			if err != nil {
+				return fmt.Errorf("reading chunk %d (%s): %w", chunk.Index, chunk.Key, err)
+			}
+			if int64(len(data)) > plan.MaxChunkSize && plan.MaxChunkSize > 0 {
+				return fmt.Errorf("chunk %d (%s) is %d bytes, above max safe chunk size %d", chunk.Index, chunk.Key, len(data), plan.MaxChunkSize)
+			}
+			if err := storage.Upload(ctx, bucket, chunk.Key, data); err != nil {
+				return fmt.Errorf("uploading chunk %d (%s): %w", chunk.Index, chunk.Key, err)
+			}
+		}
+		return nil
+	}
+
 	for i, data := range plan.ChunkData {
 		if err := storage.Upload(ctx, bucket, plan.ChunkKeys[i], data); err != nil {
-			return fmt.Errorf("uploading chunk %d: %w", i, err)
+			return fmt.Errorf("uploading chunk %d (%s): %w", i, plan.ChunkKeys[i], err)
 		}
 	}
 	return nil

--- a/internal/jobs/wordlist.go
+++ b/internal/jobs/wordlist.go
@@ -78,7 +78,9 @@ func (p *WordlistPlan) Cleanup() error {
 	if p == nil || p.cleanup == nil {
 		return nil
 	}
-	return p.cleanup()
+	cleanup := p.cleanup
+	p.cleanup = nil
+	return cleanup()
 }
 
 // PlanWordlistJob splits a wordlist into chunks and prepares tasks.

--- a/internal/jobs/wordlist_test.go
+++ b/internal/jobs/wordlist_test.go
@@ -10,6 +10,13 @@ import (
 	"testing"
 )
 
+func cleanupWordlistPlan(t *testing.T, plan *WordlistPlan) {
+	t.Helper()
+	if err := plan.Cleanup(); err != nil {
+		t.Fatalf("cleanup wordlist plan: %v", err)
+	}
+}
+
 func TestParseWordlistEntries(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -163,7 +170,7 @@ func TestPlanWordlistFileCreatesCompatibleTasks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer plan.Cleanup()
+	defer cleanupWordlistPlan(t, plan)
 
 	if plan.TotalWords != 4 {
 		t.Fatalf("TotalWords = %d, want 4", plan.TotalWords)
@@ -212,7 +219,7 @@ func TestPlanWordlistFileInputKeysRemainStable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer plan.Cleanup()
+	defer cleanupWordlistPlan(t, plan)
 
 	for i, task := range plan.Tasks {
 		want := InputKey("gobuster", "job-abc", i)
@@ -257,7 +264,7 @@ func TestUploadChunksReadsFileChunksOneAtATime(t *testing.T) {
 	if err != nil {
 		t.Fatalf("plan wordlist file: %v", err)
 	}
-	defer plan.Cleanup()
+	defer cleanupWordlistPlan(t, plan)
 
 	storage := &recordingStorage{}
 	if err := UploadChunks(context.Background(), storage, "bucket", plan); err != nil {
@@ -285,7 +292,7 @@ func TestUploadChunksFailureIncludesChunkIndexAndKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("plan wordlist file: %v", err)
 	}
-	defer plan.Cleanup()
+	defer cleanupWordlistPlan(t, plan)
 
 	failKey := InputKey("ffuf", "job-123", 1)
 	err = UploadChunks(context.Background(), &recordingStorage{failKey: failKey}, "bucket", plan)

--- a/internal/jobs/wordlist_test.go
+++ b/internal/jobs/wordlist_test.go
@@ -1,6 +1,10 @@
 package jobs
 
 import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -145,6 +149,174 @@ func TestPlanWordlistJobEmptyWordlist(t *testing.T) {
 	_, err := PlanWordlistJob("ffuf", "job-123", "https://example.com/FUZZ", "", "\n\n", 2)
 	if err == nil {
 		t.Fatal("expected error for empty wordlist")
+	}
+}
+
+func TestPlanWordlistFileCreatesCompatibleTasks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "words.txt")
+	content := "admin\nlogin\napi\ntest\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write wordlist: %v", err)
+	}
+
+	plan, err := PlanWordlistFile("ffuf", "job-123", "https://example.com/FUZZ", "-ac", path, t.TempDir(), 2, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer plan.Cleanup()
+
+	if plan.TotalWords != 4 {
+		t.Fatalf("TotalWords = %d, want 4", plan.TotalWords)
+	}
+	if plan.TotalSourceBytes != int64(len(content)) {
+		t.Fatalf("TotalSourceBytes = %d, want %d", plan.TotalSourceBytes, len(content))
+	}
+	if plan.EffectiveChunks != 2 {
+		t.Fatalf("EffectiveChunks = %d, want 2", plan.EffectiveChunks)
+	}
+	if len(plan.ChunkData) != 0 {
+		t.Fatalf("file-based plan should not keep ChunkData, got %d entries", len(plan.ChunkData))
+	}
+	if len(plan.ChunkFiles) != 2 || len(plan.Tasks) != 2 {
+		t.Fatalf("chunks/tasks = %d/%d, want 2/2", len(plan.ChunkFiles), len(plan.Tasks))
+	}
+
+	task := plan.Tasks[0]
+	if task.ToolName != "ffuf" || task.JobID != "job-123" {
+		t.Fatalf("unexpected task identity: %#v", task)
+	}
+	if task.InputKey != "scans/ffuf/job-123/inputs/chunk_0.txt" {
+		t.Fatalf("InputKey = %q", task.InputKey)
+	}
+	if task.ChunkIdx != 0 || task.TotalChunks != 2 {
+		t.Fatalf("chunk metadata = %d/%d, want 0/2", task.ChunkIdx, task.TotalChunks)
+	}
+	if task.GroupID != SafeTargetStem("https://example.com/FUZZ") {
+		t.Fatalf("GroupID = %q", task.GroupID)
+	}
+	if plan.ChunkFiles[0].Key != task.InputKey {
+		t.Fatalf("chunk key = %q, task key = %q", plan.ChunkFiles[0].Key, task.InputKey)
+	}
+	if plan.ChunkFiles[0].ByteSize == 0 || plan.ChunkFiles[0].WordCount == 0 {
+		t.Fatalf("chunk metadata not populated: %#v", plan.ChunkFiles[0])
+	}
+}
+
+func TestPlanWordlistFileInputKeysRemainStable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "words.txt")
+	if err := os.WriteFile(path, []byte("a\nb\nc\n"), 0o644); err != nil {
+		t.Fatalf("write wordlist: %v", err)
+	}
+
+	plan, err := PlanWordlistFile("gobuster", "job-abc", "example.com", "", path, t.TempDir(), 3, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer plan.Cleanup()
+
+	for i, task := range plan.Tasks {
+		want := InputKey("gobuster", "job-abc", i)
+		if task.InputKey != want {
+			t.Fatalf("task %d InputKey = %q, want %q", i, task.InputKey, want)
+		}
+	}
+}
+
+type uploadRecord struct {
+	key  string
+	size int
+}
+
+type recordingStorage struct {
+	uploads       []uploadRecord
+	failKey       string
+	maxUploadSize int
+}
+
+func (s *recordingStorage) Upload(_ context.Context, _, key string, data []byte) error {
+	if key == s.failKey {
+		return errors.New("upload failed")
+	}
+	s.uploads = append(s.uploads, uploadRecord{key: key, size: len(data)})
+	if len(data) > s.maxUploadSize {
+		s.maxUploadSize = len(data)
+	}
+	return nil
+}
+
+func (s *recordingStorage) Download(context.Context, string, string) ([]byte, error) { return nil, nil }
+func (s *recordingStorage) List(context.Context, string, string) ([]string, error)   { return nil, nil }
+func (s *recordingStorage) Count(context.Context, string, string) (int, error)       { return 0, nil }
+
+func TestUploadChunksReadsFileChunksOneAtATime(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "words.txt")
+	if err := os.WriteFile(path, []byte("a\nb\nc\nd\n"), 0o644); err != nil {
+		t.Fatalf("write wordlist: %v", err)
+	}
+	plan, err := PlanWordlistFile("ffuf", "job-123", "https://example.com/FUZZ", "", path, t.TempDir(), 2, 1)
+	if err != nil {
+		t.Fatalf("plan wordlist file: %v", err)
+	}
+	defer plan.Cleanup()
+
+	storage := &recordingStorage{}
+	if err := UploadChunks(context.Background(), storage, "bucket", plan); err != nil {
+		t.Fatalf("upload chunks: %v", err)
+	}
+	if len(storage.uploads) != 2 {
+		t.Fatalf("uploads = %d, want 2", len(storage.uploads))
+	}
+	for i, upload := range storage.uploads {
+		if upload.size != int(plan.ChunkFiles[i].ByteSize) {
+			t.Fatalf("upload %d size = %d, want %d", i, upload.size, plan.ChunkFiles[i].ByteSize)
+		}
+		if upload.size > int(plan.MaxChunkSize) {
+			t.Fatalf("upload %d exceeded max chunk size: %d", i, upload.size)
+		}
+	}
+}
+
+func TestUploadChunksFailureIncludesChunkIndexAndKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "words.txt")
+	if err := os.WriteFile(path, []byte("a\nb\n"), 0o644); err != nil {
+		t.Fatalf("write wordlist: %v", err)
+	}
+	plan, err := PlanWordlistFile("ffuf", "job-123", "https://example.com/FUZZ", "", path, t.TempDir(), 2, 1)
+	if err != nil {
+		t.Fatalf("plan wordlist file: %v", err)
+	}
+	defer plan.Cleanup()
+
+	failKey := InputKey("ffuf", "job-123", 1)
+	err = UploadChunks(context.Background(), &recordingStorage{failKey: failKey}, "bucket", plan)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "chunk 1") || !strings.Contains(err.Error(), failKey) {
+		t.Fatalf("error should include chunk index and key, got %v", err)
+	}
+}
+
+func TestUploadChunksRejectsOversizedChunkBeforeRead(t *testing.T) {
+	plan := &WordlistPlan{
+		MaxChunkSize: 10,
+		ChunkFiles: []WordlistChunk{{
+			Path:     filepath.Join(t.TempDir(), "missing.txt"),
+			Key:      "scans/ffuf/job-123/inputs/chunk_0.txt",
+			ByteSize: 11,
+			Index:    0,
+		}},
+	}
+
+	err := UploadChunks(context.Background(), &recordingStorage{}, "bucket", plan)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "above max safe chunk size") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(err.Error(), "reading chunk") {
+		t.Fatalf("expected max-size error before reading file, got %v", err)
 	}
 }
 

--- a/internal/tools/wordlist/splitter.go
+++ b/internal/tools/wordlist/splitter.go
@@ -1,0 +1,389 @@
+package wordlist
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	DefaultTargetChunkSize int64 = 16 * 1024 * 1024
+	MaxSafeChunkSize       int64 = 64 * 1024 * 1024
+	ScannerMaxTokenSize          = 16 * 1024 * 1024
+)
+
+// Policy controls wordlist chunk planning.
+type Policy struct {
+	RequestedChunks     int
+	WorkerCount         int
+	TargetChunkSize     int64
+	MaxChunkSize        int64
+	ScannerMaxTokenSize int
+}
+
+// Metadata is the bounded-memory preflight result for a wordlist file.
+type Metadata struct {
+	Path             string
+	TotalWords       int
+	TotalSourceBytes int64
+	EffectiveChunks  int
+	RequestedChunks  int
+	TargetChunkSize  int64
+	MaxChunkSize     int64
+	totalEntryBytes  int64
+}
+
+// Chunk describes one temporary chunk file and its final upload key.
+type Chunk struct {
+	Path        string
+	Key         string
+	ByteSize    int64
+	WordCount   int
+	Index       int
+	TotalChunks int
+}
+
+// Result contains the streaming split result and per-chunk metadata.
+type Result struct {
+	Metadata
+	Chunks []Chunk
+}
+
+// Cleanup removes all temporary chunk files produced by SplitFile.
+func (r *Result) Cleanup() error {
+	if r == nil {
+		return nil
+	}
+	var errs []error
+	for _, chunk := range r.Chunks {
+		if chunk.Path == "" {
+			continue
+		}
+		if err := os.Remove(chunk.Path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// InspectFile validates a wordlist path and returns lightweight metadata
+// without keeping file contents in memory.
+func InspectFile(path string, policy Policy) (*Metadata, error) {
+	policy = policy.withDefaults()
+	if policy.RequestedChunks < 0 {
+		return nil, fmt.Errorf("requested chunk count must be positive")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat wordlist file: %w", err)
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("wordlist path %q is a directory", path)
+	}
+
+	sourceBytes := info.Size()
+	if policy.RequestedChunks > 0 {
+		avg := ceilDiv(sourceBytes, int64(policy.RequestedChunks))
+		if avg > policy.MaxChunkSize {
+			return nil, fmt.Errorf("requested chunk count %d would average %s per chunk, above max safe chunk size %s; increase --chunks", policy.RequestedChunks, formatBytes(avg), formatBytes(policy.MaxChunkSize))
+		}
+	}
+
+	words, entryBytes, err := scanWordlistStats(path, policy.ScannerMaxTokenSize)
+	if err != nil {
+		return nil, err
+	}
+	if words == 0 {
+		return nil, fmt.Errorf("no entries found in wordlist")
+	}
+
+	effective := effectiveChunkCount(sourceBytes, words, policy)
+	return &Metadata{
+		Path:             path,
+		TotalWords:       words,
+		TotalSourceBytes: sourceBytes,
+		EffectiveChunks:  effective,
+		RequestedChunks:  policy.RequestedChunks,
+		TargetChunkSize:  policy.TargetChunkSize,
+		MaxChunkSize:     policy.MaxChunkSize,
+		totalEntryBytes:  entryBytes,
+	}, nil
+}
+
+// SplitFile streams path into temporary chunk files under tempDir. Non-empty
+// entries are preserved exactly except that chunks are newline-terminated.
+func SplitFile(path, tempDir string, policy Policy, keyForChunk func(int) string) (*Result, error) {
+	meta, err := InspectFile(path, policy)
+	if err != nil {
+		return nil, err
+	}
+	result, err := splitWithMetadata(meta, tempDir, policy.withDefaults(), keyForChunk)
+	if err != nil {
+		if result != nil {
+			_ = result.Cleanup()
+		}
+		return nil, err
+	}
+	return result, nil
+}
+
+func splitWithMetadata(meta *Metadata, tempDir string, policy Policy, keyForChunk func(int) string) (*Result, error) {
+	if tempDir == "" {
+		tempDir = os.TempDir()
+	}
+	if err := os.MkdirAll(tempDir, 0o700); err != nil {
+		return nil, fmt.Errorf("creating wordlist temp dir: %w", err)
+	}
+
+	file, err := os.Open(meta.Path)
+	if err != nil {
+		return nil, fmt.Errorf("opening wordlist file: %w", err)
+	}
+	defer file.Close()
+
+	result := &Result{Metadata: *meta}
+	targetBytes := ceilDiv(meta.totalEntryBytes, int64(meta.EffectiveChunks))
+	if targetBytes < 1 {
+		targetBytes = 1
+	}
+
+	scanner := newScanner(file, policy.ScannerMaxTokenSize)
+	var (
+		currentFile *os.File
+		writer      *bufio.Writer
+		chunkIndex  int
+		chunkBytes  int64
+		chunkWords  int
+		processed   int
+		currentPath string
+	)
+
+	cleanupOpenChunk := func() {
+		if currentFile != nil {
+			_ = currentFile.Close()
+			currentFile = nil
+		}
+		writer = nil
+		if currentPath != "" {
+			_ = os.Remove(currentPath)
+			currentPath = ""
+		}
+		chunkBytes = 0
+		chunkWords = 0
+	}
+
+	cleanupFailedSplit := func() {
+		cleanupOpenChunk()
+		_ = result.Cleanup()
+	}
+
+	startChunk := func() error {
+		f, err := os.CreateTemp(tempDir, fmt.Sprintf("chunk_%06d_*.txt", chunkIndex))
+		if err != nil {
+			return fmt.Errorf("creating wordlist chunk %d: %w", chunkIndex, err)
+		}
+		currentFile = f
+		writer = bufio.NewWriter(f)
+		currentPath = f.Name()
+		chunkBytes = 0
+		chunkWords = 0
+		return nil
+	}
+
+	finishChunk := func() error {
+		if currentFile == nil {
+			return nil
+		}
+		if err := writer.Flush(); err != nil {
+			cleanupOpenChunk()
+			return fmt.Errorf("flushing wordlist chunk %d: %w", chunkIndex, err)
+		}
+		if err := currentFile.Close(); err != nil {
+			cleanupOpenChunk()
+			return fmt.Errorf("closing wordlist chunk %d: %w", chunkIndex, err)
+		}
+		key := ""
+		if keyForChunk != nil {
+			key = keyForChunk(chunkIndex)
+		}
+		result.Chunks = append(result.Chunks, Chunk{
+			Path:        currentPath,
+			Key:         key,
+			ByteSize:    chunkBytes,
+			WordCount:   chunkWords,
+			Index:       chunkIndex,
+			TotalChunks: meta.EffectiveChunks,
+		})
+		currentFile = nil
+		writer = nil
+		currentPath = ""
+		return nil
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		entryBytes := int64(len(line) + 1)
+		if entryBytes > policy.MaxChunkSize {
+			cleanupFailedSplit()
+			return result, fmt.Errorf("wordlist entry is %s, above max safe chunk size %s", formatBytes(entryBytes), formatBytes(policy.MaxChunkSize))
+		}
+
+		futureChunks := meta.EffectiveChunks - chunkIndex - 1
+		if currentFile != nil && chunkWords > 0 && chunkBytes+entryBytes > policy.MaxChunkSize {
+			if futureChunks <= 0 {
+				cleanupFailedSplit()
+				return result, fmt.Errorf("wordlist chunk %d would exceed max safe chunk size %s; increase --chunks", chunkIndex, formatBytes(policy.MaxChunkSize))
+			}
+			if err := finishChunk(); err != nil {
+				cleanupFailedSplit()
+				return result, err
+			}
+			chunkIndex++
+			futureChunks = meta.EffectiveChunks - chunkIndex - 1
+		}
+
+		remainingWordsIncludingLine := meta.TotalWords - processed
+		sizeSplit := currentFile != nil && chunkWords > 0 && chunkBytes+entryBytes > targetBytes && futureChunks > 0
+		forceSplit := currentFile != nil && chunkWords > 0 && futureChunks > 0 && remainingWordsIncludingLine <= futureChunks
+		if sizeSplit || forceSplit {
+			if err := finishChunk(); err != nil {
+				cleanupFailedSplit()
+				return result, err
+			}
+			chunkIndex++
+		}
+
+		if currentFile == nil {
+			if err := startChunk(); err != nil {
+				cleanupFailedSplit()
+				return result, err
+			}
+		}
+		if _, err := writer.WriteString(line); err != nil {
+			cleanupFailedSplit()
+			return result, fmt.Errorf("writing wordlist chunk %d: %w", chunkIndex, err)
+		}
+		if err := writer.WriteByte('\n'); err != nil {
+			cleanupFailedSplit()
+			return result, fmt.Errorf("writing wordlist chunk %d: %w", chunkIndex, err)
+		}
+		chunkBytes += entryBytes
+		chunkWords++
+		processed++
+	}
+	if err := scanner.Err(); err != nil {
+		cleanupFailedSplit()
+		return result, scannerError(err, policy.ScannerMaxTokenSize)
+	}
+	if err := finishChunk(); err != nil {
+		cleanupFailedSplit()
+		return result, err
+	}
+
+	result.EffectiveChunks = len(result.Chunks)
+	for i := range result.Chunks {
+		result.Chunks[i].TotalChunks = result.EffectiveChunks
+	}
+	return result, nil
+}
+
+func scanWordlistStats(path string, scannerMax int) (int, int64, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, 0, fmt.Errorf("opening wordlist file: %w", err)
+	}
+	defer file.Close()
+
+	scanner := newScanner(file, scannerMax)
+	var words int
+	var entryBytes int64
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		words++
+		entryBytes += int64(len(line) + 1)
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, 0, scannerError(err, scannerMax)
+	}
+	return words, entryBytes, nil
+}
+
+func newScanner(file *os.File, maxTokenSize int) *bufio.Scanner {
+	scanner := bufio.NewScanner(file)
+	initialSize := 64 * 1024
+	if maxTokenSize < initialSize {
+		initialSize = maxTokenSize
+	}
+	if initialSize < 1 {
+		initialSize = 1
+	}
+	scanner.Buffer(make([]byte, initialSize), maxTokenSize)
+	return scanner
+}
+
+func scannerError(err error, maxTokenSize int) error {
+	if strings.Contains(err.Error(), "token too long") {
+		return fmt.Errorf("wordlist line exceeds scanner max token size %s", formatBytes(int64(maxTokenSize)))
+	}
+	return fmt.Errorf("scanning wordlist file: %w", err)
+}
+
+func effectiveChunkCount(sourceBytes int64, totalWords int, policy Policy) int {
+	var desired int
+	if policy.RequestedChunks > 0 {
+		desired = policy.RequestedChunks
+	} else {
+		desired = int(ceilDiv(sourceBytes, policy.TargetChunkSize))
+		if desired < policy.WorkerCount {
+			desired = policy.WorkerCount
+		}
+	}
+	if desired < 1 {
+		desired = 1
+	}
+	if totalWords > 0 && desired > totalWords {
+		desired = totalWords
+	}
+	return desired
+}
+
+func (p Policy) withDefaults() Policy {
+	if p.TargetChunkSize <= 0 {
+		p.TargetChunkSize = DefaultTargetChunkSize
+	}
+	if p.MaxChunkSize <= 0 {
+		p.MaxChunkSize = MaxSafeChunkSize
+	}
+	if p.ScannerMaxTokenSize <= 0 {
+		p.ScannerMaxTokenSize = ScannerMaxTokenSize
+	}
+	return p
+}
+
+func ceilDiv(n, d int64) int64 {
+	if d <= 0 {
+		return 0
+	}
+	if n <= 0 {
+		return 0
+	}
+	return (n + d - 1) / d
+}
+
+func formatBytes(n int64) string {
+	const mib = 1024 * 1024
+	if n%mib == 0 {
+		return fmt.Sprintf("%d MiB", n/mib)
+	}
+	return fmt.Sprintf("%d bytes", n)
+}

--- a/internal/tools/wordlist/splitter.go
+++ b/internal/tools/wordlist/splitter.go
@@ -142,7 +142,9 @@ func splitWithMetadata(meta *Metadata, tempDir string, policy Policy, keyForChun
 	if err != nil {
 		return nil, fmt.Errorf("opening wordlist file: %w", err)
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	result := &Result{Metadata: *meta}
 	targetBytes := ceilDiv(meta.totalEntryBytes, int64(meta.EffectiveChunks))
@@ -299,7 +301,9 @@ func scanWordlistStats(path string, scannerMax int) (int, int64, error) {
 	if err != nil {
 		return 0, 0, fmt.Errorf("opening wordlist file: %w", err)
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 
 	scanner := newScanner(file, scannerMax)
 	var words int

--- a/internal/tools/wordlist/splitter_test.go
+++ b/internal/tools/wordlist/splitter_test.go
@@ -1,0 +1,283 @@
+package wordlist
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeWordlist(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "words.txt")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write wordlist: %v", err)
+	}
+	return path
+}
+
+func readChunk(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read chunk: %v", err)
+	}
+	return string(data)
+}
+
+func TestSplitFileRejectsEmptyFile(t *testing.T) {
+	path := writeWordlist(t, "")
+
+	_, err := SplitFile(path, t.TempDir(), Policy{}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "no entries found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSplitFileRejectsBlankLineOnlyFile(t *testing.T) {
+	path := writeWordlist(t, "\n\n\n")
+
+	_, err := SplitFile(path, t.TempDir(), Policy{}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "no entries found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSplitFileTinyFile(t *testing.T) {
+	path := writeWordlist(t, "admin\nlogin\n")
+
+	result, err := SplitFile(path, t.TempDir(), Policy{WorkerCount: 1}, func(i int) string {
+		return "key"
+	})
+	if err != nil {
+		t.Fatalf("split wordlist: %v", err)
+	}
+	defer result.Cleanup()
+
+	if result.TotalWords != 2 {
+		t.Fatalf("TotalWords = %d, want 2", result.TotalWords)
+	}
+	if result.TotalSourceBytes != int64(len("admin\nlogin\n")) {
+		t.Fatalf("TotalSourceBytes = %d", result.TotalSourceBytes)
+	}
+	if result.EffectiveChunks != 1 || len(result.Chunks) != 1 {
+		t.Fatalf("chunks = %d/%d, want 1", result.EffectiveChunks, len(result.Chunks))
+	}
+	if got := readChunk(t, result.Chunks[0].Path); got != "admin\nlogin\n" {
+		t.Fatalf("chunk data = %q", got)
+	}
+	if result.Chunks[0].Key != "key" {
+		t.Fatalf("chunk key = %q", result.Chunks[0].Key)
+	}
+}
+
+func TestSplitFileExactSizeSplits(t *testing.T) {
+	path := writeWordlist(t, "abc\ndef\n")
+
+	result, err := SplitFile(path, t.TempDir(), Policy{RequestedChunks: 2, TargetChunkSize: 4}, nil)
+	if err != nil {
+		t.Fatalf("split wordlist: %v", err)
+	}
+	defer result.Cleanup()
+
+	if len(result.Chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(result.Chunks))
+	}
+	if got := readChunk(t, result.Chunks[0].Path); got != "abc\n" {
+		t.Fatalf("chunk 0 = %q", got)
+	}
+	if got := readChunk(t, result.Chunks[1].Path); got != "def\n" {
+		t.Fatalf("chunk 1 = %q", got)
+	}
+}
+
+func TestSplitFileUnevenSizeSplits(t *testing.T) {
+	path := writeWordlist(t, "aa\nbb\ncc\n")
+
+	result, err := SplitFile(path, t.TempDir(), Policy{RequestedChunks: 2, TargetChunkSize: 5}, nil)
+	if err != nil {
+		t.Fatalf("split wordlist: %v", err)
+	}
+	defer result.Cleanup()
+
+	if len(result.Chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d", len(result.Chunks))
+	}
+	if got := readChunk(t, result.Chunks[0].Path); got != "aa\n" {
+		t.Fatalf("chunk 0 = %q", got)
+	}
+	if got := readChunk(t, result.Chunks[1].Path); got != "bb\ncc\n" {
+		t.Fatalf("chunk 1 = %q", got)
+	}
+}
+
+func TestSplitFileExplicitChunkCount(t *testing.T) {
+	path := writeWordlist(t, "a\nb\nc\nd\n")
+
+	result, err := SplitFile(path, t.TempDir(), Policy{RequestedChunks: 3}, nil)
+	if err != nil {
+		t.Fatalf("split wordlist: %v", err)
+	}
+	defer result.Cleanup()
+
+	if result.EffectiveChunks != 3 {
+		t.Fatalf("EffectiveChunks = %d, want 3", result.EffectiveChunks)
+	}
+	for i, chunk := range result.Chunks {
+		if chunk.Index != i {
+			t.Fatalf("chunk index = %d, want %d", chunk.Index, i)
+		}
+		if chunk.TotalChunks != 3 {
+			t.Fatalf("TotalChunks = %d, want 3", chunk.TotalChunks)
+		}
+	}
+}
+
+func TestSplitFileAutoChunkCountFromSizeAndWorkers(t *testing.T) {
+	path := writeWordlist(t, "a\nb\nc\nd\n")
+
+	result, err := SplitFile(path, t.TempDir(), Policy{WorkerCount: 3, TargetChunkSize: 4}, nil)
+	if err != nil {
+		t.Fatalf("split wordlist: %v", err)
+	}
+	defer result.Cleanup()
+
+	if result.EffectiveChunks != 3 {
+		t.Fatalf("EffectiveChunks = %d, want 3", result.EffectiveChunks)
+	}
+}
+
+func TestSplitFileNoEmptyChunks(t *testing.T) {
+	path := writeWordlist(t, "a\nb\n")
+
+	result, err := SplitFile(path, t.TempDir(), Policy{RequestedChunks: 10}, nil)
+	if err != nil {
+		t.Fatalf("split wordlist: %v", err)
+	}
+	defer result.Cleanup()
+
+	if result.EffectiveChunks != 2 {
+		t.Fatalf("EffectiveChunks = %d, want 2", result.EffectiveChunks)
+	}
+	for i, chunk := range result.Chunks {
+		if chunk.WordCount == 0 {
+			t.Fatalf("chunk %d is empty", i)
+		}
+	}
+}
+
+func TestSplitFilePreservesRawEntries(t *testing.T) {
+	path := writeWordlist(t, "#comment\n admin\ntrailing \n\n")
+
+	result, err := SplitFile(path, t.TempDir(), Policy{}, nil)
+	if err != nil {
+		t.Fatalf("split wordlist: %v", err)
+	}
+	defer result.Cleanup()
+
+	if got := readChunk(t, result.Chunks[0].Path); got != "#comment\n admin\ntrailing \n" {
+		t.Fatalf("chunk data = %q", got)
+	}
+}
+
+func TestSplitFileOverlongLineError(t *testing.T) {
+	path := writeWordlist(t, strings.Repeat("a", 17)+"\n")
+
+	_, err := SplitFile(path, t.TempDir(), Policy{ScannerMaxTokenSize: 16}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "scanner max token size 16 bytes") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSplitFileRejectsUnsafeExplicitChunkSize(t *testing.T) {
+	path := writeWordlist(t, "a\n")
+	if err := os.Truncate(path, 21); err != nil {
+		t.Fatalf("truncate wordlist: %v", err)
+	}
+
+	_, err := SplitFile(path, t.TempDir(), Policy{RequestedChunks: 2, MaxChunkSize: 10}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "increase --chunks") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSplitFileRejectsChunkThatWouldExceedMaxSize(t *testing.T) {
+	path := writeWordlist(t, "aaaaaaaa\nbbbbbbbb\nc\n")
+	tempDir := t.TempDir()
+
+	_, err := SplitFile(path, tempDir, Policy{
+		RequestedChunks:     2,
+		MaxChunkSize:        10,
+		ScannerMaxTokenSize: 64,
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "would exceed max safe chunk size") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	entries, readErr := os.ReadDir(tempDir)
+	if readErr != nil {
+		t.Fatalf("read temp dir: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected temp dir cleanup after split failure, found %d files", len(entries))
+	}
+}
+
+func TestSplitFileCleansOpenChunkOnScannerError(t *testing.T) {
+	path := writeWordlist(t, "ok\n"+strings.Repeat("x", 20)+"\n")
+	tempDir := t.TempDir()
+
+	_, err := SplitFile(path, tempDir, Policy{ScannerMaxTokenSize: 16}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "scanner max token size") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	entries, readErr := os.ReadDir(tempDir)
+	if readErr != nil {
+		t.Fatalf("read temp dir: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected open chunk cleanup after scanner error, found %d files", len(entries))
+	}
+}
+
+func TestSplitFileCleanupRemovesTempFiles(t *testing.T) {
+	path := writeWordlist(t, "a\nb\n")
+
+	result, err := SplitFile(path, t.TempDir(), Policy{RequestedChunks: 2}, nil)
+	if err != nil {
+		t.Fatalf("split wordlist: %v", err)
+	}
+	paths := make([]string, len(result.Chunks))
+	for i, chunk := range result.Chunks {
+		paths[i] = chunk.Path
+		if _, err := os.Stat(chunk.Path); err != nil {
+			t.Fatalf("chunk should exist before cleanup: %v", err)
+		}
+	}
+
+	if err := result.Cleanup(); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	for _, path := range paths {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected %s to be removed, stat err=%v", path, err)
+		}
+	}
+}

--- a/internal/tools/wordlist/splitter_test.go
+++ b/internal/tools/wordlist/splitter_test.go
@@ -25,6 +25,13 @@ func readChunk(t *testing.T, path string) string {
 	return string(data)
 }
 
+func cleanupSplitResult(t *testing.T, result *Result) {
+	t.Helper()
+	if err := result.Cleanup(); err != nil {
+		t.Fatalf("cleanup split result: %v", err)
+	}
+}
+
 func TestSplitFileRejectsEmptyFile(t *testing.T) {
 	path := writeWordlist(t, "")
 
@@ -58,7 +65,7 @@ func TestSplitFileTinyFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("split wordlist: %v", err)
 	}
-	defer result.Cleanup()
+	defer cleanupSplitResult(t, result)
 
 	if result.TotalWords != 2 {
 		t.Fatalf("TotalWords = %d, want 2", result.TotalWords)
@@ -84,7 +91,7 @@ func TestSplitFileExactSizeSplits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("split wordlist: %v", err)
 	}
-	defer result.Cleanup()
+	defer cleanupSplitResult(t, result)
 
 	if len(result.Chunks) != 2 {
 		t.Fatalf("expected 2 chunks, got %d", len(result.Chunks))
@@ -104,7 +111,7 @@ func TestSplitFileUnevenSizeSplits(t *testing.T) {
 	if err != nil {
 		t.Fatalf("split wordlist: %v", err)
 	}
-	defer result.Cleanup()
+	defer cleanupSplitResult(t, result)
 
 	if len(result.Chunks) != 2 {
 		t.Fatalf("expected 2 chunks, got %d", len(result.Chunks))
@@ -124,7 +131,7 @@ func TestSplitFileExplicitChunkCount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("split wordlist: %v", err)
 	}
-	defer result.Cleanup()
+	defer cleanupSplitResult(t, result)
 
 	if result.EffectiveChunks != 3 {
 		t.Fatalf("EffectiveChunks = %d, want 3", result.EffectiveChunks)
@@ -146,7 +153,7 @@ func TestSplitFileAutoChunkCountFromSizeAndWorkers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("split wordlist: %v", err)
 	}
-	defer result.Cleanup()
+	defer cleanupSplitResult(t, result)
 
 	if result.EffectiveChunks != 3 {
 		t.Fatalf("EffectiveChunks = %d, want 3", result.EffectiveChunks)
@@ -160,7 +167,7 @@ func TestSplitFileNoEmptyChunks(t *testing.T) {
 	if err != nil {
 		t.Fatalf("split wordlist: %v", err)
 	}
-	defer result.Cleanup()
+	defer cleanupSplitResult(t, result)
 
 	if result.EffectiveChunks != 2 {
 		t.Fatalf("EffectiveChunks = %d, want 2", result.EffectiveChunks)
@@ -179,7 +186,7 @@ func TestSplitFilePreservesRawEntries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("split wordlist: %v", err)
 	}
-	defer result.Cleanup()
+	defer cleanupSplitResult(t, result)
 
 	if got := readChunk(t, result.Chunks[0].Path); got != "#comment\n admin\ntrailing \n" {
 		t.Fatalf("chunk data = %q", got)

--- a/internal/tui/core/types.go
+++ b/internal/tui/core/types.go
@@ -79,9 +79,10 @@ type DeployConfig struct {
 	PostDeployView ViewID
 
 	// Wordlist module fields — set for wordlist-type tools (ffuf, gobuster, etc.).
-	WordlistContent string // Raw wordlist file content
+	WordlistPath    string // Local wordlist file path preferred for large inputs
+	WordlistContent string // Raw wordlist file content retained for small tests/backward compatibility
 	RuntimeTarget   string // Single runtime target / URL (e.g. "https://example.com/FUZZ")
-	ChunkCount      int    // Number of wordlist chunks (defaults to WorkerCount)
+	ChunkCount      int    // Requested wordlist chunks; zero enables auto-sizing.
 
 	// Lifecycle fields.
 	CleanupPolicy string // "reuse" or "destroy-after"
@@ -139,9 +140,10 @@ type InfraOutputs struct {
 	ToolOptions string // Extra tool-specific CLI flags
 
 	// Wordlist module fields — carried forward from DeployConfig.
+	WordlistPath    string
 	WordlistContent string
 	RuntimeTarget   string
-	ChunkCount      int
+	ChunkCount      int // Requested wordlist chunks; zero enables auto-sizing.
 
 	// Lifecycle summary fields.
 	CleanupPolicy string // "reuse" or "destroy-after"

--- a/internal/tui/views/deploy/model.go
+++ b/internal/tui/views/deploy/model.go
@@ -452,6 +452,7 @@ func (m *Model) emitNavigateToStatus() tea.Cmd {
 				AMIID:                 outputs["ami_id"],
 				ToolName:              cfg.ToolName,
 				ToolOptions:           cfg.ToolOptions,
+				WordlistPath:          cfg.WordlistPath,
 				WordlistContent:       cfg.WordlistContent,
 				RuntimeTarget:         cfg.RuntimeTarget,
 				ChunkCount:            cfg.ChunkCount,

--- a/internal/tui/views/generic/config.go
+++ b/internal/tui/views/generic/config.go
@@ -17,6 +17,7 @@ import (
 	"heph4estus/internal/infra"
 	"heph4estus/internal/modules"
 	"heph4estus/internal/operator"
+	wordlisttool "heph4estus/internal/tools/wordlist"
 	"heph4estus/internal/tui/core"
 )
 
@@ -25,8 +26,10 @@ type fileReadMsg struct {
 	err     error
 }
 
-// wordlistReadMsg carries the wordlist file content separately from target file.
+// wordlistReadMsg carries bounded wordlist metadata separately from target files.
 type wordlistReadMsg struct {
+	path    string
+	meta    *wordlisttool.Metadata
 	content string
 	err     error
 }
@@ -191,7 +194,7 @@ func buildWordlistInputs(mod *modules.ModuleDefinition, workers int, computeMode
 	optsInput.CharLimit = 256
 
 	chunksInput := textinput.New()
-	chunksInput.Placeholder = "default: worker count"
+	chunksInput.Placeholder = "auto"
 	chunksInput.CharLimit = 6
 
 	workerInput := textinput.New()
@@ -387,10 +390,7 @@ func (m *ConfigModel) handleWordlistFileRead(msg wordlistReadMsg) tea.Cmd {
 		workerCount = 10
 	}
 
-	chunkCount, _ := strconv.Atoi(m.wlInputs[wlFieldChunks].Value())
-	if chunkCount <= 0 {
-		chunkCount = workerCount
-	}
+	chunkCount, _ := strconv.Atoi(strings.TrimSpace(m.wlInputs[wlFieldChunks].Value()))
 
 	computeMode := strings.TrimSpace(m.wlInputs[wlFieldComputeMode].Value())
 	if computeMode == "" {
@@ -435,6 +435,7 @@ func (m *ConfigModel) handleWordlistFileRead(msg wordlistReadMsg) tea.Cmd {
 					Placement:       placement,
 					ToolName:        m.toolName,
 					ToolOptions:     toolOptions,
+					WordlistPath:    msg.path,
 					WordlistContent: msg.content,
 					RuntimeTarget:   runtimeTarget,
 					ChunkCount:      chunkCount,
@@ -474,6 +475,7 @@ func (m *ConfigModel) handleWordlistFileRead(msg wordlistReadMsg) tea.Cmd {
 				ToolName:        m.toolName,
 				ToolOptions:     toolOptions,
 				PostDeployView:  core.ViewGenericStatus,
+				WordlistPath:    msg.path,
 				WordlistContent: msg.content,
 				RuntimeTarget:   runtimeTarget,
 				ChunkCount:      chunkCount,
@@ -629,19 +631,30 @@ func (m *ConfigModel) submitWordlist() tea.Cmd {
 	}
 
 	chunksStr := strings.TrimSpace(m.wlInputs[wlFieldChunks].Value())
+	requestedChunks := 0
 	if chunksStr != "" {
-		if v, err := strconv.Atoi(chunksStr); err != nil || v <= 0 {
+		v, err := strconv.Atoi(chunksStr)
+		if err != nil || v <= 0 {
 			m.errMsg = "Chunks must be a positive number"
 			return nil
 		}
+		requestedChunks = v
+	}
+
+	workerCount, _ := strconv.Atoi(m.wlInputs[wlFieldWorkerCount].Value())
+	if workerCount <= 0 {
+		workerCount = 10
 	}
 
 	m.errMsg = ""
 	return func() tea.Msg {
-		data, err := os.ReadFile(wlPath)
+		meta, err := wordlisttool.InspectFile(wlPath, wordlisttool.Policy{
+			RequestedChunks: requestedChunks,
+			WorkerCount:     workerCount,
+		})
 		if err != nil {
 			return wordlistReadMsg{err: err}
 		}
-		return wordlistReadMsg{content: string(data)}
+		return wordlistReadMsg{path: wlPath, meta: meta}
 	}
 }

--- a/internal/tui/views/generic/config_test.go
+++ b/internal/tui/views/generic/config_test.go
@@ -1,6 +1,8 @@
 package generic
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -113,6 +115,38 @@ func TestGenericConfigWordlistShowsFields(t *testing.T) {
 	}
 	if !strings.Contains(v, "Chunks") {
 		t.Fatal("expected Chunks label")
+	}
+}
+
+func TestGenericConfigWordlistCarriesPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "words.txt")
+	if err := os.WriteFile(path, []byte("admin\nlogin\n"), 0o644); err != nil {
+		t.Fatalf("write wordlist: %v", err)
+	}
+
+	m := NewConfig("ffuf")
+	m.wlInputs[wlFieldTarget].SetValue("https://example.com/FUZZ")
+	m.wlInputs[wlFieldComputeMode].SetValue("auto")
+	m.wlInputs[wlFieldCloud].SetValue("aws")
+
+	_, cmd := m.Update(wordlistReadMsg{path: path})
+	if cmd == nil {
+		t.Fatal("expected navigation command after wordlist metadata read")
+	}
+	msg := cmd()
+	nav, ok := msg.(core.NavigateWithDataMsg)
+	if !ok {
+		t.Fatalf("expected NavigateWithDataMsg, got %T", msg)
+	}
+	cfg, ok := nav.Data.(core.DeployConfig)
+	if !ok {
+		t.Fatalf("expected DeployConfig, got %T", nav.Data)
+	}
+	if cfg.WordlistPath != path {
+		t.Fatalf("WordlistPath = %q, want %q", cfg.WordlistPath, path)
+	}
+	if cfg.WordlistContent != "" {
+		t.Fatalf("WordlistContent should not be populated for path-based flow")
 	}
 }
 

--- a/internal/tui/views/generic/status.go
+++ b/internal/tui/views/generic/status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -219,7 +220,7 @@ func NewStatusWithDeps(infra core.InfraOutputs, sub GenericSubmitter, tracker Ge
 		Ellipsis:       lipgloss.NewStyle().Foreground(core.Steel),
 	}
 
-	isWL := infra.WordlistContent != ""
+	isWL := infra.WordlistPath != "" || infra.WordlistContent != ""
 
 	var jobTracker *operator.Tracker
 	if len(jt) > 0 && jt[0] != nil {
@@ -325,16 +326,7 @@ func (m *StatusModel) initWordlist() tea.Cmd {
 	infra := m.infra
 	uploader := m.uploader
 
-	chunkCount := infra.ChunkCount
-	if chunkCount <= 0 {
-		chunkCount = infra.WorkerCount
-	}
-
-	plan, err := jobs.PlanWordlistJob(
-		infra.ToolName, infra.JobID,
-		infra.RuntimeTarget, infra.ToolOptions,
-		infra.WordlistContent, chunkCount,
-	)
+	plan, tempDir, err := m.planWordlist(infra)
 	if err != nil {
 		m.errMsg = fmt.Sprintf("Wordlist error: %v", err)
 		return nil
@@ -346,11 +338,48 @@ func (m *StatusModel) initWordlist() tea.Cmd {
 	m.trackCreate()
 
 	return func() tea.Msg {
+		defer func() {
+			if tempDir != "" {
+				_ = os.RemoveAll(tempDir)
+			}
+		}()
+		defer plan.Cleanup()
 		if err := uploader.UploadChunks(context.Background(), infra.S3BucketName, plan); err != nil {
 			return uploadCompleteMsg{err: err}
 		}
 		return uploadCompleteMsg{tasks: plan.Tasks, words: plan.TotalWords}
 	}
+}
+
+func (m *StatusModel) planWordlist(infra core.InfraOutputs) (*jobs.WordlistPlan, string, error) {
+	if infra.WordlistPath != "" {
+		tempDir, err := os.MkdirTemp("", "heph-wordlist-*")
+		if err != nil {
+			return nil, "", fmt.Errorf("creating temp dir: %w", err)
+		}
+		plan, err := jobs.PlanWordlistFile(
+			infra.ToolName, infra.JobID,
+			infra.RuntimeTarget, infra.ToolOptions,
+			infra.WordlistPath, tempDir,
+			infra.ChunkCount, infra.WorkerCount,
+		)
+		if err != nil {
+			_ = os.RemoveAll(tempDir)
+			return nil, "", err
+		}
+		return plan, tempDir, nil
+	}
+
+	chunkCount := infra.ChunkCount
+	if chunkCount <= 0 {
+		chunkCount = infra.WorkerCount
+	}
+	plan, err := jobs.PlanWordlistJob(
+		infra.ToolName, infra.JobID,
+		infra.RuntimeTarget, infra.ToolOptions,
+		infra.WordlistContent, chunkCount,
+	)
+	return plan, "", err
 }
 
 func (m *StatusModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
@@ -526,6 +555,7 @@ func (m *StatusModel) View() string {
 			fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Target:"), m.infra.RuntimeTarget)
 		}
 		fmt.Fprintf(&b, "  %s%d\n", labelStyle.Render("Chunks:"), m.totalTargets)
+		fmt.Fprintf(&b, "  %s%d\n", labelStyle.Render("Words:"), m.totalWords)
 		fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Elapsed:"), elapsed.String())
 
 	case phaseEnqueuing:

--- a/internal/tui/views/generic/status.go
+++ b/internal/tui/views/generic/status.go
@@ -337,18 +337,34 @@ func (m *StatusModel) initWordlist() tea.Cmd {
 	m.phase = phaseUploading
 	m.trackCreate()
 
-	return func() tea.Msg {
+	return func() (msg tea.Msg) {
 		defer func() {
 			if tempDir != "" {
-				_ = os.RemoveAll(tempDir)
+				if err := os.RemoveAll(tempDir); err != nil {
+					msg = uploadCleanupError(msg, fmt.Errorf("removing wordlist temp dir: %w", err))
+				}
 			}
 		}()
-		defer plan.Cleanup()
+		defer func() {
+			if err := plan.Cleanup(); err != nil {
+				msg = uploadCleanupError(msg, fmt.Errorf("cleaning wordlist chunks: %w", err))
+			}
+		}()
 		if err := uploader.UploadChunks(context.Background(), infra.S3BucketName, plan); err != nil {
 			return uploadCompleteMsg{err: err}
 		}
 		return uploadCompleteMsg{tasks: plan.Tasks, words: plan.TotalWords}
 	}
+}
+
+func uploadCleanupError(msg tea.Msg, err error) tea.Msg {
+	if err == nil {
+		return msg
+	}
+	if current, ok := msg.(uploadCompleteMsg); ok && current.err != nil {
+		return msg
+	}
+	return uploadCompleteMsg{err: err}
 }
 
 func (m *StatusModel) planWordlist(infra core.InfraOutputs) (*jobs.WordlistPlan, string, error) {

--- a/internal/tui/views/generic/status_test.go
+++ b/internal/tui/views/generic/status_test.go
@@ -3,6 +3,8 @@ package generic
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -19,10 +21,12 @@ import (
 type mockUploader struct {
 	uploaded bool
 	err      error
+	plan     *jobs.WordlistPlan
 }
 
-func (u *mockUploader) UploadChunks(_ context.Context, _ string, _ *jobs.WordlistPlan) error {
+func (u *mockUploader) UploadChunks(_ context.Context, _ string, plan *jobs.WordlistPlan) error {
 	u.uploaded = true
+	u.plan = plan
 	return u.err
 }
 
@@ -257,18 +261,23 @@ func TestGenericStatusNoTargets(t *testing.T) {
 	}
 }
 
-func testWordlistInfra() core.InfraOutputs {
+func testWordlistInfra(t *testing.T) core.InfraOutputs {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "words.txt")
+	if err := os.WriteFile(path, []byte("admin\nlogin\napi\ntest\n# comment\n\n"), 0o644); err != nil {
+		t.Fatalf("write wordlist: %v", err)
+	}
 	return core.InfraOutputs{
-		SQSQueueURL:     "https://sqs.example.com/q",
-		S3BucketName:    "test-bucket",
-		ECSClusterName:  "test-cluster",
-		ToolName:        "ffuf",
-		ToolOptions:     "-ac",
-		WordlistContent: "admin\nlogin\napi\ntest\n# comment\n\n",
-		RuntimeTarget:   "https://example.com/FUZZ",
-		ChunkCount:      2,
-		WorkerCount:     2,
-		ComputeMode:     "fargate",
+		SQSQueueURL:    "https://sqs.example.com/q",
+		S3BucketName:   "test-bucket",
+		ECSClusterName: "test-cluster",
+		ToolName:       "ffuf",
+		ToolOptions:    "-ac",
+		WordlistPath:   path,
+		RuntimeTarget:  "https://example.com/FUZZ",
+		ChunkCount:     2,
+		WorkerCount:    2,
+		ComputeMode:    "fargate",
 	}
 }
 
@@ -276,7 +285,7 @@ func TestGenericStatusWordlistInit(t *testing.T) {
 	sub := &mockSubmitter{}
 	tracker := &mockTracker{}
 	uploader := &mockUploader{}
-	m := NewStatusWithDeps(testWordlistInfra(), sub, tracker, uploader)
+	m := NewStatusWithDeps(testWordlistInfra(t), sub, tracker, uploader)
 
 	cmd := m.Init()
 	if cmd == nil {
@@ -305,6 +314,9 @@ func TestGenericStatusWordlistInit(t *testing.T) {
 	if !uploader.uploaded {
 		t.Fatal("expected uploader to have been called")
 	}
+	if uploader.plan == nil || len(uploader.plan.ChunkFiles) != 2 {
+		t.Fatalf("expected file-based chunk plan, got %#v", uploader.plan)
+	}
 	if len(uc.tasks) != 2 {
 		t.Fatalf("expected 2 tasks, got %d", len(uc.tasks))
 	}
@@ -331,7 +343,7 @@ func TestGenericStatusWordlistInit(t *testing.T) {
 func TestGenericStatusWordlistUploadToEnqueue(t *testing.T) {
 	sub := &mockSubmitter{}
 	tracker := &mockTracker{}
-	m := NewStatusWithDeps(testWordlistInfra(), sub, tracker, &mockUploader{})
+	m := NewStatusWithDeps(testWordlistInfra(t), sub, tracker, &mockUploader{})
 	m.Init()
 
 	tasks := []worker.Task{
@@ -350,7 +362,7 @@ func TestGenericStatusWordlistUploadToEnqueue(t *testing.T) {
 func TestGenericStatusWordlistViewShowsTarget(t *testing.T) {
 	sub := &mockSubmitter{}
 	tracker := &mockTracker{}
-	m := NewStatusWithDeps(testWordlistInfra(), sub, tracker, &mockUploader{})
+	m := NewStatusWithDeps(testWordlistInfra(t), sub, tracker, &mockUploader{})
 	m.Init()
 
 	v := m.View()
@@ -359,6 +371,33 @@ func TestGenericStatusWordlistViewShowsTarget(t *testing.T) {
 	}
 	if !strings.Contains(v, "chunks") || !strings.Contains(v, "Uploading") {
 		t.Fatal("expected view to show uploading chunks status")
+	}
+	if !strings.Contains(v, "Words") {
+		t.Fatal("expected view to show total words after planning")
+	}
+}
+
+func TestGenericStatusWordlistContentFallback(t *testing.T) {
+	infra := testWordlistInfra(t)
+	infra.WordlistPath = ""
+	infra.WordlistContent = "admin\nlogin\n"
+
+	uploader := &mockUploader{}
+	m := NewStatusWithDeps(infra, &mockSubmitter{}, &mockTracker{}, uploader)
+	cmd := m.Init()
+	if cmd == nil {
+		t.Fatal("expected init command")
+	}
+	msg := cmd()
+	uc, ok := msg.(uploadCompleteMsg)
+	if !ok {
+		t.Fatalf("expected uploadCompleteMsg, got %T", msg)
+	}
+	if uc.err != nil {
+		t.Fatalf("unexpected upload error: %v", uc.err)
+	}
+	if uploader.plan == nil || len(uploader.plan.ChunkData) == 0 {
+		t.Fatal("expected fallback in-memory chunk data")
 	}
 }
 


### PR DESCRIPTION
 ## Summary

  Implements memory-safe wordlist planning, splitting, upload, and enqueue for large wordlist inputs across CLI and TUI
  flows.

  This replaces the production `os.ReadFile` + in-memory chunk model with a streaming file-based splitter that preserves
  existing task compatibility while bounding upload memory to safe chunk sizes.

  ## Changes

  - Added `internal/tools/wordlist` streaming splitter
    - Splits on line boundaries only
    - Skips only truly empty lines
    - Preserves raw non-empty entries, including spaces and `#` prefixes
    - Auto-sizes omitted chunks from file size and worker count
    - Enforces 16 MiB target chunk size, 64 MiB max safe chunk size, and 16 MiB scanner token limit
    - Cleans up temporary chunk files on success and failure

  - Added file-backed jobs planning
    - Introduced `PlanWordlistFile`
    - Retained `PlanWordlistJob` for small in-memory tests/backward compatibility
    - Stores chunk paths and metadata instead of `[][]byte`
    - Uploads one chunk file at a time through the existing `cloud.Storage.Upload(ctx, bucket, key, []byte)` API
    - Keeps task schema and input key layout stable

  - Updated CLI wordlist flow
    - Preflight now streams metadata instead of reading full file content
    - Rejects directories, empty wordlists, overlong lines, and unsafe explicit chunk sizing
    - Logs parsed entries, source size, requested/effective chunks, and target/max chunk sizes
    - Uses file-based planning and upload for production scans

  - Updated TUI wordlist flow
    - Added `WordlistPath` to deploy/status config
    - TUI now prefers path-based wordlist execution
    - Kept `WordlistContent` fallback for compatibility
    - Status view shows planned chunk and word counts

  ## Compatibility

  - No changes to worker task JSON
  - No changes to worker execution behavior
  - No changes to result key layout
  - No changes to module YAML or provider APIs
  - No changes to the public `cloud.Storage` interface
  - `InputKey` remains `scans/<tool>/<job>/inputs/chunk_<n>.txt`
  - `ChunkIdx`, `TotalChunks`, and `GroupID` remain compatible

  ## Validation

  Ran:

  ```sh
  env GOCACHE=/tmp/heph-go-build go test ./internal/tools/wordlist ./internal/jobs ./cmd/heph ./internal/tui/views/generic
  env GOCACHE=/tmp/heph-go-build go test ./...
  git diff --check