### PR TITLE
feat(jobs): optimize high-volume task enqueueing

### DIFF
--- a/cmd/heph/cmd_lifecycle_test.go
+++ b/cmd/heph/cmd_lifecycle_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -368,6 +370,68 @@ func TestRunNmapScanWithDepsStartedFalseOnLaunchFailure(t *testing.T) {
 	}
 	if started {
 		t.Fatal("expected started=false on launch failure")
+	}
+}
+
+func TestRunNmapScanWithDepsBatchesLargeEnqueue(t *testing.T) {
+	tasks := make([]nmaptool.ScanTask, 25)
+	for i := range tasks {
+		tasks[i] = nmaptool.ScanTask{
+			JobID:   "job-1",
+			Target:  fmt.Sprintf("192.0.2.%d", i),
+			Options: "-sS",
+		}
+	}
+	queue := &mockQueue{}
+
+	started, err := runNmapScanWithDeps(
+		context.Background(),
+		tasks,
+		1,
+		"fargate",
+		0,
+		"text",
+		testOutputs(),
+		queue,
+		&mockStorage{count: len(tasks)},
+		&mockCompute{},
+		operator.NoopTracker(),
+		"job-1",
+		fleet.PlacementPolicy{},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !started {
+		t.Fatal("expected started=true")
+	}
+
+	gotSizes := make([]int, len(queue.batches))
+	for i, batch := range queue.batches {
+		gotSizes[i] = len(batch)
+	}
+	sort.Ints(gotSizes)
+	wantSizes := []int{5, 10, 10}
+	for i, want := range wantSizes {
+		if gotSizes[i] != want {
+			t.Fatalf("queued batch sizes = %v, want %v", gotSizes, wantSizes)
+		}
+	}
+
+	sawLast := false
+	for _, batch := range queue.batches {
+		for _, body := range batch {
+			var task worker.Task
+			if err := json.Unmarshal([]byte(body), &task); err != nil {
+				t.Fatalf("unmarshal task: %v", err)
+			}
+			if task.ToolName == "nmap" && task.Target == "192.0.2.24" {
+				sawLast = true
+			}
+		}
+	}
+	if !sawLast {
+		t.Fatal("expected queued payloads to include the final nmap target")
 	}
 }
 

--- a/cmd/heph/cmd_nmap.go
+++ b/cmd/heph/cmd_nmap.go
@@ -319,10 +319,9 @@ func runNmapScanWithDeps(ctx context.Context, tasks []nmap.ScanTask, workers int
 	enqueueCtx, enqueueCancel := context.WithTimeout(ctx, enqueueTimeout)
 	defer enqueueCancel()
 
-	const sqsMaxPayload = 256 * 1024 // 256 KB SQS message size limit
-	bodies := make([]string, len(tasks))
+	genericTasks := make([]worker.Task, len(tasks))
 	for i, t := range tasks {
-		gt := worker.Task{
+		genericTasks[i] = worker.Task{
 			ToolName:    "nmap",
 			JobID:       t.JobID,
 			Target:      t.Target,
@@ -331,19 +330,12 @@ func runNmapScanWithDeps(ctx context.Context, tasks []nmap.ScanTask, workers int
 			ChunkIdx:    t.ChunkIdx,
 			TotalChunks: t.TotalChunks,
 		}
-		b, err := json.Marshal(gt)
-		if err != nil {
-			return false, fmt.Errorf("marshaling task %d: %w", i, err)
-		}
-		if len(b) > sqsMaxPayload {
-			return false, fmt.Errorf("task %d exceeds SQS 256KB limit (%d bytes)", i, len(b))
-		}
-		bodies[i] = string(b)
 	}
-	if err := queue.SendBatch(enqueueCtx, queueURL, bodies); err != nil {
+	enqueueResult, err := jobs.EnqueueTasks(enqueueCtx, queue, queueURL, genericTasks, jobs.EnqueueOptions{})
+	if err != nil {
 		return false, fmt.Errorf("enqueueing targets: %w", err)
 	}
-	logStatus("Enqueued %d targets", len(tasks))
+	logStatus("Enqueued %d targets", enqueueResult.SentTasks)
 
 	_ = tracker.UpdatePhase(jobID, operator.PhaseLaunching)
 

--- a/cmd/heph/cmd_scan.go
+++ b/cmd/heph/cmd_scan.go
@@ -370,18 +370,11 @@ func runTargetListScan(ctx context.Context, tool, jobID, inputFile string, prefl
 	enqueueCtx, enqueueCancel := context.WithTimeout(ctx, enqueueTimeout)
 	defer enqueueCancel()
 
-	bodies := make([]string, len(plan.Tasks))
-	for i, t := range plan.Tasks {
-		b, err := json.Marshal(t)
-		if err != nil {
-			return false, fmt.Errorf("marshaling task %d: %w", i, err)
-		}
-		bodies[i] = string(b)
-	}
-	if err := queue.SendBatch(enqueueCtx, queueURL, bodies); err != nil {
+	enqueueResult, err := jobs.EnqueueTasks(enqueueCtx, queue, queueURL, plan.Tasks, jobs.EnqueueOptions{})
+	if err != nil {
 		return false, fmt.Errorf("enqueueing targets: %w", err)
 	}
-	logStatus("Enqueued %d target tasks", len(plan.Tasks))
+	logStatus("Enqueued %d target tasks", enqueueResult.SentTasks)
 	if plan.FileBacked {
 		if err := plan.Cleanup(); err != nil {
 			logStatus("Warning: failed to clean temporary target-list chunks: %v", err)
@@ -485,18 +478,11 @@ func runWordlistScan(ctx context.Context, tool, jobID, wordlistFile string, pref
 	enqueueCtx, enqueueCancel := context.WithTimeout(ctx, enqueueTimeout)
 	defer enqueueCancel()
 
-	bodies := make([]string, len(plan.Tasks))
-	for i, t := range plan.Tasks {
-		b, err := json.Marshal(t)
-		if err != nil {
-			return false, fmt.Errorf("marshaling task %d: %w", i, err)
-		}
-		bodies[i] = string(b)
-	}
-	if err := queue.SendBatch(enqueueCtx, queueURL, bodies); err != nil {
+	enqueueResult, err := jobs.EnqueueTasks(enqueueCtx, queue, queueURL, plan.Tasks, jobs.EnqueueOptions{})
+	if err != nil {
 		return false, fmt.Errorf("enqueueing chunk tasks: %w", err)
 	}
-	logStatus("Enqueued %d chunk tasks", len(plan.Tasks))
+	logStatus("Enqueued %d chunk tasks", enqueueResult.SentTasks)
 	if err := plan.Cleanup(); err != nil {
 		logStatus("Warning: failed to clean temporary wordlist chunks: %v", err)
 	}

--- a/internal/jobs/enqueue.go
+++ b/internal/jobs/enqueue.go
@@ -1,0 +1,199 @@
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"heph4estus/internal/cloud"
+	"heph4estus/internal/worker"
+)
+
+const (
+	// DefaultEnqueueBatchSize matches the SQS SendMessageBatch limit.
+	DefaultEnqueueBatchSize = 10
+	DefaultEnqueueWorkers   = 4
+	// DefaultMaxQueueMessageBytes matches the SQS message body limit.
+	DefaultMaxQueueMessageBytes = 256 * 1024
+)
+
+// EnqueueOptions controls how worker tasks are marshaled and sent to a queue.
+type EnqueueOptions struct {
+	BatchSize       int
+	Concurrency     int
+	MaxMessageBytes int
+}
+
+// EnqueueResult reports how much work was successfully published.
+type EnqueueResult struct {
+	TotalTasks int
+	SentTasks  int
+	// BatchCount is the number of batches successfully accepted by the queue.
+	BatchCount int
+	Elapsed    time.Duration
+}
+
+type enqueueBatch struct {
+	index int
+	start int
+	end   int
+}
+
+type enqueueBatchResult struct {
+	sent int
+	err  error
+}
+
+type taskMarshaler func(worker.Task) ([]byte, error)
+
+// EnqueueTasks sends tasks through a bounded worker pool without materializing
+// every JSON message body in memory at once.
+func EnqueueTasks(ctx context.Context, queue cloud.Queue, queueID string, tasks []worker.Task, opts EnqueueOptions) (EnqueueResult, error) {
+	return enqueueTasks(ctx, queue, queueID, tasks, opts, marshalWorkerTask)
+}
+
+func enqueueTasks(ctx context.Context, queue cloud.Queue, queueID string, tasks []worker.Task, opts EnqueueOptions, marshal taskMarshaler) (result EnqueueResult, err error) {
+	started := time.Now()
+	result.TotalTasks = len(tasks)
+	defer func() {
+		result.Elapsed = time.Since(started)
+	}()
+
+	if len(tasks) == 0 {
+		return result, nil
+	}
+	if queue == nil {
+		return result, fmt.Errorf("enqueue queue is nil")
+	}
+	if marshal == nil {
+		return result, fmt.Errorf("enqueue task marshaler is nil")
+	}
+
+	opts = normalizeEnqueueOptions(opts)
+	batchCount := (len(tasks) + opts.BatchSize - 1) / opts.BatchSize
+	workerCount := opts.Concurrency
+	if workerCount > batchCount {
+		workerCount = batchCount
+	}
+
+	enqueueCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	jobs := make(chan enqueueBatch)
+	results := make(chan enqueueBatchResult)
+
+	var firstErrMu sync.Mutex
+	var firstErr error
+	recordErr := func(err error) {
+		if err == nil {
+			return
+		}
+		firstErrMu.Lock()
+		defer firstErrMu.Unlock()
+		if firstErr == nil {
+			firstErr = err
+			cancel()
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(workerCount)
+	for i := 0; i < workerCount; i++ {
+		go func() {
+			defer wg.Done()
+			for batch := range jobs {
+				sent, sendErr := sendTaskBatch(enqueueCtx, queue, queueID, tasks, batch, opts.MaxMessageBytes, marshal)
+				recordErr(sendErr)
+				results <- enqueueBatchResult{sent: sent, err: sendErr}
+			}
+		}()
+	}
+
+	go func() {
+		defer close(jobs)
+		for start := 0; start < len(tasks); start += opts.BatchSize {
+			end := start + opts.BatchSize
+			if end > len(tasks) {
+				end = len(tasks)
+			}
+			batch := enqueueBatch{
+				index: start / opts.BatchSize,
+				start: start,
+				end:   end,
+			}
+			select {
+			case <-enqueueCtx.Done():
+				return
+			case jobs <- batch:
+			}
+		}
+	}()
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	for batchResult := range results {
+		if batchResult.err == nil {
+			result.SentTasks += batchResult.sent
+			result.BatchCount++
+		}
+	}
+	firstErrMu.Lock()
+	err = firstErr
+	firstErrMu.Unlock()
+	if err != nil {
+		return result, err
+	}
+	if err := ctx.Err(); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func normalizeEnqueueOptions(opts EnqueueOptions) EnqueueOptions {
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = DefaultEnqueueBatchSize
+	}
+	if opts.BatchSize > DefaultEnqueueBatchSize {
+		opts.BatchSize = DefaultEnqueueBatchSize
+	}
+	if opts.Concurrency <= 0 {
+		opts.Concurrency = DefaultEnqueueWorkers
+	}
+	if opts.MaxMessageBytes <= 0 {
+		opts.MaxMessageBytes = DefaultMaxQueueMessageBytes
+	}
+	return opts
+}
+
+func sendTaskBatch(ctx context.Context, queue cloud.Queue, queueID string, tasks []worker.Task, batch enqueueBatch, maxMessageBytes int, marshal taskMarshaler) (int, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	bodies := make([]string, 0, batch.end-batch.start)
+	for i := batch.start; i < batch.end; i++ {
+		body, err := marshal(tasks[i])
+		if err != nil {
+			return 0, fmt.Errorf("marshal task %d in enqueue batch %d: %w", i, batch.index, err)
+		}
+		if len(body) > maxMessageBytes {
+			return 0, fmt.Errorf("task %d in enqueue batch %d exceeds max queue message size (%d > %d bytes)", i, batch.index, len(body), maxMessageBytes)
+		}
+		bodies = append(bodies, string(body))
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if err := queue.SendBatch(ctx, queueID, bodies); err != nil {
+		return 0, fmt.Errorf("send enqueue batch %d (tasks %d-%d): %w", batch.index, batch.start, batch.end-1, err)
+	}
+	return len(bodies), nil
+}
+
+func marshalWorkerTask(task worker.Task) ([]byte, error) {
+	return json.Marshal(task)
+}

--- a/internal/jobs/enqueue_test.go
+++ b/internal/jobs/enqueue_test.go
@@ -1,0 +1,315 @@
+package jobs
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"heph4estus/internal/cloud"
+	"heph4estus/internal/worker"
+)
+
+var _ cloud.Queue = (*enqueueRecordingQueue)(nil)
+
+type enqueueRecordingQueue struct {
+	mu sync.Mutex
+
+	batches  [][]string
+	queueIDs []string
+
+	failCall int
+	sendErr  error
+
+	active    int
+	maxActive int
+	started   chan struct{}
+	release   <-chan struct{}
+}
+
+func (q *enqueueRecordingQueue) Send(context.Context, string, string) error { return nil }
+
+func (q *enqueueRecordingQueue) SendBatch(ctx context.Context, queueID string, bodies []string) error {
+	copied := append([]string(nil), bodies...)
+
+	q.mu.Lock()
+	call := len(q.batches)
+	q.batches = append(q.batches, copied)
+	q.queueIDs = append(q.queueIDs, queueID)
+	q.active++
+	if q.active > q.maxActive {
+		q.maxActive = q.active
+	}
+	q.mu.Unlock()
+
+	if q.started != nil {
+		q.started <- struct{}{}
+	}
+
+	defer func() {
+		q.mu.Lock()
+		q.active--
+		q.mu.Unlock()
+	}()
+
+	if q.release != nil {
+		select {
+		case <-q.release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	if q.failCall == call {
+		return q.sendErr
+	}
+	return nil
+}
+
+func (q *enqueueRecordingQueue) Receive(context.Context, string) (*cloud.Message, error) {
+	return nil, nil
+}
+
+func (q *enqueueRecordingQueue) Delete(context.Context, string, string) error { return nil }
+
+func makeEnqueueTasks(n int) []worker.Task {
+	tasks := make([]worker.Task, n)
+	for i := range tasks {
+		tasks[i] = worker.Task{
+			ToolName: "httpx",
+			JobID:    "job-123",
+			Target:   fmt.Sprintf("target-%03d.example.com", i),
+			Options:  "-silent",
+		}
+	}
+	return tasks
+}
+
+func TestEnqueueTasksEmpty(t *testing.T) {
+	queue := &enqueueRecordingQueue{}
+	result, err := EnqueueTasks(context.Background(), queue, "queue-url", nil, EnqueueOptions{})
+	if err != nil {
+		t.Fatalf("enqueue tasks: %v", err)
+	}
+	if result.TotalTasks != 0 || result.SentTasks != 0 || result.BatchCount != 0 {
+		t.Fatalf("result = %#v, want zero counts", result)
+	}
+	if len(queue.batches) != 0 {
+		t.Fatalf("queue batches = %d, want 0", len(queue.batches))
+	}
+}
+
+func TestEnqueueTasksSplitsDefaultBatches(t *testing.T) {
+	queue := &enqueueRecordingQueue{}
+	result, err := EnqueueTasks(context.Background(), queue, "queue-url", makeEnqueueTasks(25), EnqueueOptions{
+		Concurrency: 1,
+	})
+	if err != nil {
+		t.Fatalf("enqueue tasks: %v", err)
+	}
+	if result.TotalTasks != 25 || result.SentTasks != 25 || result.BatchCount != 3 {
+		t.Fatalf("result = %#v, want total=25 sent=25 batches=3", result)
+	}
+
+	wantSizes := []int{10, 10, 5}
+	if len(queue.batches) != len(wantSizes) {
+		t.Fatalf("batches = %d, want %d", len(queue.batches), len(wantSizes))
+	}
+	for i, want := range wantSizes {
+		if got := len(queue.batches[i]); got != want {
+			t.Fatalf("batch %d size = %d, want %d", i, got, want)
+		}
+		if queue.queueIDs[i] != "queue-url" {
+			t.Fatalf("batch %d queueID = %q, want queue-url", i, queue.queueIDs[i])
+		}
+	}
+
+	var first, last worker.Task
+	if err := json.Unmarshal([]byte(queue.batches[0][0]), &first); err != nil {
+		t.Fatalf("unmarshal first task: %v", err)
+	}
+	if err := json.Unmarshal([]byte(queue.batches[2][4]), &last); err != nil {
+		t.Fatalf("unmarshal last task: %v", err)
+	}
+	if first.Target != "target-000.example.com" || last.Target != "target-024.example.com" {
+		t.Fatalf("unexpected task order: first=%q last=%q", first.Target, last.Target)
+	}
+}
+
+func TestEnqueueTasksCustomBatchSize(t *testing.T) {
+	queue := &enqueueRecordingQueue{}
+	result, err := EnqueueTasks(context.Background(), queue, "queue-url", makeEnqueueTasks(5), EnqueueOptions{
+		BatchSize:   2,
+		Concurrency: 1,
+	})
+	if err != nil {
+		t.Fatalf("enqueue tasks: %v", err)
+	}
+	if result.BatchCount != 3 || result.SentTasks != 5 {
+		t.Fatalf("result = %#v, want 3 batches and 5 sent tasks", result)
+	}
+	for i, want := range []int{2, 2, 1} {
+		if got := len(queue.batches[i]); got != want {
+			t.Fatalf("batch %d size = %d, want %d", i, got, want)
+		}
+	}
+}
+
+func TestEnqueueTasksUsesBoundedDefaultConcurrency(t *testing.T) {
+	release := make(chan struct{})
+	queue := &enqueueRecordingQueue{
+		started: make(chan struct{}, 20),
+		release: release,
+	}
+	done := make(chan struct {
+		result EnqueueResult
+		err    error
+	}, 1)
+
+	go func() {
+		result, err := EnqueueTasks(context.Background(), queue, "queue-url", makeEnqueueTasks(20), EnqueueOptions{
+			BatchSize: 1,
+		})
+		done <- struct {
+			result EnqueueResult
+			err    error
+		}{result: result, err: err}
+	}()
+
+	for i := 0; i < DefaultEnqueueWorkers; i++ {
+		select {
+		case <-queue.started:
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for batch %d to start", i)
+		}
+	}
+
+	queue.mu.Lock()
+	active := queue.active
+	maxActive := queue.maxActive
+	queue.mu.Unlock()
+	if active != DefaultEnqueueWorkers {
+		t.Fatalf("active sends = %d, want %d", active, DefaultEnqueueWorkers)
+	}
+	if maxActive > DefaultEnqueueWorkers {
+		t.Fatalf("max active sends = %d, want <= %d", maxActive, DefaultEnqueueWorkers)
+	}
+
+	select {
+	case <-queue.started:
+		t.Fatalf("started more than %d sends before release", DefaultEnqueueWorkers)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("enqueue tasks: %v", got.err)
+		}
+		if got.result.SentTasks != 20 || got.result.BatchCount != 20 {
+			t.Fatalf("result = %#v, want 20 sent tasks and batches", got.result)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for enqueue to finish")
+	}
+}
+
+func TestEnqueueTasksSendFailureIncludesBatchOffset(t *testing.T) {
+	sendErr := errors.New("send failed")
+	queue := &enqueueRecordingQueue{
+		failCall: 1,
+		sendErr:  sendErr,
+	}
+
+	result, err := EnqueueTasks(context.Background(), queue, "queue-url", makeEnqueueTasks(4), EnqueueOptions{
+		BatchSize:   2,
+		Concurrency: 1,
+	})
+	if !errors.Is(err, sendErr) {
+		t.Fatalf("error = %v, want wrapping sendErr", err)
+	}
+	if result.SentTasks != 2 || result.BatchCount != 1 {
+		t.Fatalf("result = %#v, want one successful batch before failure", result)
+	}
+	if !strings.Contains(err.Error(), "batch 1") || !strings.Contains(err.Error(), "tasks 2-3") {
+		t.Fatalf("error should include batch and task offsets, got %v", err)
+	}
+}
+
+func TestEnqueueTasksRejectsOversizedPayload(t *testing.T) {
+	queue := &enqueueRecordingQueue{}
+	tasks := []worker.Task{{
+		ToolName: "httpx",
+		Target:   strings.Repeat("x", 80),
+	}}
+
+	result, err := EnqueueTasks(context.Background(), queue, "queue-url", tasks, EnqueueOptions{
+		MaxMessageBytes: 20,
+	})
+	if err == nil {
+		t.Fatal("expected oversized payload error")
+	}
+	if result.SentTasks != 0 || result.BatchCount != 0 {
+		t.Fatalf("result = %#v, want no sent tasks", result)
+	}
+	if len(queue.batches) != 0 {
+		t.Fatalf("queue batches = %d, want 0", len(queue.batches))
+	}
+	if !strings.Contains(err.Error(), "task 0") || !strings.Contains(err.Error(), "exceeds max queue message size") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnqueueTasksMarshalFailureIncludesTaskIndex(t *testing.T) {
+	marshalErr := errors.New("marshal failed")
+	queue := &enqueueRecordingQueue{}
+	tasks := []worker.Task{
+		{ToolName: "httpx", Target: "ok"},
+		{ToolName: "httpx", Target: "bad"},
+	}
+	marshal := func(task worker.Task) ([]byte, error) {
+		if task.Target == "bad" {
+			return nil, marshalErr
+		}
+		return json.Marshal(task)
+	}
+
+	result, err := enqueueTasks(context.Background(), queue, "queue-url", tasks, EnqueueOptions{
+		BatchSize:   2,
+		Concurrency: 1,
+	}, marshal)
+	if !errors.Is(err, marshalErr) {
+		t.Fatalf("error = %v, want wrapping marshalErr", err)
+	}
+	if result.SentTasks != 0 || result.BatchCount != 0 {
+		t.Fatalf("result = %#v, want no sent tasks", result)
+	}
+	if len(queue.batches) != 0 {
+		t.Fatalf("queue batches = %d, want 0", len(queue.batches))
+	}
+	if !strings.Contains(err.Error(), "task 1") {
+		t.Fatalf("error should include task index, got %v", err)
+	}
+}
+
+func TestEnqueueTasksContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	queue := &enqueueRecordingQueue{}
+	result, err := EnqueueTasks(ctx, queue, "queue-url", makeEnqueueTasks(1), EnqueueOptions{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if result.SentTasks != 0 || result.BatchCount != 0 {
+		t.Fatalf("result = %#v, want no sent tasks", result)
+	}
+	if len(queue.batches) != 0 {
+		t.Fatalf("queue batches = %d, want 0", len(queue.batches))
+	}
+}

--- a/internal/tui/views/generic/status.go
+++ b/internal/tui/views/generic/status.go
@@ -2,7 +2,6 @@ package generic
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -114,15 +113,8 @@ type realSubmitter struct {
 }
 
 func (s *realSubmitter) EnqueueTasks(ctx context.Context, queueURL string, tasks []worker.Task) error {
-	bodies := make([]string, len(tasks))
-	for i, t := range tasks {
-		b, err := json.Marshal(t)
-		if err != nil {
-			return fmt.Errorf("marshal task %d: %w", i, err)
-		}
-		bodies[i] = string(b)
-	}
-	return s.queue.SendBatch(ctx, queueURL, bodies)
+	_, err := jobs.EnqueueTasks(ctx, s.queue, queueURL, tasks, jobs.EnqueueOptions{})
+	return err
 }
 
 func (s *realSubmitter) LaunchWorkers(ctx context.Context, opts cloud.ContainerOpts) (string, error) {

--- a/internal/tui/views/nmap/status.go
+++ b/internal/tui/views/nmap/status.go
@@ -2,7 +2,6 @@ package nmap
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -88,15 +87,8 @@ type realSubmitter struct {
 }
 
 func (s *realSubmitter) EnqueueTargets(ctx context.Context, queueURL string, tasks []worker.Task) error {
-	bodies := make([]string, len(tasks))
-	for i, t := range tasks {
-		b, err := json.Marshal(t)
-		if err != nil {
-			return fmt.Errorf("marshal task %d: %w", i, err)
-		}
-		bodies[i] = string(b)
-	}
-	return s.queue.SendBatch(ctx, queueURL, bodies)
+	_, err := jobs.EnqueueTasks(ctx, s.queue, queueURL, tasks, jobs.EnqueueOptions{})
+	return err
 }
 
 func (s *realSubmitter) LaunchWorkers(ctx context.Context, opts cloud.ContainerOpts) (string, error) {


### PR DESCRIPTION

## Summary
- add a shared bounded enqueue helper for worker tasks with 10-message batches, default 4-way concurrency, and 256 KiB payload validation
- route CLI and TUI nmap, target-list, and wordlist producers through the shared enqueue path
- add helper coverage for batching, concurrency, cancellation, partial failures, oversized payloads, and marshal errors, plus a CLI lifecycle regression for large nmap enqueues

## Validation
- go test ./internal/jobs ./cmd/heph ./internal/tui/views/nmap ./internal/tui/views/generic
- go test ./...
- go vet ./...
- git diff --check

## Notes
- golangci-lint was not run locally because the installed binary is built with Go 1.25 while this module targets Go 1.26.
