### PR TITLE
feat(naabu): parse and render result artifacts

### DIFF
--- a/internal/tools/naabu/models.go
+++ b/internal/tools/naabu/models.go
@@ -25,6 +25,23 @@ type DiscoveryResult struct {
 	IP        string `json:"ip,omitempty"`
 	Port      int    `json:"port,omitempty"`
 	Protocol  string `json:"protocol,omitempty"`
+	TLS       bool   `json:"tls,omitempty"`
+	CDN       bool   `json:"cdn,omitempty"`
+	CDNName   string `json:"cdn-name,omitempty"`
+	Timestamp string `json:"timestamp,omitempty"`
+}
+
+type OpenPort struct {
+	Host      string `json:"host,omitempty"`
+	IP        string `json:"ip,omitempty"`
+	Protocol  string `json:"protocol,omitempty"`
+	Port      int    `json:"port,omitempty"`
+	Service   string `json:"service,omitempty"`
+	Product   string `json:"product,omitempty"`
+	Version   string `json:"version,omitempty"`
+	TLS       bool   `json:"tls,omitempty"`
+	CDN       bool   `json:"cdn,omitempty"`
+	CDNName   string `json:"cdn-name,omitempty"`
 	Timestamp string `json:"timestamp,omitempty"`
 }
 

--- a/internal/tools/naabu/parser.go
+++ b/internal/tools/naabu/parser.go
@@ -1,0 +1,168 @@
+package naabu
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const maxResultLineBytes = 10 * 1024 * 1024
+
+type nmapXMLRun struct {
+	Hosts []nmapXMLHost `xml:"host"`
+}
+
+type nmapXMLHost struct {
+	Addresses []nmapXMLAddress  `xml:"address"`
+	Hostnames []nmapXMLHostname `xml:"hostnames>hostname"`
+	Ports     []nmapXMLPort     `xml:"ports>port"`
+}
+
+type nmapXMLAddress struct {
+	Addr     string `xml:"addr,attr"`
+	AddrType string `xml:"addrtype,attr"`
+}
+
+type nmapXMLHostname struct {
+	Name string `xml:"name,attr"`
+}
+
+type nmapXMLPort struct {
+	Protocol string          `xml:"protocol,attr"`
+	PortID   string          `xml:"portid,attr"`
+	State    nmapXMLState    `xml:"state"`
+	Service  nmapXMLService  `xml:"service"`
+	Scripts  []nmapXMLScript `xml:"script"`
+}
+
+type nmapXMLState struct {
+	State string `xml:"state,attr"`
+}
+
+type nmapXMLService struct {
+	Name    string `xml:"name,attr"`
+	Product string `xml:"product,attr"`
+	Version string `xml:"version,attr"`
+}
+
+type nmapXMLScript struct {
+	ID     string `xml:"id,attr"`
+	Output string `xml:"output,attr"`
+}
+
+func ParseNmapXML(data []byte, fallbackTarget string) ([]OpenPort, error) {
+	var parsed nmapXMLRun
+	if err := xml.Unmarshal(data, &parsed); err != nil {
+		return nil, err
+	}
+
+	ports := make([]OpenPort, 0)
+	for _, host := range parsed.Hosts {
+		ip := preferredNmapAddress(host, fallbackTarget)
+		hostName := firstNmapHostname(host)
+		for _, port := range host.Ports {
+			if !strings.EqualFold(strings.TrimSpace(port.State.State), "open") {
+				continue
+			}
+			portNumber, err := parseNmapPortID(port.PortID)
+			if err != nil {
+				return nil, err
+			}
+			ports = append(ports, OpenPort{
+				Host:     hostName,
+				IP:       ip,
+				Protocol: normalizeProtocol(port.Protocol),
+				Port:     portNumber,
+				Service:  strings.TrimSpace(port.Service.Name),
+				Product:  strings.TrimSpace(port.Service.Product),
+				Version:  strings.TrimSpace(port.Service.Version),
+			})
+		}
+	}
+	return ports, nil
+}
+
+func ParseDiscoveryJSONL(data []byte) ([]OpenPort, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	scanner.Buffer(make([]byte, 0, 64*1024), maxResultLineBytes)
+
+	var ports []OpenPort
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var record DiscoveryResult
+		if err := json.Unmarshal(line, &record); err != nil {
+			return nil, fmt.Errorf("line %d: %w", lineNo, err)
+		}
+		ports = append(ports, OpenPort{
+			Host:      strings.TrimSpace(record.Host),
+			IP:        strings.TrimSpace(record.IP),
+			Protocol:  normalizeProtocol(record.Protocol),
+			Port:      record.Port,
+			TLS:       record.TLS,
+			CDN:       record.CDN,
+			CDNName:   strings.TrimSpace(record.CDNName),
+			Timestamp: strings.TrimSpace(record.Timestamp),
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return ports, nil
+}
+
+func preferredNmapAddress(host nmapXMLHost, fallback string) string {
+	for _, addr := range host.Addresses {
+		if strings.TrimSpace(addr.Addr) != "" && strings.EqualFold(addr.AddrType, "ipv4") {
+			return strings.TrimSpace(addr.Addr)
+		}
+	}
+	for _, addr := range host.Addresses {
+		if strings.TrimSpace(addr.Addr) != "" && strings.EqualFold(addr.AddrType, "ipv6") {
+			return strings.TrimSpace(addr.Addr)
+		}
+	}
+	for _, addr := range host.Addresses {
+		if strings.TrimSpace(addr.Addr) != "" {
+			return strings.TrimSpace(addr.Addr)
+		}
+	}
+	return strings.TrimSpace(fallback)
+}
+
+func firstNmapHostname(host nmapXMLHost) string {
+	for _, hostname := range host.Hostnames {
+		if strings.TrimSpace(hostname.Name) != "" {
+			return strings.TrimSpace(hostname.Name)
+		}
+	}
+	return ""
+}
+
+func parseNmapPortID(value string) (int, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, fmt.Errorf("missing nmap portid")
+	}
+	port, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid nmap portid %q: %w", value, err)
+	}
+	return port, nil
+}
+
+func normalizeProtocol(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if value == "" {
+		return "tcp"
+	}
+	return value
+}

