### PR TITLE
feat(wordlist): stream large input chunk uploads

### DIFF
--- a/cmd/heph/cmd_scan.go
+++ b/cmd/heph/cmd_scan.go
@@ -362,6 +362,10 @@ func runTargetListScan(ctx context.Context, tool, jobID, inputFile, content, opt
 }
 
 func runWordlistScan(ctx context.Context, tool, jobID, wordlistFile string, preflight *wordlisttool.Metadata, runtimeTarget, options string, chunks, workers int, computeMode, format string, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, outputs map[string]string, bucket, queueURL string, tracker *operator.Tracker, cloudKind cloud.Kind, placementPolicy fleet.PlacementPolicy) (bool, error) {
+	if err := wordlisttool.CleanupStaleTempDirs(wordlisttool.DefaultStaleTempAge); err != nil {
+		logStatus("Warning: failed to clean stale wordlist temp dirs: %v", err)
+	}
+
 	tempDir, err := os.MkdirTemp("", "heph-wordlist-*")
 	if err != nil {
 		return false, fmt.Errorf("creating wordlist temp dir: %w", err)

--- a/internal/cloud/aws/aws_test.go
+++ b/internal/cloud/aws/aws_test.go
@@ -10,13 +10,13 @@ import (
 	"heph4estus/internal/cloud"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
-	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
-	"github.com/aws/aws-sdk-go-v2/service/sfn"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/aws-sdk-go-v2/service/sfn"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	sqstypes "github.com/aws/aws-sdk-go-v2/service/sqs/types"
 )
@@ -32,8 +32,8 @@ func (nopLogger) Fatal(string, ...interface{}) {}
 // ---------- SDK-level mocks ----------
 
 type mockS3API struct {
-	putObjectFunc      func(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
-	getObjectFunc      func(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	putObjectFunc     func(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+	getObjectFunc     func(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error)
 	listObjectsV2Func func(context.Context, *s3.ListObjectsV2Input, ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
 }
 
@@ -48,6 +48,7 @@ func (m *mockS3API) ListObjectsV2(ctx context.Context, in *s3.ListObjectsV2Input
 }
 
 var _ S3API = (*mockS3API)(nil)
+var _ cloud.StreamingStorage = (*S3Client)(nil)
 
 type mockSQSAPI struct {
 	sendMessageFunc      func(context.Context, *sqs.SendMessageInput, ...func(*sqs.Options)) (*sqs.SendMessageOutput, error)
@@ -122,6 +123,30 @@ func TestS3Upload_Error(t *testing.T) {
 	}
 	if err := client.Upload(context.Background(), "b", "k", nil); !errors.Is(err, want) {
 		t.Fatalf("expected %v, got %v", want, err)
+	}
+}
+
+func TestS3UploadStream_Success(t *testing.T) {
+	client := &S3Client{
+		logger: nopLogger{},
+		client: &mockS3API{
+			putObjectFunc: func(_ context.Context, in *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+				if aws.ToString(in.Bucket) != "b" || aws.ToString(in.Key) != "k" {
+					t.Fatalf("unexpected bucket/key: %s/%s", aws.ToString(in.Bucket), aws.ToString(in.Key))
+				}
+				data, err := io.ReadAll(in.Body)
+				if err != nil {
+					t.Fatalf("read body: %v", err)
+				}
+				if string(data) != "stream data" {
+					t.Fatalf("body = %q, want stream data", string(data))
+				}
+				return &s3.PutObjectOutput{}, nil
+			},
+		},
+	}
+	if err := client.UploadStream(context.Background(), "b", "k", strings.NewReader("stream data"), 11); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/internal/cloud/aws/s3.go
+++ b/internal/cloud/aws/s3.go
@@ -42,6 +42,18 @@ func (c *S3Client) Upload(ctx context.Context, bucket, key string, data []byte) 
 	return err
 }
 
+// UploadStream uploads a stream to an object store bucket without buffering
+// the full object in memory.
+func (c *S3Client) UploadStream(ctx context.Context, bucket, key string, body io.Reader, _ int64) error {
+	c.logger.Info("Uploading stream to S3: %s/%s", bucket, key)
+	_, err := c.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   body,
+	})
+	return err
+}
+
 // Download retrieves an object from the store.
 func (c *S3Client) Download(ctx context.Context, bucket, key string) ([]byte, error) {
 	c.logger.Info("Downloading object from S3: %s/%s", bucket, key)

--- a/internal/cloud/mock/provider.go
+++ b/internal/cloud/mock/provider.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"context"
 	"heph4estus/internal/cloud"
+	"io"
 )
 
 // Compile-time interface checks.
@@ -27,14 +28,22 @@ func (p *Provider) Compute() cloud.Compute { return p.ComputeImpl() }
 
 // Storage is a test double for cloud.Storage.
 type Storage struct {
-	UploadFunc   func(ctx context.Context, bucket, key string, data []byte) error
-	DownloadFunc func(ctx context.Context, bucket, key string) ([]byte, error)
-	ListFunc     func(ctx context.Context, bucket, prefix string) ([]string, error)
-	CountFunc    func(ctx context.Context, bucket, prefix string) (int, error)
+	UploadFunc       func(ctx context.Context, bucket, key string, data []byte) error
+	UploadStreamFunc func(ctx context.Context, bucket, key string, body io.Reader, size int64) error
+	DownloadFunc     func(ctx context.Context, bucket, key string) ([]byte, error)
+	ListFunc         func(ctx context.Context, bucket, prefix string) ([]string, error)
+	CountFunc        func(ctx context.Context, bucket, prefix string) (int, error)
 }
 
 func (s *Storage) Upload(ctx context.Context, bucket, key string, data []byte) error {
 	return s.UploadFunc(ctx, bucket, key, data)
+}
+
+func (s *Storage) UploadStream(ctx context.Context, bucket, key string, body io.Reader, size int64) error {
+	if s.UploadStreamFunc == nil {
+		return cloud.ErrNotImplemented
+	}
+	return s.UploadStreamFunc(ctx, bucket, key, body, size)
 }
 
 func (s *Storage) Download(ctx context.Context, bucket, key string) ([]byte, error) {
@@ -75,9 +84,9 @@ func (q *Queue) Delete(ctx context.Context, queueID, receiptHandle string) error
 
 // Compute is a test double for cloud.Compute.
 type Compute struct {
-	RunContainerFunc    func(ctx context.Context, opts cloud.ContainerOpts) (string, error)
+	RunContainerFunc     func(ctx context.Context, opts cloud.ContainerOpts) (string, error)
 	RunSpotInstancesFunc func(ctx context.Context, opts cloud.SpotOpts) ([]string, error)
-	GetSpotStatusFunc   func(ctx context.Context, instanceIDs []string) ([]cloud.SpotStatus, error)
+	GetSpotStatusFunc    func(ctx context.Context, instanceIDs []string) ([]cloud.SpotStatus, error)
 }
 
 func (c *Compute) RunContainer(ctx context.Context, opts cloud.ContainerOpts) (string, error) {

--- a/internal/cloud/provider.go
+++ b/internal/cloud/provider.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"errors"
+	"io"
 )
 
 // ErrNotImplemented is returned by stub implementations.
@@ -21,6 +22,12 @@ type Storage interface {
 	Download(ctx context.Context, bucket, key string) ([]byte, error)
 	List(ctx context.Context, bucket, prefix string) ([]string, error)
 	Count(ctx context.Context, bucket, prefix string) (int, error)
+}
+
+// StreamingStorage is an optional extension for backends that can upload an
+// object from a stream without materializing the full payload in memory.
+type StreamingStorage interface {
+	UploadStream(ctx context.Context, bucket, key string, body io.Reader, size int64) error
 }
 
 // Queue abstracts message-queue operations (SQS, Pub/Sub, etc.).
@@ -64,14 +71,14 @@ type ContainerOpts struct {
 // SpotOpts configures a spot/preemptible instance request.
 type SpotOpts struct {
 	AMI             string
-	InstanceTypes   []string          // Multiple types for availability
+	InstanceTypes   []string // Multiple types for availability
 	KeyPair         string
-	UserData        string            // base64-encoded
-	MaxPrice        string            // Per-instance-hour bid
+	UserData        string // base64-encoded
+	MaxPrice        string // Per-instance-hour bid
 	Count           int
 	SecurityGroups  []string
 	SubnetIDs       []string
-	InstanceProfile string            // IAM instance profile ARN
+	InstanceProfile string // IAM instance profile ARN
 	Tags            map[string]string
 }
 

--- a/internal/cloud/selfhosted/s3compat.go
+++ b/internal/cloud/selfhosted/s3compat.go
@@ -124,6 +124,18 @@ func (s *Storage) Upload(ctx context.Context, bucket, key string, data []byte) e
 	return err
 }
 
+// UploadStream uploads a stream to an S3-compatible bucket without buffering
+// the full object in memory.
+func (s *Storage) UploadStream(ctx context.Context, bucket, key string, body io.Reader, _ int64) error {
+	s.logger.Info("Uploading stream to S3-compatible: %s/%s", bucket, key)
+	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+		Body:   body,
+	})
+	return err
+}
+
 // Download retrieves an object from an S3-compatible bucket.
 func (s *Storage) Download(ctx context.Context, bucket, key string) ([]byte, error) {
 	s.logger.Info("Downloading object from S3-compatible: %s/%s", bucket, key)

--- a/internal/cloud/selfhosted/s3compat_test.go
+++ b/internal/cloud/selfhosted/s3compat_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"heph4estus/internal/cloud"
 	"heph4estus/internal/logger"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -96,6 +97,25 @@ func TestStorageUploadDownloadRoundTrip(t *testing.T) {
 		t.Fatalf("Upload: %v", err)
 	}
 	got, err := s.Download(context.Background(), "bucket", "scans/a.json")
+	if err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("round trip mismatch: got %q, want %q", got, want)
+	}
+}
+
+func TestStorageUploadStreamDownloadRoundTrip(t *testing.T) {
+	fake := newFakeS3()
+	s := NewStorageWithClient(fake, logger.NewSimpleLogger())
+
+	var _ cloud.StreamingStorage = s
+
+	want := []byte("hello streaming heph4estus")
+	if err := s.UploadStream(context.Background(), "bucket", "scans/stream.txt", bytes.NewReader(want), int64(len(want))); err != nil {
+		t.Fatalf("UploadStream: %v", err)
+	}
+	got, err := s.Download(context.Background(), "bucket", "scans/stream.txt")
 	if err != nil {
 		t.Fatalf("Download: %v", err)
 	}

--- a/internal/jobs/wordlist.go
+++ b/internal/jobs/wordlist.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -175,18 +176,8 @@ func PlanWordlistFile(toolName, jobID, runtimeTarget, options, wordlistPath, tem
 func UploadChunks(ctx context.Context, storage cloud.Storage, bucket string, plan *WordlistPlan) error {
 	if len(plan.ChunkFiles) > 0 {
 		for _, chunk := range plan.ChunkFiles {
-			if chunk.ByteSize > plan.MaxChunkSize && plan.MaxChunkSize > 0 {
-				return fmt.Errorf("chunk %d (%s) is %d bytes, above max safe chunk size %d", chunk.Index, chunk.Key, chunk.ByteSize, plan.MaxChunkSize)
-			}
-			data, err := os.ReadFile(chunk.Path)
-			if err != nil {
-				return fmt.Errorf("reading chunk %d (%s): %w", chunk.Index, chunk.Key, err)
-			}
-			if int64(len(data)) > plan.MaxChunkSize && plan.MaxChunkSize > 0 {
-				return fmt.Errorf("chunk %d (%s) is %d bytes, above max safe chunk size %d", chunk.Index, chunk.Key, len(data), plan.MaxChunkSize)
-			}
-			if err := storage.Upload(ctx, bucket, chunk.Key, data); err != nil {
-				return fmt.Errorf("uploading chunk %d (%s): %w", chunk.Index, chunk.Key, err)
+			if err := uploadChunkFile(ctx, storage, bucket, plan, chunk); err != nil {
+				return err
 			}
 		}
 		return nil
@@ -196,6 +187,53 @@ func UploadChunks(ctx context.Context, storage cloud.Storage, bucket string, pla
 		if err := storage.Upload(ctx, bucket, plan.ChunkKeys[i], data); err != nil {
 			return fmt.Errorf("uploading chunk %d (%s): %w", i, plan.ChunkKeys[i], err)
 		}
+	}
+	return nil
+}
+
+func uploadChunkFile(ctx context.Context, storage cloud.Storage, bucket string, plan *WordlistPlan, chunk WordlistChunk) error {
+	if chunk.ByteSize > plan.MaxChunkSize && plan.MaxChunkSize > 0 {
+		return fmt.Errorf("chunk %d (%s) is %d bytes, above max safe chunk size %d", chunk.Index, chunk.Key, chunk.ByteSize, plan.MaxChunkSize)
+	}
+
+	if streamer, ok := storage.(cloud.StreamingStorage); ok {
+		file, err := os.Open(chunk.Path)
+		if err != nil {
+			return fmt.Errorf("opening chunk %d (%s): %w", chunk.Index, chunk.Key, err)
+		}
+		err = streamer.UploadStream(ctx, bucket, chunk.Key, file, chunk.ByteSize)
+		closeErr := file.Close()
+		if err == nil {
+			if closeErr != nil {
+				return fmt.Errorf("closing chunk %d (%s): %w", chunk.Index, chunk.Key, closeErr)
+			}
+			return nil
+		}
+		if errors.Is(err, cloud.ErrNotImplemented) {
+			if closeErr != nil {
+				return fmt.Errorf("closing chunk %d (%s): %w", chunk.Index, chunk.Key, closeErr)
+			}
+			return uploadChunkFileBuffered(ctx, storage, bucket, plan, chunk)
+		}
+		if closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("closing chunk file: %w", closeErr))
+		}
+		return fmt.Errorf("uploading chunk %d (%s): %w", chunk.Index, chunk.Key, err)
+	}
+
+	return uploadChunkFileBuffered(ctx, storage, bucket, plan, chunk)
+}
+
+func uploadChunkFileBuffered(ctx context.Context, storage cloud.Storage, bucket string, plan *WordlistPlan, chunk WordlistChunk) error {
+	data, err := os.ReadFile(chunk.Path)
+	if err != nil {
+		return fmt.Errorf("reading chunk %d (%s): %w", chunk.Index, chunk.Key, err)
+	}
+	if int64(len(data)) > plan.MaxChunkSize && plan.MaxChunkSize > 0 {
+		return fmt.Errorf("chunk %d (%s) is %d bytes, above max safe chunk size %d", chunk.Index, chunk.Key, len(data), plan.MaxChunkSize)
+	}
+	if err := storage.Upload(ctx, bucket, chunk.Key, data); err != nil {
+		return fmt.Errorf("uploading chunk %d (%s): %w", chunk.Index, chunk.Key, err)
 	}
 	return nil
 }

--- a/internal/jobs/wordlist_test.go
+++ b/internal/jobs/wordlist_test.go
@@ -3,11 +3,14 @@ package jobs
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+
+	"heph4estus/internal/cloud"
 )
 
 func cleanupWordlistPlan(t *testing.T, plan *WordlistPlan) {
@@ -254,6 +257,121 @@ func (s *recordingStorage) Upload(_ context.Context, _, key string, data []byte)
 func (s *recordingStorage) Download(context.Context, string, string) ([]byte, error) { return nil, nil }
 func (s *recordingStorage) List(context.Context, string, string) ([]string, error)   { return nil, nil }
 func (s *recordingStorage) Count(context.Context, string, string) (int, error)       { return 0, nil }
+
+type streamingRecordingStorage struct {
+	recordingStorage
+	streamUploads []uploadRecord
+	streamFailKey string
+	streamNotImpl bool
+}
+
+func (s *streamingRecordingStorage) UploadStream(_ context.Context, _, key string, body io.Reader, size int64) error {
+	if s.streamNotImpl {
+		return cloud.ErrNotImplemented
+	}
+	if key == s.streamFailKey {
+		return errors.New("stream upload failed")
+	}
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return err
+	}
+	s.streamUploads = append(s.streamUploads, uploadRecord{key: key, size: len(data)})
+	if int64(len(data)) != size {
+		return errors.New("stream size mismatch")
+	}
+	return nil
+}
+
+func TestUploadChunksUsesStreamingStorageForFileChunks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "words.txt")
+	if err := os.WriteFile(path, []byte("a\nb\nc\nd\n"), 0o644); err != nil {
+		t.Fatalf("write wordlist: %v", err)
+	}
+	plan, err := PlanWordlistFile("ffuf", "job-123", "https://example.com/FUZZ", "", path, t.TempDir(), 2, 1)
+	if err != nil {
+		t.Fatalf("plan wordlist file: %v", err)
+	}
+	defer cleanupWordlistPlan(t, plan)
+
+	storage := &streamingRecordingStorage{}
+	if err := UploadChunks(context.Background(), storage, "bucket", plan); err != nil {
+		t.Fatalf("upload chunks: %v", err)
+	}
+	if len(storage.streamUploads) != 2 {
+		t.Fatalf("stream uploads = %d, want 2", len(storage.streamUploads))
+	}
+	if len(storage.uploads) != 0 {
+		t.Fatalf("byte uploads = %d, want 0", len(storage.uploads))
+	}
+	for i, upload := range storage.streamUploads {
+		if upload.size != int(plan.ChunkFiles[i].ByteSize) {
+			t.Fatalf("stream upload %d size = %d, want %d", i, upload.size, plan.ChunkFiles[i].ByteSize)
+		}
+	}
+}
+
+func TestUploadChunksFallsBackWhenStreamingNotImplemented(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "words.txt")
+	if err := os.WriteFile(path, []byte("a\nb\nc\nd\n"), 0o644); err != nil {
+		t.Fatalf("write wordlist: %v", err)
+	}
+	plan, err := PlanWordlistFile("ffuf", "job-123", "https://example.com/FUZZ", "", path, t.TempDir(), 2, 1)
+	if err != nil {
+		t.Fatalf("plan wordlist file: %v", err)
+	}
+	defer cleanupWordlistPlan(t, plan)
+
+	storage := &streamingRecordingStorage{streamNotImpl: true}
+	if err := UploadChunks(context.Background(), storage, "bucket", plan); err != nil {
+		t.Fatalf("upload chunks: %v", err)
+	}
+	if len(storage.streamUploads) != 0 {
+		t.Fatalf("stream uploads = %d, want 0", len(storage.streamUploads))
+	}
+	if len(storage.uploads) != 2 {
+		t.Fatalf("byte uploads = %d, want 2", len(storage.uploads))
+	}
+}
+
+func TestUploadChunksStreamingFailureIncludesChunkIndexAndKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "words.txt")
+	if err := os.WriteFile(path, []byte("a\nb\n"), 0o644); err != nil {
+		t.Fatalf("write wordlist: %v", err)
+	}
+	plan, err := PlanWordlistFile("ffuf", "job-123", "https://example.com/FUZZ", "", path, t.TempDir(), 2, 1)
+	if err != nil {
+		t.Fatalf("plan wordlist file: %v", err)
+	}
+	defer cleanupWordlistPlan(t, plan)
+
+	failKey := InputKey("ffuf", "job-123", 1)
+	err = UploadChunks(context.Background(), &streamingRecordingStorage{streamFailKey: failKey}, "bucket", plan)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "chunk 1") || !strings.Contains(err.Error(), failKey) {
+		t.Fatalf("error should include chunk index and key, got %v", err)
+	}
+}
+
+func TestUploadChunksPreservesInMemoryPlanUpload(t *testing.T) {
+	plan, err := PlanWordlistJob("ffuf", "job-123", "https://example.com/FUZZ", "", "a\nb\n", 2)
+	if err != nil {
+		t.Fatalf("plan wordlist job: %v", err)
+	}
+
+	storage := &recordingStorage{}
+	if err := UploadChunks(context.Background(), storage, "bucket", plan); err != nil {
+		t.Fatalf("upload chunks: %v", err)
+	}
+	if len(storage.uploads) != 2 {
+		t.Fatalf("uploads = %d, want 2", len(storage.uploads))
+	}
+	if storage.uploads[0].key != plan.ChunkKeys[0] || storage.uploads[1].key != plan.ChunkKeys[1] {
+		t.Fatalf("uploaded keys = %v, want %v", storage.uploads, plan.ChunkKeys)
+	}
+}
 
 func TestUploadChunksReadsFileChunksOneAtATime(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "words.txt")

