### PR TITLE
feat(naabu): add tool package and container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,23 +5,25 @@ TOOL_IMAGE_PREFIX ?= heph
 TOOL_IMAGE_SUFFIX ?= worker
 TOOL_IMAGE_TAG ?= latest
 
-TOOL_IMAGES := nmap nuclei subfinder httpx masscan
+TOOL_IMAGES := nmap nuclei subfinder httpx masscan naabu naabu-nmap
 
 NMAP_INSTALL_CMD := apk add --no-cache nmap nmap-scripts
 NUCLEI_INSTALL_CMD := go install github.com/projectdiscovery/nuclei/v3/cmd/nuclei@v3.7.1
 SUBFINDER_INSTALL_CMD := go install github.com/projectdiscovery/subfinder/v2/cmd/subfinder@v2.13.0
 HTTPX_INSTALL_CMD := go install github.com/projectdiscovery/httpx/cmd/httpx@v1.9.0
 MASSCAN_INSTALL_CMD := apk add --no-cache masscan
+NAABU_INSTALL_CMD := go install github.com/projectdiscovery/naabu/v2/cmd/naabu@v2.6.1
 
 NMAP_SMOKE_ARGS := --version
 NUCLEI_SMOKE_ARGS := --help
 SUBFINDER_SMOKE_ARGS := --help
 HTTPX_SMOKE_ARGS := --help
 MASSCAN_SMOKE_ARGS := --version
+NAABU_SMOKE_ARGS := -version
 
 tool_image = $(TOOL_IMAGE_PREFIX)-$(1)-$(TOOL_IMAGE_SUFFIX):$(TOOL_IMAGE_TAG)
 
-.PHONY: all build test lint docker-build docker-build-all docker-build-nmap docker-build-nmap-generic docker-build-nuclei docker-build-subfinder docker-build-httpx docker-build-masscan docker-smoke-all docker-smoke-nmap docker-smoke-nuclei docker-smoke-subfinder docker-smoke-httpx docker-smoke-masscan container-smoke tf-validate clean
+.PHONY: all build test lint docker-build docker-build-all docker-build-nmap docker-build-nmap-generic docker-build-nuclei docker-build-subfinder docker-build-httpx docker-build-masscan docker-build-naabu docker-build-naabu-nmap docker-smoke-all docker-smoke-nmap docker-smoke-nuclei docker-smoke-subfinder docker-smoke-httpx docker-smoke-masscan docker-smoke-naabu docker-smoke-naabu-nmap container-smoke tf-validate clean
 
 all: build test lint
 
@@ -74,6 +76,16 @@ docker-build-masscan:
 		--build-arg TOOL_INSTALL_CMD="$(MASSCAN_INSTALL_CMD)" \
 		-f $(CONTAINER_DOCKERFILE) $(CONTAINER_CONTEXT)
 
+docker-build-naabu:
+	$(DOCKER) build -t $(call tool_image,naabu) \
+		--build-arg GO_INSTALL_CMD="$(NAABU_INSTALL_CMD)" \
+		-f containers/naabu/Dockerfile $(CONTAINER_CONTEXT)
+
+docker-build-naabu-nmap:
+	$(DOCKER) build -t $(call tool_image,naabu-nmap) \
+		--build-arg GO_INSTALL_CMD="$(NAABU_INSTALL_CMD)" \
+		-f containers/naabu/Dockerfile $(CONTAINER_CONTEXT)
+
 docker-build-all: $(addprefix docker-build-,$(TOOL_IMAGES))
 
 docker-smoke-nmap:
@@ -90,6 +102,13 @@ docker-smoke-httpx:
 
 docker-smoke-masscan:
 	SMOKE_ALLOW_NONZERO=1 containers/smoke-tool.sh "$(call tool_image,masscan)" masscan $(MASSCAN_SMOKE_ARGS)
+
+docker-smoke-naabu:
+	containers/smoke-tool.sh "$(call tool_image,naabu)" naabu $(NAABU_SMOKE_ARGS)
+
+docker-smoke-naabu-nmap:
+	containers/smoke-tool.sh "$(call tool_image,naabu-nmap)" naabu $(NAABU_SMOKE_ARGS)
+	containers/smoke-tool.sh "$(call tool_image,naabu-nmap)" nmap $(NMAP_SMOKE_ARGS)
 
 docker-smoke-all: $(addprefix docker-smoke-,$(TOOL_IMAGES))
 