--- a/internal/tools/naabu/parser_test.go
+++ b/internal/tools/naabu/parser_test.go
@@ -1,0 +1,127 @@
+package naabu
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseNmapXMLReturnsOpenPorts(t *testing.T) {
+	artifact := []byte(`<nmaprun><host><address addr="192.0.2.10" addrtype="ipv4"/><ports><port protocol="tcp" portid="80"><state state="open"/><service name="http" product="nginx" version="1.25"/></port><port protocol="tcp" portid="22"><state state="closed"/></port></ports></host></nmaprun>`)
+
+	ports, err := ParseNmapXML(artifact, "fallback.example")
+	if err != nil {
+		t.Fatalf("ParseNmapXML: %v", err)
+	}
+	if len(ports) != 1 {
+		t.Fatalf("len(ports) = %d, want 1", len(ports))
+	}
+
+	got := ports[0]
+	if got.IP != "192.0.2.10" {
+		t.Fatalf("IP = %q, want 192.0.2.10", got.IP)
+	}
+	if got.Protocol != "tcp" || got.Port != 80 {
+		t.Fatalf("port = %s/%d, want tcp/80", got.Protocol, got.Port)
+	}
+	if got.Service != "http" || got.Product != "nginx" || got.Version != "1.25" {
+		t.Fatalf("service = %q %q %q, want http nginx 1.25", got.Service, got.Product, got.Version)
+	}
+}
+
+func TestParseNmapXMLUsesFallbackTargetWithoutAddress(t *testing.T) {
+	artifact := []byte(`<nmaprun><host><ports><port portid="443"><state state="open"/><service name="https"/></port></ports></host></nmaprun>`)
+
+	ports, err := ParseNmapXML(artifact, "example.com")
+	if err != nil {
+		t.Fatalf("ParseNmapXML: %v", err)
+	}
+	if len(ports) != 1 {
+		t.Fatalf("len(ports) = %d, want 1", len(ports))
+	}
+	if ports[0].IP != "example.com" {
+		t.Fatalf("IP = %q, want fallback target", ports[0].IP)
+	}
+	if ports[0].Protocol != "tcp" {
+		t.Fatalf("Protocol = %q, want default tcp", ports[0].Protocol)
+	}
+}
+
+func TestParseNmapXMLNoOpenPorts(t *testing.T) {
+	artifact := []byte(`<nmaprun><host><address addr="192.0.2.10" addrtype="ipv4"/><ports><port protocol="tcp" portid="22"><state state="closed"/></port></ports></host></nmaprun>`)
+
+	ports, err := ParseNmapXML(artifact, "fallback.example")
+	if err != nil {
+		t.Fatalf("ParseNmapXML: %v", err)
+	}
+	if len(ports) != 0 {
+		t.Fatalf("len(ports) = %d, want 0", len(ports))
+	}
+}
+
+func TestParseNmapXMLMalformed(t *testing.T) {
+	if _, err := ParseNmapXML([]byte(`<nmaprun><host>`), "fallback.example"); err == nil {
+		t.Fatal("expected malformed XML error")
+	}
+}
+
+func TestParseDiscoveryJSONLBasic(t *testing.T) {
+	ports, err := ParseDiscoveryJSONL([]byte(`{"ip":"104.16.99.52","port":443}` + "\n"))
+	if err != nil {
+		t.Fatalf("ParseDiscoveryJSONL: %v", err)
+	}
+	if len(ports) != 1 {
+		t.Fatalf("len(ports) = %d, want 1", len(ports))
+	}
+	got := ports[0]
+	if got.IP != "104.16.99.52" || got.Port != 443 {
+		t.Fatalf("port = %s/%d, want 104.16.99.52/443", got.IP, got.Port)
+	}
+	if got.Protocol != "tcp" {
+		t.Fatalf("Protocol = %q, want default tcp", got.Protocol)
+	}
+}
+
+func TestParseDiscoveryJSONLOptionalFields(t *testing.T) {
+	artifact := []byte(`{"host":"example.com","ip":"192.0.2.10","port":8443,"protocol":"udp","tls":true,"cdn":true,"cdn-name":"cloudflare","timestamp":"2026-06-07T12:00:00Z"}` + "\n")
+
+	ports, err := ParseDiscoveryJSONL(artifact)
+	if err != nil {
+		t.Fatalf("ParseDiscoveryJSONL: %v", err)
+	}
+	if len(ports) != 1 {
+		t.Fatalf("len(ports) = %d, want 1", len(ports))
+	}
+	got := ports[0]
+	if got.Host != "example.com" || got.IP != "192.0.2.10" {
+		t.Fatalf("target = host %q ip %q, want example.com 192.0.2.10", got.Host, got.IP)
+	}
+	if got.Protocol != "udp" || got.Port != 8443 {
+		t.Fatalf("port = %s/%d, want udp/8443", got.Protocol, got.Port)
+	}
+	if !got.TLS || !got.CDN || got.CDNName != "cloudflare" {
+		t.Fatalf("metadata = tls %v cdn %v cdn-name %q, want true true cloudflare", got.TLS, got.CDN, got.CDNName)
+	}
+	if got.Timestamp != "2026-06-07T12:00:00Z" {
+		t.Fatalf("Timestamp = %q", got.Timestamp)
+	}
+}
+
+func TestParseDiscoveryJSONLSkipsBlankLines(t *testing.T) {
+	ports, err := ParseDiscoveryJSONL([]byte("\n" + `{"ip":"192.0.2.10","port":80}` + "\n\n"))
+	if err != nil {
+		t.Fatalf("ParseDiscoveryJSONL: %v", err)
+	}
+	if len(ports) != 1 {
+		t.Fatalf("len(ports) = %d, want 1", len(ports))
+	}
+}
+
+func TestParseDiscoveryJSONLMalformedLineNumber(t *testing.T) {
+	_, err := ParseDiscoveryJSONL([]byte("\n{bad json}\n"))
+	if err == nil {
+		t.Fatal("expected malformed JSON error")
+	}
+	if !strings.Contains(err.Error(), "line 2") {
+		t.Fatalf("error = %q, want line number", err)
+	}
+}