--- a/internal/tools/wordlist/cleanup.go
+++ b/internal/tools/wordlist/cleanup.go
@@ -1,0 +1,53 @@
+package wordlist
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	tempDirPrefix       = "heph-wordlist-"
+	DefaultStaleTempAge = 24 * time.Hour
+)
+
+// CleanupStaleTempDirs removes stale wordlist temp directories from os.TempDir.
+func CleanupStaleTempDirs(maxAge time.Duration) error {
+	return cleanupStaleTempDirs(os.TempDir(), time.Now(), maxAge)
+}
+
+func cleanupStaleTempDirs(root string, now time.Time, maxAge time.Duration) error {
+	if maxAge <= 0 {
+		maxAge = DefaultStaleTempAge
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return fmt.Errorf("reading temp dir %s: %w", root, err)
+	}
+
+	var errs []error
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), tempDirPrefix) {
+			continue
+		}
+		if entry.Type()&os.ModeSymlink != 0 || !entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("stat stale wordlist temp dir %s: %w", filepath.Join(root, entry.Name()), err))
+			continue
+		}
+		if now.Sub(info.ModTime()) < maxAge {
+			continue
+		}
+		path := filepath.Join(root, entry.Name())
+		if err := os.RemoveAll(path); err != nil {
+			errs = append(errs, fmt.Errorf("removing stale wordlist temp dir %s: %w", path, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/internal/tools/wordlist/cleanup_test.go
+++ b/internal/tools/wordlist/cleanup_test.go
@@ -1,0 +1,98 @@
+package wordlist
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCleanupStaleTempDirsRemovesOnlyStaleWordlistDirs(t *testing.T) {
+	root := t.TempDir()
+	now := time.Now()
+	stale := filepath.Join(root, "heph-wordlist-stale")
+	fresh := filepath.Join(root, "heph-wordlist-fresh")
+	other := filepath.Join(root, "other-stale")
+	for _, dir := range []string{stale, fresh, other} {
+		if err := os.Mkdir(dir, 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	old := now.Add(-48 * time.Hour)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatalf("chtimes stale: %v", err)
+	}
+	if err := os.Chtimes(other, old, old); err != nil {
+		t.Fatalf("chtimes other: %v", err)
+	}
+
+	if err := cleanupStaleTempDirs(root, now, 24*time.Hour); err != nil {
+		t.Fatalf("cleanup stale temp dirs: %v", err)
+	}
+	if _, err := os.Stat(stale); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stale wordlist dir should be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Fatalf("fresh wordlist dir should remain: %v", err)
+	}
+	if _, err := os.Stat(other); err != nil {
+		t.Fatalf("non-matching dir should remain: %v", err)
+	}
+}
+
+func TestCleanupStaleTempDirsIgnoresFilesAndSymlinks(t *testing.T) {
+	root := t.TempDir()
+	now := time.Now()
+	old := now.Add(-48 * time.Hour)
+
+	filePath := filepath.Join(root, "heph-wordlist-file")
+	if err := os.WriteFile(filePath, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := os.Chtimes(filePath, old, old); err != nil {
+		t.Fatalf("chtimes file: %v", err)
+	}
+
+	target := filepath.Join(root, "target")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatalf("mkdir target: %v", err)
+	}
+	link := filepath.Join(root, "heph-wordlist-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink not available: %v", err)
+	}
+
+	if err := cleanupStaleTempDirs(root, now, 24*time.Hour); err != nil {
+		t.Fatalf("cleanup stale temp dirs: %v", err)
+	}
+	if _, err := os.Lstat(filePath); err != nil {
+		t.Fatalf("matching file should remain: %v", err)
+	}
+	if _, err := os.Lstat(link); err != nil {
+		t.Fatalf("matching symlink should remain: %v", err)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("symlink target should remain: %v", err)
+	}
+}
+
+func TestCleanupStaleTempDirsDefaultsMaxAge(t *testing.T) {
+	root := t.TempDir()
+	now := time.Now()
+	stale := filepath.Join(root, "heph-wordlist-stale")
+	if err := os.Mkdir(stale, 0o700); err != nil {
+		t.Fatalf("mkdir stale: %v", err)
+	}
+	old := now.Add(-DefaultStaleTempAge - time.Hour)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatalf("chtimes stale: %v", err)
+	}
+
+	if err := cleanupStaleTempDirs(root, now, 0); err != nil {
+		t.Fatalf("cleanup stale temp dirs: %v", err)
+	}
+	if _, err := os.Stat(stale); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stale wordlist dir should be removed with default age, stat err=%v", err)
+	}
+}