--- a/cmd/heph/cmd_infra_test.go
+++ b/cmd/heph/cmd_infra_test.go
@@ -87,7 +87,7 @@ func TestResolveToolPaths_Httpx(t *testing.T) {
 
 func TestResolveToolPaths_AllRegistryTools(t *testing.T) {
 	// Every registered tool should be resolvable via generic backend.
-	tools := []string{"dalfox", "dnsx", "gospider", "gowitness", "httpx", "katana", "masscan", "massdns", "nmap", "nuclei", "subfinder", "feroxbuster", "ffuf", "gobuster"}
+	tools := []string{"dalfox", "dnsx", "gospider", "gowitness", "httpx", "katana", "masscan", "massdns", "naabu", "naabu-nmap", "nmap", "nuclei", "subfinder", "feroxbuster", "ffuf", "gobuster"}
 	for _, tool := range tools {
 		paths, err := resolveToolConfig(tool, "generic")
 		if err != nil {

--- a/containers/naabu/Dockerfile
+++ b/containers/naabu/Dockerfile
@@ -1,0 +1,36 @@
+FROM golang:1.26-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o /app/bin/worker ./cmd/workers/generic
+
+RUN apk add --no-cache build-base libpcap-dev
+
+ARG GO_INSTALL_CMD="go install github.com/projectdiscovery/naabu/v2/cmd/naabu@v2.6.1"
+ENV GOBIN=/app/bin
+RUN sh -c "${GO_INSTALL_CMD}"
+
+FROM alpine:3.19
+
+RUN apk add --no-cache ca-certificates tzdata libpcap nmap nmap-scripts
+
+WORKDIR /app
+
+COPY --from=builder /app/bin/ /app/bin/
+ENV PATH="/app/bin:${PATH}"
+
+ENV QUEUE_URL=""
+ENV S3_BUCKET=""
+ENV TOOL_NAME=""
+ENV JITTER_MAX_SECONDS=""
+
+RUN addgroup -S worker && adduser -S worker -G worker
+RUN chown -R worker:worker /app
+USER worker
+
+ENTRYPOINT ["/app/bin/worker"]

--- a/internal/infra/toolconfig.go
+++ b/internal/infra/toolconfig.go
@@ -8,6 +8,7 @@ import (
 
 	"heph4estus/internal/cloud"
 	"heph4estus/internal/modules"
+	naabutool "heph4estus/internal/tools/naabu"
 )
 
 // ToolConfig holds all deploy metadata derived from a module definition.
@@ -51,6 +52,9 @@ func ResolveToolConfig(tool string, kind ...cloud.Kind) (*ToolConfig, error) {
 		DockerTag:   fmt.Sprintf("heph-%s-worker:latest", tool),
 		ECRRepoName: fmt.Sprintf("heph-dev-%s", tool),
 		BuildArgs:   InstallCmdToBuildArgs(mod.InstallCmd),
+	}
+	if tool == naabutool.ModuleNaabu || tool == naabutool.ModuleNaabuNmap {
+		cfg.Dockerfile = "containers/naabu/Dockerfile"
 	}
 
 	switch cloudKind.Canonical() {

--- a/internal/infra/toolconfig_test.go
+++ b/internal/infra/toolconfig_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"heph4estus/internal/cloud"
+	naabutool "heph4estus/internal/tools/naabu"
 )
 
 func TestResolveToolConfig_Nmap(t *testing.T) {
@@ -73,6 +74,34 @@ func TestResolveToolConfig_HighPriorityToolImagesUseGenericContainer(t *testing.
 			}
 			if cfg.BuildArgs[tt.buildArgKey] == "" {
 				t.Fatalf("BuildArgs missing %s", tt.buildArgKey)
+			}
+		})
+	}
+}
+
+func TestResolveToolConfig_NaabuModulesUseDedicatedContainer(t *testing.T) {
+	tests := []string{naabutool.ModuleNaabu, naabutool.ModuleNaabuNmap}
+	for _, tool := range tests {
+		t.Run(tool, func(t *testing.T) {
+			cfg, err := ResolveToolConfig(tool)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.Dockerfile != "containers/naabu/Dockerfile" {
+				t.Fatalf("Dockerfile = %q, want containers/naabu/Dockerfile", cfg.Dockerfile)
+			}
+			if cfg.DockerCtx != "." {
+				t.Fatalf("DockerCtx = %q, want .", cfg.DockerCtx)
+			}
+			wantTag := fmt.Sprintf("heph-%s-worker:latest", tool)
+			if cfg.DockerTag != wantTag {
+				t.Fatalf("DockerTag = %q, want %q", cfg.DockerTag, wantTag)
+			}
+			if cfg.ECRRepoName != fmt.Sprintf("heph-dev-%s", tool) {
+				t.Fatalf("ECRRepoName = %q", cfg.ECRRepoName)
+			}
+			if got := cfg.BuildArgs["GO_INSTALL_CMD"]; got != naabutool.InstallCmd {
+				t.Fatalf("GO_INSTALL_CMD = %q, want %q", got, naabutool.InstallCmd)
 			}
 		})
 	}

--- a/internal/modules/definitions/naabu-nmap.yaml
+++ b/internal/modules/definitions/naabu-nmap.yaml
@@ -1,0 +1,10 @@
+name: naabu-nmap
+description: Fast port discovery plus deep nmap service scan
+shell: "naabu -host {{target}} -silent -nmap-cli 'nmap -sV {{options}} -oX {{output}}'"
+input_type: target_list
+output_ext: xml
+install_cmd: "go install github.com/projectdiscovery/naabu/v2/cmd/naabu@v2.6.1"
+default_cpu: 512
+default_memory: 1024
+timeout: 15m
+tags: [scanner, network, pipeline]

--- a/internal/modules/definitions/naabu.yaml
+++ b/internal/modules/definitions/naabu.yaml
@@ -1,0 +1,10 @@
+name: naabu
+description: Fast port discovery scanner
+exec: ["naabu", "-host", "{{target}}", "-silent", "-json", "-o", "{{output}}"]
+input_type: target_list
+output_ext: jsonl
+install_cmd: "go install github.com/projectdiscovery/naabu/v2/cmd/naabu@v2.6.1"
+default_cpu: 256
+default_memory: 512
+timeout: 5m
+tags: [scanner, network]

--- a/internal/modules/registry_test.go
+++ b/internal/modules/registry_test.go
@@ -229,8 +229,8 @@ func TestNewDefaultRegistry(t *testing.T) {
 	}
 
 	names := r.Names()
-	if len(names) != 14 {
-		t.Fatalf("expected 14 modules, got %d: %v", len(names), names)
+	if len(names) != 16 {
+		t.Fatalf("expected 16 modules, got %d: %v", len(names), names)
 	}
 
 	// Every built-in module must pass validation (already validated by Add, but smoke-test)
@@ -250,7 +250,7 @@ func TestNewDefaultRegistry_KnownModules(t *testing.T) {
 	expected := []string{
 		"dalfox", "dnsx", "feroxbuster", "ffuf", "gobuster",
 		"gospider", "gowitness", "httpx", "katana", "massdns",
-		"masscan", "nmap", "nuclei", "subfinder",
+		"masscan", "naabu", "naabu-nmap", "nmap", "nuclei", "subfinder",
 	}
 	for _, name := range expected {
 		if _, err := r.Get(name); err != nil {

--- a/internal/tools/naabu/models.go
+++ b/internal/tools/naabu/models.go
@@ -1,0 +1,51 @@
+package naabu
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	InstallVersion = "v2.6.1"
+	InstallCmd     = "go install github.com/projectdiscovery/naabu/v2/cmd/naabu@" + InstallVersion
+
+	ModuleNaabuNmap = "naabu-nmap"
+	ModuleNaabu     = "naabu"
+)
+
+type Mode string
+
+const (
+	ModeCombined  Mode = "combined"
+	ModeDiscovery Mode = "discovery"
+)
+
+type DiscoveryResult struct {
+	Host      string `json:"host,omitempty"`
+	IP        string `json:"ip,omitempty"`
+	Port      int    `json:"port,omitempty"`
+	Protocol  string `json:"protocol,omitempty"`
+	Timestamp string `json:"timestamp,omitempty"`
+}
+
+func ParseMode(value string) (Mode, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "combined", ModuleNaabuNmap:
+		return ModeCombined, nil
+	case "discovery", ModuleNaabu:
+		return ModeDiscovery, nil
+	default:
+		return "", fmt.Errorf("unknown naabu mode %q", value)
+	}
+}
+
+func (m Mode) ModuleName() string {
+	switch m {
+	case ModeCombined:
+		return ModuleNaabuNmap
+	case ModeDiscovery:
+		return ModuleNaabu
+	default:
+		return ""
+	}
+}

--- a/internal/tools/naabu/models_test.go
+++ b/internal/tools/naabu/models_test.go
@@ -1,0 +1,60 @@
+package naabu
+
+import "testing"
+
+func TestParseMode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  Mode
+	}{
+		{"", ModeCombined},
+		{"combined", ModeCombined},
+		{"naabu-nmap", ModeCombined},
+		{"discovery", ModeDiscovery},
+		{"naabu", ModeDiscovery},
+		{" DISCOVERY ", ModeDiscovery},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseMode(tt.input)
+			if err != nil {
+				t.Fatalf("ParseMode(%q): %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseMode(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseModeRejectsUnknown(t *testing.T) {
+	if _, err := ParseMode("pipeline"); err == nil {
+		t.Fatal("expected unknown mode error")
+	}
+}
+
+func TestModeModuleName(t *testing.T) {
+	tests := []struct {
+		mode Mode
+		want string
+	}{
+		{ModeCombined, ModuleNaabuNmap},
+		{ModeDiscovery, ModuleNaabu},
+		{Mode("unknown"), ""},
+	}
+	for _, tt := range tests {
+		if got := tt.mode.ModuleName(); got != tt.want {
+			t.Fatalf("%q.ModuleName() = %q, want %q", tt.mode, got, tt.want)
+		}
+	}
+}
+
+func TestInstallMetadata(t *testing.T) {
+	if InstallVersion != "v2.6.1" {
+		t.Fatalf("InstallVersion = %q", InstallVersion)
+	}
+	want := "go install github.com/projectdiscovery/naabu/v2/cmd/naabu@v2.6.1"
+	if InstallCmd != want {
+		t.Fatalf("InstallCmd = %q, want %q", InstallCmd, want)
+	}
+}

--- a/internal/worker/template_test.go
+++ b/internal/worker/template_test.go
@@ -34,6 +34,12 @@ func TestRenderCommand(t *testing.T) {
 			want:     "tool -w /tmp/words.txt -o /tmp/out.txt",
 		},
 		{
+			name:     "naabu nmap shell template",
+			template: "naabu -host {{target}} -silent -nmap-cli 'nmap -sV {{options}} -oX {{output}}'",
+			vars:     TemplateVars{Output: "/tmp/out.xml", Target: "192.0.2.10", Options: "-Pn -T4"},
+			want:     "naabu -host 192.0.2.10 -silent -nmap-cli 'nmap -sV -Pn -T4 -oX /tmp/out.xml'",
+		},
+		{
 			name:     "no placeholders",
 			template: "echo hello",
 			vars:     TemplateVars{Input: "/tmp/in", Output: "/tmp/out", Target: "target"},


### PR DESCRIPTION

## Summary
- add Naabu tool metadata with mode/module constants pinned to v2.6.1
- add built-in `naabu` and `naabu-nmap` generic module definitions
- add a dedicated Naabu worker container with Naabu plus Nmap runtime support
- wire Makefile build/smoke targets and infra tool config resolution for both Naabu modules

## Validation
- make -n docker-build-naabu docker-build-naabu-nmap docker-smoke-naabu docker-smoke-naabu-nmap
- go test ./internal/tools/naabu ./internal/modules ./internal/infra ./internal/worker ./cmd/heph
- go test ./...
- go vet ./...
- git diff --check

## Notes
- Real Docker builds/smokes were not run locally.
- Dedicated `heph naabu` CLI/TUI flow and Naabu result parsing remain scoped to later Phase 8 PRs.