--- a/internal/tui/views/generic/resultfmt.go
+++ b/internal/tui/views/generic/resultfmt.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	naabutool "heph4estus/internal/tools/naabu"
 	"heph4estus/internal/tui/core"
 	"heph4estus/internal/worker"
 )
@@ -96,6 +97,12 @@ func outputRef(bucket, key string) string {
 
 func formatToolArtifact(r worker.Result, artifact []byte) (string, string, error) {
 	switch strings.ToLower(strings.TrimSpace(r.ToolName)) {
+	case naabutool.ModuleNaabuNmap:
+		body, err := formatNaabuNmapArtifact(r, artifact)
+		return "Naabu + Nmap Open Ports", body, err
+	case naabutool.ModuleNaabu:
+		body, err := formatNaabuDiscoveryArtifact(artifact)
+		return "Naabu Open Ports", body, err
 	case "nmap":
 		body, err := formatNmapArtifact(r, artifact)
 		return "Nmap Open Ports", body, err
@@ -194,6 +201,80 @@ func nmapHostLabel(host nmapXMLHost, fallback string) string {
 		}
 	}
 	return fallback
+}
+
+func formatNaabuNmapArtifact(r worker.Result, artifact []byte) (string, error) {
+	ports, err := naabutool.ParseNmapXML(artifact, r.Target)
+	if err != nil {
+		return "", err
+	}
+	return formatNaabuOpenPorts(ports, "No open ports found."), nil
+}
+
+func formatNaabuDiscoveryArtifact(artifact []byte) (string, error) {
+	ports, err := naabutool.ParseDiscoveryJSONL(artifact)
+	if err != nil {
+		return "", err
+	}
+	return formatNaabuOpenPorts(ports, "No naabu ports found."), nil
+}
+
+func formatNaabuOpenPorts(ports []naabutool.OpenPort, emptyMessage string) string {
+	if len(ports) == 0 {
+		return emptyMessage
+	}
+
+	lines := []string{
+		fmt.Sprintf("%-24s %-9s %-30s %s", "HOST/IP", "PORT", "SERVICE", "DETAILS"),
+		fmt.Sprintf("%-24s %-9s %-30s %s", strings.Repeat("-", 24), strings.Repeat("-", 9), strings.Repeat("-", 30), strings.Repeat("-", 30)),
+	}
+	for _, port := range ports {
+		lines = append(lines, fmt.Sprintf("%-24s %-9s %-30s %s",
+			clipText(firstNonEmpty(port.Host, port.IP, "-"), 24),
+			formatNaabuPort(port),
+			clipText(formatNaabuService(port), 30),
+			clipText(formatNaabuDetails(port), 80),
+		))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatNaabuPort(port naabutool.OpenPort) string {
+	protocol := firstNonEmpty(port.Protocol, "tcp")
+	if port.Port <= 0 {
+		return protocol + "/-"
+	}
+	return fmt.Sprintf("%s/%d", protocol, port.Port)
+}
+
+func formatNaabuService(port naabutool.OpenPort) string {
+	service := strings.TrimSpace(strings.Join(nonEmpty(port.Service, port.Product, port.Version), " "))
+	if service == "" {
+		return "-"
+	}
+	return service
+}
+
+func formatNaabuDetails(port naabutool.OpenPort) string {
+	parts := make([]string, 0, 4)
+	if port.Host != "" && port.IP != "" && port.Host != port.IP {
+		parts = append(parts, "ip="+port.IP)
+	}
+	if port.TLS {
+		parts = append(parts, "tls")
+	}
+	if port.CDNName != "" {
+		parts = append(parts, "cdn="+port.CDNName)
+	} else if port.CDN {
+		parts = append(parts, "cdn")
+	}
+	if port.Timestamp != "" {
+		parts = append(parts, "time="+port.Timestamp)
+	}
+	if len(parts) == 0 {
+		return "-"
+	}
+	return strings.Join(parts, ",")
 }
 
 type nucleiRecord struct {

--- a/internal/tui/views/generic/resultfmt_test.go
+++ b/internal/tui/views/generic/resultfmt_test.go
@@ -28,6 +28,45 @@ func TestFormatNmapArtifact(t *testing.T) {
 	}
 }
 
+func TestFormatNaabuNmapArtifact(t *testing.T) {
+	result := worker.Result{ToolName: "naabu-nmap", Target: "example.com"}
+	artifact := []byte(`<nmaprun><host><address addr="192.0.2.10" addrtype="ipv4"/><hostnames><hostname name="example.com"/></hostnames><ports><port protocol="tcp" portid="443"><state state="open"/><service name="https" product="nginx" version="1.25"/></port><port protocol="tcp" portid="25"><state state="filtered"/></port></ports></host></nmaprun>`)
+
+	title, body, err := formatToolArtifact(result, artifact)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if title != "Naabu + Nmap Open Ports" {
+		t.Fatalf("title = %q", title)
+	}
+	for _, want := range []string{"example.com", "tcp/443", "https nginx 1.25", "ip=192.0.2.10"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in naabu-nmap output:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "tcp/25") {
+		t.Fatal("filtered ports should not be rendered")
+	}
+}
+
+func TestFormatNaabuDiscoveryArtifact(t *testing.T) {
+	result := worker.Result{ToolName: "naabu", Target: "example.com"}
+	artifact := []byte(`{"host":"example.com","ip":"192.0.2.10","port":443,"tls":true,"cdn":true,"cdn-name":"cloudflare"}` + "\n")
+
+	title, body, err := formatToolArtifact(result, artifact)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if title != "Naabu Open Ports" {
+		t.Fatalf("title = %q", title)
+	}
+	for _, want := range []string{"example.com", "tcp/443", "ip=192.0.2.10", "tls", "cdn=cloudflare"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in naabu output:\n%s", want, body)
+		}
+	}
+}
+
 func TestFormatNucleiArtifact(t *testing.T) {
 	body, err := formatNucleiArtifact([]byte(`{"template-id":"cves/2026/test","matched-at":"https://example.com","info":{"name":"Example Finding","severity":"high"}}` + "\n"))
 	if err != nil {
@@ -81,6 +120,22 @@ func TestFormatResultMalformedArtifactFallsBackToRaw(t *testing.T) {
 		ToolName:  "nuclei",
 		Target:    "example.com",
 		OutputKey: "scans/nuclei/job/artifacts/example.jsonl",
+		Timestamp: time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC),
+	}
+	body := formatResultWithArtifact("bucket", result, []byte(`{bad json}`), nil)
+	if !strings.Contains(body, "Artifact parse error") {
+		t.Fatal("expected parse error in formatted result")
+	}
+	if !strings.Contains(body, "{bad json}") {
+		t.Fatal("expected raw artifact fallback")
+	}
+}
+
+func TestFormatResultMalformedNaabuArtifactFallsBackToRaw(t *testing.T) {
+	result := worker.Result{
+		ToolName:  "naabu",
+		Target:    "example.com",
+		OutputKey: "scans/naabu/job/artifacts/example.jsonl",
 		Timestamp: time.Date(2026, 5, 12, 0, 0, 0, 0, time.UTC),
 	}
 	body := formatResultWithArtifact("bucket", result, []byte(`{bad json}`), nil)


### PR DESCRIPTION
## Summary
- Add reusable Naabu JSONL and Naabu+nmap XML artifact parsers
- Normalize open-port records with host/IP/protocol/service/TLS/CDN metadata
- Render naabu and naabu-nmap artifacts in the generic TUI result detail view

## Testing
- go test ./internal/tools/naabu ./internal/tui/views/generic
- go test ./...
- go vet ./...
- git diff --check