### PR TITLE
feat(tui): format generic result artifacts

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -174,7 +174,8 @@ func (a *App) buildResultsDeps(infra core.InfraOutputs, toolName string) (core.R
 
 	if infra.Exported && infra.ExportDir != "" {
 		source = &core.LocalResultsSource{
-			ResultsDir: filepath.Join(infra.ExportDir, "results"),
+			ResultsDir:   filepath.Join(infra.ExportDir, "results"),
+			ArtifactsDir: filepath.Join(infra.ExportDir, "artifacts"),
 		}
 	} else {
 		provider, err := a.buildProvider(infra.Cloud)

--- a/internal/tui/core/results_source.go
+++ b/internal/tui/core/results_source.go
@@ -20,6 +20,11 @@ type ResultsSource interface {
 	Download(ctx context.Context, key string) ([]byte, error)
 }
 
+// ArtifactSource reads tool output artifacts referenced by worker.Result.
+type ArtifactSource interface {
+	DownloadArtifact(ctx context.Context, outputKey string) ([]byte, error)
+}
+
 // S3ResultsSource reads results from an S3 bucket via cloud.Storage.
 type S3ResultsSource struct {
 	Storage cloud.Storage
@@ -35,11 +40,16 @@ func (s *S3ResultsSource) Download(ctx context.Context, key string) ([]byte, err
 	return s.Storage.Download(ctx, s.Bucket, key)
 }
 
+func (s *S3ResultsSource) DownloadArtifact(ctx context.Context, outputKey string) ([]byte, error) {
+	return s.Storage.Download(ctx, s.Bucket, s3ObjectKey(outputKey))
+}
+
 // LocalResultsSource reads results from a local export directory.
 // Keys are relative paths within the results directory, matching the
 // suffix format used in S3 keys (e.g. "target_123.json").
 type LocalResultsSource struct {
-	ResultsDir string // e.g. <outDir>/<tool>/<jobID>/results
+	ResultsDir   string // e.g. <outDir>/<tool>/<jobID>/results
+	ArtifactsDir string // e.g. <outDir>/<tool>/<jobID>/artifacts
 }
 
 func (l *LocalResultsSource) ListKeys(_ context.Context) ([]string, error) {
@@ -77,6 +87,40 @@ func (l *LocalResultsSource) Download(_ context.Context, key string) ([]byte, er
 		return nil, fmt.Errorf("reading local result %s: %w", key, err)
 	}
 	return data, nil
+}
+
+func (l *LocalResultsSource) DownloadArtifact(_ context.Context, outputKey string) ([]byte, error) {
+	artifactsDir := l.ArtifactsDir
+	if artifactsDir == "" {
+		artifactsDir = filepath.Join(filepath.Dir(l.ResultsDir), "artifacts")
+	}
+	rel := artifactRelativePath(outputKey)
+	localPath := filepath.Join(artifactsDir, filepath.FromSlash(rel))
+	data, err := os.ReadFile(localPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading local artifact %s: %w", outputKey, err)
+	}
+	return data, nil
+}
+
+func s3ObjectKey(key string) string {
+	key = strings.TrimSpace(key)
+	if strings.HasPrefix(key, "s3://") {
+		withoutScheme := strings.TrimPrefix(key, "s3://")
+		if idx := strings.Index(withoutScheme, "/"); idx >= 0 {
+			return withoutScheme[idx+1:]
+		}
+	}
+	return strings.TrimPrefix(key, "/")
+}
+
+func artifactRelativePath(key string) string {
+	key = s3ObjectKey(key)
+	if idx := strings.Index(key, "/artifacts/"); idx >= 0 {
+		return key[idx+len("/artifacts/"):]
+	}
+	key = strings.TrimPrefix(key, "artifacts/")
+	return strings.TrimPrefix(key, "/")
 }
 
 // Destroyer abstracts infrastructure teardown for the results view.

--- a/internal/tui/core/results_source_test.go
+++ b/internal/tui/core/results_source_test.go
@@ -66,6 +66,22 @@ func TestS3ResultsSource_Download(t *testing.T) {
 	}
 }
 
+func TestS3ResultsSource_DownloadArtifact(t *testing.T) {
+	data := []byte(`{"url":"https://example.com","status_code":200}`)
+	key := "scans/httpx/job-1/artifacts/example.com_1000.jsonl"
+	s := &S3ResultsSource{
+		Storage: &mockStorage{data: map[string][]byte{key: data}},
+		Bucket:  "test-bucket",
+	}
+	got, err := s.DownloadArtifact(context.Background(), key)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("expected %q, got %q", data, got)
+	}
+}
+
 func TestLocalResultsSource_ListKeys(t *testing.T) {
 	dir := t.TempDir()
 	resultsDir := filepath.Join(dir, "results")
@@ -105,6 +121,33 @@ func TestLocalResultsSource_Download(t *testing.T) {
 
 	src := &LocalResultsSource{ResultsDir: resultsDir}
 	got, err := src.Download(context.Background(), "192.168.1.1_1000.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("expected %q, got %q", content, got)
+	}
+}
+
+func TestLocalResultsSource_DownloadArtifact(t *testing.T) {
+	dir := t.TempDir()
+	resultsDir := filepath.Join(dir, "results")
+	artifactsDir := filepath.Join(dir, "artifacts")
+	nestedDir := filepath.Join(artifactsDir, "group1")
+	if err := os.MkdirAll(resultsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	content := []byte(`<nmaprun></nmaprun>`)
+	if err := os.WriteFile(filepath.Join(nestedDir, "example.xml"), content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	src := &LocalResultsSource{ResultsDir: resultsDir, ArtifactsDir: artifactsDir}
+	got, err := src.DownloadArtifact(context.Background(), "scans/nmap/job-1/artifacts/group1/example.xml")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/tui/views/generic/resultfmt.go
+++ b/internal/tui/views/generic/resultfmt.go
@@ -1,0 +1,456 @@
+package generic
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"sort"
+	"strings"
+
+	"heph4estus/internal/tui/core"
+	"heph4estus/internal/worker"
+)
+
+const maxResultLineBytes = 10 * 1024 * 1024
+
+func formatResultFromSource(ctx context.Context, source core.ResultsSource, bucket string, r worker.Result) string {
+	var (
+		artifact    []byte
+		artifactErr error
+	)
+	if r.OutputKey != "" {
+		artifact, artifactErr = downloadResultArtifact(ctx, source, r.OutputKey)
+	}
+	return formatResultWithArtifact(bucket, r, artifact, artifactErr)
+}
+
+func downloadResultArtifact(ctx context.Context, source core.ResultsSource, outputKey string) ([]byte, error) {
+	artifactSource, ok := source.(core.ArtifactSource)
+	if !ok {
+		return nil, fmt.Errorf("artifact download not available for this source")
+	}
+	return artifactSource.DownloadArtifact(ctx, outputKey)
+}
+
+func formatResultWithArtifact(bucket string, r worker.Result, artifact []byte, artifactErr error) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "Target:    %s\n", r.Target)
+	fmt.Fprintf(&b, "Tool:      %s\n", r.ToolName)
+	if r.TotalChunks > 0 {
+		fmt.Fprintf(&b, "Chunk:     %d / %d\n", r.ChunkIdx+1, r.TotalChunks)
+	}
+	fmt.Fprintf(&b, "Timestamp: %s\n", r.Timestamp.Format("2006-01-02 15:04:05"))
+	if r.Error != "" {
+		fmt.Fprintf(&b, "Error:     %s\n", r.Error)
+	}
+	if r.OutputKey != "" {
+		fmt.Fprintf(&b, "Output:    %s\n", outputRef(bucket, r.OutputKey))
+	}
+	if artifactErr != nil {
+		fmt.Fprintf(&b, "Artifact:  unavailable: %v\n", artifactErr)
+	}
+
+	if len(bytes.TrimSpace(artifact)) > 0 {
+		title, formatted, err := formatToolArtifact(r, artifact)
+		if err != nil {
+			fmt.Fprintf(&b, "\nArtifact parse error: %v\n", err)
+			b.WriteString("\n--- Raw Artifact ---\n")
+			b.WriteString(strings.TrimRight(string(artifact), "\n"))
+			b.WriteByte('\n')
+		} else {
+			fmt.Fprintf(&b, "\n--- %s ---\n", title)
+			b.WriteString(formatted)
+			if !strings.HasSuffix(formatted, "\n") {
+				b.WriteByte('\n')
+			}
+		}
+		if strings.TrimSpace(r.Output) != "" {
+			b.WriteString("\n--- Command Output ---\n")
+			b.WriteString(strings.TrimRight(r.Output, "\n"))
+			b.WriteByte('\n')
+		}
+		return b.String()
+	}
+
+	if r.OutputKey != "" && artifactErr == nil && artifact != nil {
+		b.WriteString("\n--- Artifact ---\n(empty artifact)\n")
+	}
+	if strings.TrimSpace(r.Output) != "" {
+		b.WriteString("\n--- Output ---\n")
+		b.WriteString(strings.TrimRight(r.Output, "\n"))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func outputRef(bucket, key string) string {
+	if key == "" || strings.HasPrefix(key, "s3://") || bucket == "" {
+		return key
+	}
+	return fmt.Sprintf("s3://%s/%s", bucket, strings.TrimPrefix(key, "/"))
+}
+
+func formatToolArtifact(r worker.Result, artifact []byte) (string, string, error) {
+	switch strings.ToLower(strings.TrimSpace(r.ToolName)) {
+	case "nmap":
+		body, err := formatNmapArtifact(r, artifact)
+		return "Nmap Open Ports", body, err
+	case "nuclei":
+		body, err := formatNucleiArtifact(artifact)
+		return "Nuclei Findings", body, err
+	case "httpx":
+		body, err := formatHTTPXArtifact(artifact)
+		return "HTTPX Results", body, err
+	case "ffuf":
+		body, err := formatFFUFArtifact(artifact)
+		return "FFUF Hits", body, err
+	case "masscan":
+		body, err := formatMasscanArtifact(artifact)
+		return "Masscan Open Ports", body, err
+	default:
+		return "Raw Artifact", rawArtifact(artifact), nil
+	}
+}
+
+type nmapXMLRun struct {
+	Hosts []nmapXMLHost `xml:"host"`
+}
+
+type nmapXMLHost struct {
+	Addresses []nmapXMLAddress `xml:"address"`
+	Ports     []nmapXMLPort    `xml:"ports>port"`
+}
+
+type nmapXMLAddress struct {
+	Addr     string `xml:"addr,attr"`
+	AddrType string `xml:"addrtype,attr"`
+}
+
+type nmapXMLPort struct {
+	Protocol string          `xml:"protocol,attr"`
+	PortID   string          `xml:"portid,attr"`
+	State    nmapXMLState    `xml:"state"`
+	Service  nmapXMLService  `xml:"service"`
+	Scripts  []nmapXMLScript `xml:"script"`
+}
+
+type nmapXMLState struct {
+	State string `xml:"state,attr"`
+}
+
+type nmapXMLService struct {
+	Name    string `xml:"name,attr"`
+	Product string `xml:"product,attr"`
+	Version string `xml:"version,attr"`
+}
+
+type nmapXMLScript struct {
+	ID     string `xml:"id,attr"`
+	Output string `xml:"output,attr"`
+}
+
+func formatNmapArtifact(r worker.Result, artifact []byte) (string, error) {
+	var parsed nmapXMLRun
+	if err := xml.Unmarshal(artifact, &parsed); err != nil {
+		return "", err
+	}
+
+	lines := []string{
+		fmt.Sprintf("%-24s %-9s %s", "HOST", "PORT", "SERVICE"),
+		fmt.Sprintf("%-24s %-9s %s", strings.Repeat("-", 24), strings.Repeat("-", 9), strings.Repeat("-", 40)),
+	}
+	for _, host := range parsed.Hosts {
+		hostLabel := nmapHostLabel(host, r.Target)
+		for _, port := range host.Ports {
+			if !strings.EqualFold(port.State.State, "open") {
+				continue
+			}
+			service := strings.TrimSpace(strings.Join(nonEmpty(port.Service.Name, port.Service.Product, port.Service.Version), " "))
+			if service == "" {
+				service = "-"
+			}
+			lines = append(lines, fmt.Sprintf("%-24s %-9s %s", clipText(hostLabel, 24), port.Protocol+"/"+port.PortID, service))
+		}
+	}
+	if len(lines) == 2 {
+		return "No open ports found.", nil
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+func nmapHostLabel(host nmapXMLHost, fallback string) string {
+	for _, addr := range host.Addresses {
+		if addr.Addr != "" && (addr.AddrType == "" || addr.AddrType == "ipv4") {
+			return addr.Addr
+		}
+	}
+	for _, addr := range host.Addresses {
+		if addr.Addr != "" {
+			return addr.Addr
+		}
+	}
+	return fallback
+}
+
+type nucleiRecord struct {
+	TemplateID string `json:"template-id"`
+	ID         string `json:"id"`
+	Host       string `json:"host"`
+	MatchedAt  string `json:"matched-at"`
+	URL        string `json:"url"`
+	Info       struct {
+		Name     string `json:"name"`
+		Severity string `json:"severity"`
+	} `json:"info"`
+}
+
+func formatNucleiArtifact(artifact []byte) (string, error) {
+	records, err := parseJSONLines[nucleiRecord](artifact)
+	if err != nil {
+		return "", err
+	}
+	if len(records) == 0 {
+		return "No nuclei findings found.", nil
+	}
+	sort.SliceStable(records, func(i, j int) bool {
+		return severityRank(records[i].Info.Severity) < severityRank(records[j].Info.Severity)
+	})
+
+	lines := []string{
+		fmt.Sprintf("%-9s %-28s %-44s %s", "SEVERITY", "TEMPLATE", "TARGET", "NAME"),
+		fmt.Sprintf("%-9s %-28s %-44s %s", strings.Repeat("-", 9), strings.Repeat("-", 28), strings.Repeat("-", 44), strings.Repeat("-", 30)),
+	}
+	for _, rec := range records {
+		template := firstNonEmpty(rec.TemplateID, rec.ID, "-")
+		target := firstNonEmpty(rec.MatchedAt, rec.URL, rec.Host, "-")
+		name := firstNonEmpty(rec.Info.Name, "-")
+		severity := strings.ToUpper(firstNonEmpty(rec.Info.Severity, "unknown"))
+		lines = append(lines, fmt.Sprintf("%-9s %-28s %-44s %s", clipText(severity, 9), clipText(template, 28), clipText(target, 44), name))
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+type httpxRecord struct {
+	URL           string   `json:"url"`
+	Input         string   `json:"input"`
+	Host          string   `json:"host"`
+	StatusCode    int      `json:"status_code"`
+	Title         string   `json:"title"`
+	Webserver     string   `json:"webserver"`
+	Tech          []string `json:"tech"`
+	ContentLength int      `json:"content_length"`
+}
+
+func formatHTTPXArtifact(artifact []byte) (string, error) {
+	records, err := parseJSONLines[httpxRecord](artifact)
+	if err != nil {
+		return "", err
+	}
+	if len(records) == 0 {
+		return "No httpx records found.", nil
+	}
+
+	lines := []string{
+		fmt.Sprintf("%-44s %-6s %-24s %-30s %s", "URL", "STATUS", "TITLE", "SERVER", "TECH"),
+		fmt.Sprintf("%-44s %-6s %-24s %-30s %s", strings.Repeat("-", 44), strings.Repeat("-", 6), strings.Repeat("-", 24), strings.Repeat("-", 30), strings.Repeat("-", 30)),
+	}
+	for _, rec := range records {
+		target := firstNonEmpty(rec.URL, rec.Input, rec.Host, "-")
+		status := "-"
+		if rec.StatusCode > 0 {
+			status = fmt.Sprintf("%d", rec.StatusCode)
+		}
+		lines = append(lines, fmt.Sprintf("%-44s %-6s %-24s %-30s %s",
+			clipText(target, 44),
+			status,
+			clipText(firstNonEmpty(rec.Title, "-"), 24),
+			clipText(firstNonEmpty(rec.Webserver, "-"), 30),
+			clipText(strings.Join(rec.Tech, ","), 60),
+		))
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+type ffufArtifact struct {
+	Results []ffufResult `json:"results"`
+}
+
+type ffufResult struct {
+	Input            map[string]any `json:"input"`
+	Status           int            `json:"status"`
+	Length           int            `json:"length"`
+	Words            int            `json:"words"`
+	Lines            int            `json:"lines"`
+	URL              string         `json:"url"`
+	RedirectLocation string         `json:"redirectlocation"`
+}
+
+func formatFFUFArtifact(artifact []byte) (string, error) {
+	var parsed ffufArtifact
+	if err := json.Unmarshal(artifact, &parsed); err != nil {
+		return "", err
+	}
+	if len(parsed.Results) == 0 {
+		return "No ffuf hits found.", nil
+	}
+
+	lines := []string{
+		fmt.Sprintf("%-44s %-6s %-8s %-7s %-7s %s", "URL/INPUT", "STATUS", "LENGTH", "WORDS", "LINES", "REDIRECT"),
+		fmt.Sprintf("%-44s %-6s %-8s %-7s %-7s %s", strings.Repeat("-", 44), strings.Repeat("-", 6), strings.Repeat("-", 8), strings.Repeat("-", 7), strings.Repeat("-", 7), strings.Repeat("-", 30)),
+	}
+	for _, hit := range parsed.Results {
+		target := firstNonEmpty(hit.URL, formatInputMap(hit.Input), "-")
+		redirect := firstNonEmpty(hit.RedirectLocation, "-")
+		lines = append(lines, fmt.Sprintf("%-44s %-6d %-8d %-7d %-7d %s",
+			clipText(target, 44),
+			hit.Status,
+			hit.Length,
+			hit.Words,
+			hit.Lines,
+			clipText(redirect, 60),
+		))
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+type masscanRecord struct {
+	IP    string        `json:"ip"`
+	Ports []masscanPort `json:"ports"`
+}
+
+type masscanPort struct {
+	Port   int    `json:"port"`
+	Proto  string `json:"proto"`
+	Status string `json:"status"`
+	Reason string `json:"reason"`
+}
+
+func formatMasscanArtifact(artifact []byte) (string, error) {
+	var records []masscanRecord
+	if err := json.Unmarshal(artifact, &records); err != nil {
+		jsonlRecords, jsonlErr := parseJSONLines[masscanRecord](artifact)
+		if jsonlErr != nil {
+			return "", err
+		}
+		records = jsonlRecords
+	}
+	if len(records) == 0 {
+		return "No masscan ports found.", nil
+	}
+
+	lines := []string{
+		fmt.Sprintf("%-24s %-9s %-10s %s", "IP", "PORT", "STATUS", "REASON"),
+		fmt.Sprintf("%-24s %-9s %-10s %s", strings.Repeat("-", 24), strings.Repeat("-", 9), strings.Repeat("-", 10), strings.Repeat("-", 30)),
+	}
+	for _, rec := range records {
+		for _, port := range rec.Ports {
+			proto := firstNonEmpty(port.Proto, "tcp")
+			status := firstNonEmpty(port.Status, "open")
+			reason := firstNonEmpty(port.Reason, "-")
+			lines = append(lines, fmt.Sprintf("%-24s %-9s %-10s %s", clipText(rec.IP, 24), fmt.Sprintf("%s/%d", proto, port.Port), status, reason))
+		}
+	}
+	if len(lines) == 2 {
+		return "No masscan ports found.", nil
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+func parseJSONLines[T any](artifact []byte) ([]T, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(artifact))
+	scanner.Buffer(make([]byte, 0, 64*1024), maxResultLineBytes)
+
+	var records []T
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var record T
+		if err := json.Unmarshal(line, &record); err != nil {
+			return nil, fmt.Errorf("line %d: %w", lineNo, err)
+		}
+		records = append(records, record)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+func formatInputMap(input map[string]any) string {
+	if len(input) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(input))
+	for key := range input {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%v", key, input[key]))
+	}
+	return strings.Join(parts, ",")
+}
+
+func rawArtifact(artifact []byte) string {
+	body := strings.TrimRight(string(artifact), "\n")
+	if strings.TrimSpace(body) == "" {
+		return "(empty artifact)"
+	}
+	return body
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func nonEmpty(values ...string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func severityRank(severity string) int {
+	switch strings.ToLower(strings.TrimSpace(severity)) {
+	case "critical":
+		return 0
+	case "high":
+		return 1
+	case "medium":
+		return 2
+	case "low":
+		return 3
+	case "info", "informational":
+		return 4
+	default:
+		return 5
+	}
+}
+
+func clipText(value string, maxLen int) string {
+	if maxLen <= 0 || len(value) <= maxLen {
+		return value
+	}
+	if maxLen <= 3 {
+		return value[:maxLen]
+	}
+	return value[:maxLen-3] + "..."
+}

--- a/internal/tui/views/generic/resultfmt_test.go
+++ b/internal/tui/views/generic/resultfmt_test.go
@@ -1,0 +1,110 @@
+package generic
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"heph4estus/internal/worker"
+)
+
+func TestFormatNmapArtifact(t *testing.T) {
+	result := worker.Result{ToolName: "nmap", Target: "192.0.2.10"}
+	artifact := []byte(`<nmaprun><host><address addr="192.0.2.10" addrtype="ipv4"/><ports><port protocol="tcp" portid="80"><state state="open"/><service name="http" product="nginx" version="1.25"/></port><port protocol="tcp" portid="22"><state state="closed"/></port></ports></host></nmaprun>`)
+
+	_, body, err := formatToolArtifact(result, artifact)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(body, "tcp/80") {
+		t.Fatal("expected open port in nmap output")
+	}
+	if !strings.Contains(body, "nginx") {
+		t.Fatal("expected service product in nmap output")
+	}
+	if strings.Contains(body, "tcp/22") {
+		t.Fatal("closed ports should not be rendered")
+	}
+}
+
+func TestFormatNucleiArtifact(t *testing.T) {
+	body, err := formatNucleiArtifact([]byte(`{"template-id":"cves/2026/test","matched-at":"https://example.com","info":{"name":"Example Finding","severity":"high"}}` + "\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{"HIGH", "cves/2026/test", "https://example.com", "Example Finding"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in nuclei output:\n%s", want, body)
+		}
+	}
+}
+
+func TestFormatHTTPXArtifact(t *testing.T) {
+	body, err := formatHTTPXArtifact([]byte(`{"url":"https://example.com","status_code":200,"title":"Example","webserver":"nginx","tech":["Go","React"]}` + "\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{"https://example.com", "200", "Example", "nginx", "Go,React"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in httpx output:\n%s", want, body)
+		}
+	}
+}
+
+func TestFormatFFUFArtifact(t *testing.T) {
+	body, err := formatFFUFArtifact([]byte(`{"results":[{"url":"https://example.com/admin","status":200,"length":1234,"words":50,"lines":20,"redirectlocation":""}]}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{"https://example.com/admin", "200", "1234", "50", "20"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in ffuf output:\n%s", want, body)
+		}
+	}
+}
+
+func TestFormatMasscanArtifact(t *testing.T) {
+	body, err := formatMasscanArtifact([]byte(`[{"ip":"192.0.2.10","ports":[{"port":443,"proto":"tcp","status":"open","reason":"syn-ack"}]}]`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{"192.0.2.10", "tcp/443", "open", "syn-ack"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in masscan output:\n%s", want, body)
+		}
+	}
+}
+
+func TestFormatResultMalformedArtifactFallsBackToRaw(t *testing.T) {
+	result := worker.Result{
+		ToolName:  "nuclei",
+		Target:    "example.com",
+		OutputKey: "scans/nuclei/job/artifacts/example.jsonl",
+		Timestamp: time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC),
+	}
+	body := formatResultWithArtifact("bucket", result, []byte(`{bad json}`), nil)
+	if !strings.Contains(body, "Artifact parse error") {
+		t.Fatal("expected parse error in formatted result")
+	}
+	if !strings.Contains(body, "{bad json}") {
+		t.Fatal("expected raw artifact fallback")
+	}
+}
+
+func TestFormatResultMissingArtifactShowsOutputFallback(t *testing.T) {
+	result := worker.Result{
+		ToolName:  "httpx",
+		Target:    "example.com",
+		Output:    "stdout fallback",
+		OutputKey: "scans/httpx/job/artifacts/example.jsonl",
+		Timestamp: time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC),
+	}
+	body := formatResultWithArtifact("bucket", result, nil, fmt.Errorf("not found"))
+	if !strings.Contains(body, "Artifact:  unavailable") {
+		t.Fatal("expected artifact error")
+	}
+	if !strings.Contains(body, "stdout fallback") {
+		t.Fatal("expected stdout fallback")
+	}
+}

--- a/internal/tui/views/generic/results.go
+++ b/internal/tui/views/generic/results.go
@@ -25,8 +25,10 @@ type keysLoadedMsg struct {
 }
 
 type resultLoadedMsg struct {
-	result worker.Result
-	err    error
+	key     string
+	result  worker.Result
+	content string
+	err     error
 }
 
 // pageStatusesMsg carries lightweight status info for a page of results.
@@ -79,6 +81,7 @@ type ResultsModel struct {
 	page       int
 	cursor     int
 	results    map[string]*worker.Result
+	details    map[string]string
 	detail     bool
 	detailVP   viewport.Model
 	destroying bool
@@ -108,6 +111,7 @@ func NewResults(infra core.InfraOutputs, source core.ResultsSource, destroyer co
 		destroyer: destroyer,
 		infra:     infra,
 		results:   make(map[string]*worker.Result),
+		details:   make(map[string]string),
 		help:      h,
 	}
 
@@ -214,12 +218,22 @@ func (m *ResultsModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 			m.errMsg = fmt.Sprintf("Error loading detail: %v", msg.err)
 			return m, nil
 		}
-		pk := m.pageKeys()
-		if m.cursor < len(pk) {
-			m.results[pk[m.cursor]] = &msg.result
+		key := msg.key
+		if key == "" {
+			pk := m.pageKeys()
+			if m.cursor < len(pk) {
+				key = pk[m.cursor]
+			}
+		}
+		if key != "" {
+			m.results[key] = &msg.result
+			m.details[key] = msg.content
 		}
 		m.detail = true
-		content := formatResult(m.infra.S3BucketName, msg.result)
+		content := msg.content
+		if content == "" {
+			content = formatResult(m.infra.S3BucketName, msg.result)
+		}
 		m.detailVP.SetContent(content)
 		m.detailVP.GotoTop()
 
@@ -413,22 +427,32 @@ func (m *ResultsModel) loadDetail() tea.Cmd {
 	k := pk[m.cursor]
 
 	if r, ok := m.results[k]; ok {
+		if content, ok := m.details[k]; ok {
+			return func() tea.Msg {
+				return resultLoadedMsg{key: k, result: *r, content: content}
+			}
+		}
+		src := m.source
+		bucket := m.infra.S3BucketName
 		return func() tea.Msg {
-			return resultLoadedMsg{result: *r}
+			content := formatResultFromSource(context.Background(), src, bucket, *r)
+			return resultLoadedMsg{key: k, result: *r, content: content}
 		}
 	}
 
 	src := m.source
+	bucket := m.infra.S3BucketName
 	return func() tea.Msg {
 		data, err := src.Download(context.Background(), k)
 		if err != nil {
-			return resultLoadedMsg{err: err}
+			return resultLoadedMsg{key: k, err: err}
 		}
 		var result worker.Result
 		if err := json.Unmarshal(data, &result); err != nil {
-			return resultLoadedMsg{err: err}
+			return resultLoadedMsg{key: k, err: err}
 		}
-		return resultLoadedMsg{result: result}
+		content := formatResultFromSource(context.Background(), src, bucket, result)
+		return resultLoadedMsg{key: k, result: result, content: content}
 	}
 }
 
@@ -441,28 +465,7 @@ func (m *ResultsModel) runDestroy() tea.Cmd {
 }
 
 func formatResult(bucket string, r worker.Result) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "Target:    %s\n", r.Target)
-	fmt.Fprintf(&b, "Tool:      %s\n", r.ToolName)
-	if r.TotalChunks > 0 {
-		fmt.Fprintf(&b, "Chunk:     %d / %d\n", r.ChunkIdx+1, r.TotalChunks)
-	}
-	fmt.Fprintf(&b, "Timestamp: %s\n", r.Timestamp.Format("2006-01-02 15:04:05"))
-	if r.Error != "" {
-		fmt.Fprintf(&b, "Error:     %s\n", r.Error)
-	}
-	if r.OutputKey != "" {
-		outputRef := r.OutputKey
-		if bucket != "" && !strings.HasPrefix(outputRef, "s3://") {
-			outputRef = fmt.Sprintf("s3://%s/%s", bucket, strings.TrimPrefix(outputRef, "/"))
-		}
-		fmt.Fprintf(&b, "Output:    %s\n", outputRef)
-	}
-	if r.Output != "" {
-		b.WriteString("\n--- Output ---\n")
-		b.WriteString(r.Output)
-	}
-	return b.String()
+	return formatResultWithArtifact(bucket, r, nil, nil)
 }
 
 func truncate(s string, maxLen int) string {

--- a/internal/tui/views/generic/results_test.go
+++ b/internal/tui/views/generic/results_test.go
@@ -15,10 +15,12 @@ import (
 
 // mockResultsSource implements core.ResultsSource for testing.
 type mockResultsSource struct {
-	keys    []string
-	listErr error
-	data    map[string][]byte
-	dlErr   error
+	keys        []string
+	listErr     error
+	data        map[string][]byte
+	dlErr       error
+	artifacts   map[string][]byte
+	artifactErr error
 }
 
 func (s *mockResultsSource) ListKeys(_ context.Context) ([]string, error) {
@@ -33,6 +35,16 @@ func (s *mockResultsSource) Download(_ context.Context, key string) ([]byte, err
 		return d, nil
 	}
 	return nil, fmt.Errorf("not found: %s", key)
+}
+
+func (s *mockResultsSource) DownloadArtifact(_ context.Context, key string) ([]byte, error) {
+	if s.artifactErr != nil {
+		return nil, s.artifactErr
+	}
+	if d, ok := s.artifacts[key]; ok {
+		return d, nil
+	}
+	return nil, fmt.Errorf("artifact not found: %s", key)
 }
 
 // mockDestroyer implements core.Destroyer for testing.
@@ -131,6 +143,81 @@ func TestGenericResultsDetailView(t *testing.T) {
 
 	if !m.detail {
 		t.Fatal("expected detail mode to be active")
+	}
+}
+
+func TestGenericResultsDetailViewFormatsArtifact(t *testing.T) {
+	result := worker.Result{
+		ToolName:  "httpx",
+		Target:    "example.com",
+		OutputKey: "scans/httpx/job-1/artifacts/example.com_1700000000.jsonl",
+		Timestamp: time.Date(2026, 4, 5, 12, 0, 0, 0, time.UTC),
+	}
+	data, _ := json.Marshal(result)
+
+	key := "example.com_1700000000.json"
+	source := &mockResultsSource{
+		keys: []string{key},
+		data: map[string][]byte{key: data},
+		artifacts: map[string][]byte{
+			result.OutputKey: []byte(`{"url":"https://example.com","status_code":200,"title":"Example","webserver":"nginx","tech":["Go"]}` + "\n"),
+		},
+	}
+	m := NewResults(testResultInfra(), source, nil)
+	cmd := m.Init()
+	msg := cmd()
+	m.Update(msg)
+
+	_, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected detail load command")
+	}
+	msg = cmd()
+	m.Update(msg)
+
+	content := m.details[key]
+	if !strings.Contains(content, "HTTPX Results") {
+		t.Fatal("expected formatted httpx section")
+	}
+	if !strings.Contains(content, "https://example.com") {
+		t.Fatal("expected artifact URL in detail view")
+	}
+	if !strings.Contains(content, "Example") {
+		t.Fatal("expected artifact title in detail view")
+	}
+}
+
+func TestGenericResultsDetailViewShowsArtifactErrorWithFallback(t *testing.T) {
+	result := worker.Result{
+		ToolName:  "httpx",
+		Target:    "example.com",
+		Output:    "stdout fallback",
+		OutputKey: "scans/httpx/job-1/artifacts/missing.jsonl",
+		Timestamp: time.Date(2026, 4, 5, 12, 0, 0, 0, time.UTC),
+	}
+	data, _ := json.Marshal(result)
+
+	key := "example.com_1700000000.json"
+	source := &mockResultsSource{
+		keys:        []string{key},
+		data:        map[string][]byte{key: data},
+		artifactErr: fmt.Errorf("not found"),
+	}
+	m := NewResults(testResultInfra(), source, nil)
+	cmd := m.Init()
+	msg := cmd()
+	m.Update(msg)
+
+	_, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	msg = cmd()
+	m.Update(msg)
+
+	content := m.details[key]
+	if !strings.Contains(content, "Artifact:  unavailable") {
+		t.Fatal("expected artifact error in detail view")
+	}
+	if !strings.Contains(content, "stdout fallback") {
+		t.Fatal("expected stdout fallback in detail view")
 	}
 }
 


### PR DESCRIPTION
## Summary

  Adds tool-specific formatting to the generic TUI results detail view.

  ## Changes

  - Adds artifact download support for S3-backed and locally exported results.
  - Formats generic result details for:
    - `nmap` XML open ports/services
    - `nuclei` JSONL findings
    - `httpx` JSONL probe results
    - `ffuf` JSON hits
    - `masscan` JSON open ports
  - Keeps raw fallback rendering for unknown tools, malformed artifacts, missing artifacts, and stdout-only results.
  - Caches formatted detail content so reopening a result does not redownload artifacts.
  - Preserves existing pagination, result status loading, export summary, and destroy behavior.

  ## Tests

  ```bash
  GOCACHE=/tmp/heph-go-cache go test ./internal/tui/... ./internal/worker/... ./internal/operator/... ./cmd/heph/...
  GOCACHE=/tmp/heph-go-cache go test ./...