--- a/internal/tui/views/generic/status.go
+++ b/internal/tui/views/generic/status.go
@@ -17,6 +17,7 @@ import (
 	awscloud "heph4estus/internal/cloud/aws"
 	"heph4estus/internal/jobs"
 	"heph4estus/internal/operator"
+	wordlisttool "heph4estus/internal/tools/wordlist"
 	"heph4estus/internal/tui/core"
 	"heph4estus/internal/worker"
 )
@@ -369,6 +370,9 @@ func uploadCleanupError(msg tea.Msg, err error) tea.Msg {
 
 func (m *StatusModel) planWordlist(infra core.InfraOutputs) (*jobs.WordlistPlan, string, error) {
 	if infra.WordlistPath != "" {
+		if err := wordlisttool.CleanupStaleTempDirs(wordlisttool.DefaultStaleTempAge); err != nil {
+			m.cleanupWarning = fmt.Sprintf("wordlist temp cleanup warning: %v", err)
+		}
 		tempDir, err := os.MkdirTemp("", "heph-wordlist-*")
 		if err != nil {
 			return nil, "", fmt.Errorf("creating temp dir: %w", err)


### PR DESCRIPTION
## Summary

  - Add optional streaming object uploads via
  `cloud.StreamingStorage` while keeping the existing
  `cloud.Storage.Upload([]byte)` API intact.
  - Implement streaming uploads for AWS S3 and selfhosted
  S3-compatible/MinIO storage.
  - Move file-backed wordlist chunk uploads to the streaming
  path, with fallback to the existing byte-slice upload when
  streaming is unavailable.
  - Add best-effort cleanup for stale `heph-wordlist-*` temp
  directories before CLI/TUI wordlist planning.

  ## Notes

  - No queue payload, worker protocol, object key layout, or
  task schema changes.
  - Legacy in-memory wordlist planning still uses the
  existing byte upload path.
  - Streaming is opportunistic, so custom/test storage
  backends continue to work through fallback behavior.

  ## Testing

  - `go test ./internal/cloud/... ./internal/jobs ./
  internal/tools/wordlist ./internal/tui/views/generic ./
  cmd/heph`
  - `go test ./...`
  - `go vet ./...`
  - `git diff --check`

  `golangci-lint run` could not run locally because the
  installed binary was built with Go 1.25 while the module
  targets Go 1.26.