### PR TITLE
feat(naabu): add CLI/TUI mode selector

### DIFF
--- a/cmd/heph/cmd_naabu.go
+++ b/cmd/heph/cmd_naabu.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"heph4estus/internal/cloud"
+	"heph4estus/internal/logger"
+	naabutool "heph4estus/internal/tools/naabu"
+)
+
+func runNaabu(args []string, log logger.Logger) error {
+	fs := flag.NewFlagSet("naabu", flag.ContinueOnError)
+	inputFile := fs.String("file", "", "Path to file containing targets (required)")
+	modeValue := fs.String("mode", string(naabutool.ModeCombined), "Mode: combined or discovery")
+	nmapOptions := fs.String("nmap-options", "", "Extra nmap options for combined mode")
+	workers := fs.Int("workers", 0, "Number of worker tasks to launch (default: from config or 10)")
+	computeMode := fs.String("compute-mode", "", "Compute mode: auto, fargate, or spot (default: from config or auto)")
+	placementMode := fs.String("placement", "", "Fleet placement policy: diversity or throughput (default: from config or diversity)")
+	maxWorkersPerHost := fs.Int("max-workers-per-host", 0, "Maximum admitted workers per host/public IP (default: from config or policy)")
+	minUniqueIPs := fs.Int("min-unique-ips", 0, "Minimum unique public IPv4 addresses required before scan start")
+	ipv6Required := fs.Bool("ipv6-required", false, "Require IPv6-validated workers before scan start")
+	dualStackRequired := fs.Bool("dual-stack-required", false, "Require workers with both public IPv4 and IPv6-ready public IPv6")
+	format := fs.String("format", "text", "Output format: text or json")
+	outDir := fs.String("out", "", "Download results/artifacts to this directory after completion")
+
+	noDeploy := fs.Bool("no-deploy", false, "Fail instead of deploying or redeploying infrastructure")
+	autoApprove := fs.Bool("auto-approve", false, "Skip deploy confirmation prompts when lifecycle requires deploy")
+	destroyAfter := fs.Bool("destroy-after", false, "Destroy infrastructure after the run completes")
+	cloudFlag := fs.String("cloud", "", "Cloud provider: "+cloud.SupportedKindsText()+" (default: from config or aws)")
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	normalizedMode := strings.ToLower(strings.TrimSpace(*modeValue))
+	if normalizedMode == "" {
+		normalizedMode = string(naabutool.ModeCombined)
+	}
+	if normalizedMode != string(naabutool.ModeCombined) && normalizedMode != string(naabutool.ModeDiscovery) {
+		return fmt.Errorf("--mode must be combined or discovery")
+	}
+	mode, _ := naabutool.ParseMode(normalizedMode)
+	if mode == naabutool.ModeDiscovery && strings.TrimSpace(*nmapOptions) != "" {
+		return fmt.Errorf("--nmap-options is only valid with --mode combined")
+	}
+
+	return runScan(buildNaabuScanArgs(mode, naabuScanArgsOptions{
+		InputFile:         *inputFile,
+		NmapOptions:       *nmapOptions,
+		Workers:           *workers,
+		ComputeMode:       *computeMode,
+		PlacementMode:     *placementMode,
+		MaxWorkersPerHost: *maxWorkersPerHost,
+		MinUniqueIPs:      *minUniqueIPs,
+		IPv6Required:      *ipv6Required,
+		DualStackRequired: *dualStackRequired,
+		Format:            *format,
+		OutDir:            *outDir,
+		NoDeploy:          *noDeploy,
+		AutoApprove:       *autoApprove,
+		DestroyAfter:      *destroyAfter,
+		Cloud:             *cloudFlag,
+	}), log)
+}
+
+type naabuScanArgsOptions struct {
+	InputFile         string
+	NmapOptions       string
+	Workers           int
+	ComputeMode       string
+	PlacementMode     string
+	MaxWorkersPerHost int
+	MinUniqueIPs      int
+	IPv6Required      bool
+	DualStackRequired bool
+	Format            string
+	OutDir            string
+	NoDeploy          bool
+	AutoApprove       bool
+	DestroyAfter      bool
+	Cloud             string
+}
+
+func buildNaabuScanArgs(mode naabutool.Mode, opts naabuScanArgsOptions) []string {
+	scanArgs := []string{"--tool", mode.ModuleName()}
+	appendStringFlag := func(name, value string) {
+		if strings.TrimSpace(value) != "" {
+			scanArgs = append(scanArgs, name, value)
+		}
+	}
+	appendIntFlag := func(name string, value int) {
+		if value != 0 {
+			scanArgs = append(scanArgs, name, strconv.Itoa(value))
+		}
+	}
+	appendBoolFlag := func(name string, value bool) {
+		if value {
+			scanArgs = append(scanArgs, name)
+		}
+	}
+
+	appendStringFlag("--file", opts.InputFile)
+	if mode == naabutool.ModeCombined {
+		appendStringFlag("--options", opts.NmapOptions)
+	}
+	appendIntFlag("--workers", opts.Workers)
+	appendStringFlag("--compute-mode", opts.ComputeMode)
+	appendStringFlag("--placement", opts.PlacementMode)
+	appendIntFlag("--max-workers-per-host", opts.MaxWorkersPerHost)
+	appendIntFlag("--min-unique-ips", opts.MinUniqueIPs)
+	appendBoolFlag("--ipv6-required", opts.IPv6Required)
+	appendBoolFlag("--dual-stack-required", opts.DualStackRequired)
+	appendStringFlag("--format", opts.Format)
+	appendStringFlag("--out", opts.OutDir)
+	appendBoolFlag("--no-deploy", opts.NoDeploy)
+	appendBoolFlag("--auto-approve", opts.AutoApprove)
+	appendBoolFlag("--destroy-after", opts.DestroyAfter)
+	appendStringFlag("--cloud", opts.Cloud)
+
+	return scanArgs
+}

--- a/cmd/heph/main.go
+++ b/cmd/heph/main.go
@@ -20,6 +20,7 @@ const usage = `Usage: heph <command> [options]
 
 Commands:
   nmap     Run an nmap scan (auto-deploys infrastructure if needed)
+  naabu    Run a naabu scan with combined or discovery mode
   scan     Run a generic tool scan (e.g. httpx, nuclei, ffuf; auto-deploys if needed)
   infra    Manage cloud infrastructure explicitly (deploy/destroy/backup/recover/trust/rotate)
   fleet    Inspect and manage provider-native fleet state
@@ -42,6 +43,8 @@ func run(args []string, log logger.Logger) error {
 	switch cmd {
 	case "nmap":
 		return runNmap(cmdArgs, log)
+	case "naabu":
+		return runNaabu(cmdArgs, log)
 	case "scan":
 		return runScan(cmdArgs, log)
 	case "infra":

--- a/cmd/heph/main_test.go
+++ b/cmd/heph/main_test.go
@@ -107,6 +107,107 @@ func TestNmapNonexistentFile(t *testing.T) {
 	}
 }
 
+// --- naabu subcommand ---
+
+func TestUsageIncludesNaabu(t *testing.T) {
+	if !strings.Contains(usage, "naabu") {
+		t.Fatal("expected usage to include naabu command")
+	}
+}
+
+func TestNaabuMissingFile(t *testing.T) {
+	err := run([]string{"naabu"}, testLogger())
+	if err == nil {
+		t.Fatal("expected error for naabu without --file")
+	}
+	if !strings.Contains(err.Error(), "--file flag is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNaabuInvalidMode(t *testing.T) {
+	err := run([]string{"naabu", "--file", "targets.txt", "--mode", "pipeline"}, testLogger())
+	if err == nil {
+		t.Fatal("expected error for invalid naabu mode")
+	}
+	if !strings.Contains(err.Error(), "--mode must be combined or discovery") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNaabuDiscoveryRejectsNmapOptions(t *testing.T) {
+	err := run([]string{"naabu", "--file", "targets.txt", "--mode", "discovery", "--nmap-options", "-Pn"}, testLogger())
+	if err == nil {
+		t.Fatal("expected error for nmap options in discovery mode")
+	}
+	if !strings.Contains(err.Error(), "--nmap-options is only valid with --mode combined") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNaabuCombinedMapsToNaabuNmapScan(t *testing.T) {
+	args := buildNaabuScanArgs("combined", naabuScanArgsOptions{
+		InputFile:   "targets.txt",
+		NmapOptions: "-Pn",
+		Workers:     12,
+		Format:      "json",
+	})
+	if got := flagValue(args, "--tool"); got != "naabu-nmap" {
+		t.Fatalf("--tool = %q, want naabu-nmap", got)
+	}
+	if got := flagValue(args, "--options"); got != "-Pn" {
+		t.Fatalf("--options = %q, want -Pn", got)
+	}
+	if got := flagValue(args, "--workers"); got != "12" {
+		t.Fatalf("--workers = %q, want 12", got)
+	}
+	if got := flagValue(args, "--format"); got != "json" {
+		t.Fatalf("--format = %q, want json", got)
+	}
+}
+
+func TestNaabuDiscoveryMapsToNaabuScan(t *testing.T) {
+	args := buildNaabuScanArgs("discovery", naabuScanArgsOptions{
+		InputFile:   "targets.txt",
+		NmapOptions: "-Pn",
+	})
+	if got := flagValue(args, "--tool"); got != "naabu" {
+		t.Fatalf("--tool = %q, want naabu", got)
+	}
+	if got := flagValue(args, "--options"); got != "" {
+		t.Fatalf("--options should not be set for discovery, got %q", got)
+	}
+}
+
+func TestNaabuZeroWorkersResolvesToDefault(t *testing.T) {
+	err := run([]string{"naabu", "--file", "/nonexistent/targets.txt", "--workers", "0"}, testLogger())
+	if err == nil {
+		t.Fatal("expected error (file not found)")
+	}
+	if strings.Contains(err.Error(), "--workers must be positive") {
+		t.Fatal("--workers 0 should resolve to default, not error")
+	}
+}
+
+func TestNaabuNonexistentFile(t *testing.T) {
+	err := run([]string{"naabu", "--file", "/nonexistent/targets.txt"}, testLogger())
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(err.Error(), "validating target file") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func flagValue(args []string, flag string) string {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
 // --- scan subcommand ---
 
 func TestScanMissingTool(t *testing.T) {

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -15,6 +15,7 @@ import (
 	"heph4estus/internal/tui/views/deploy"
 	genericview "heph4estus/internal/tui/views/generic"
 	"heph4estus/internal/tui/views/menu"
+	naabuview "heph4estus/internal/tui/views/naabu"
 	nmapview "heph4estus/internal/tui/views/nmap"
 	"heph4estus/internal/tui/views/settings"
 )
@@ -58,6 +59,8 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			newView = menu.New()
 		case core.ViewNmapConfig:
 			newView = nmapview.NewConfig()
+		case core.ViewNaabuConfig:
+			newView = naabuview.NewConfig()
 		}
 		if newView != nil {
 			a.switchView(newView)

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -92,6 +92,18 @@ func TestNavigateToNmapConfig(t *testing.T) {
 	}
 }
 
+func TestNavigateToNaabuConfig(t *testing.T) {
+	app := NewApp()
+	app.Init()
+
+	_, _ = app.Update(core.NavigateMsg{Target: core.ViewNaabuConfig})
+
+	v := app.View()
+	if !strings.Contains(v.Content, "Naabu") {
+		t.Fatal("expected naabu config view to contain 'Naabu'")
+	}
+}
+
 func TestNavigateWithDataMsg_Deploy(t *testing.T) {
 	app := NewApp()
 	app.Init()

--- a/internal/tui/views/menu/model.go
+++ b/internal/tui/views/menu/model.go
@@ -11,6 +11,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"heph4estus/internal/modules"
+	naabutool "heph4estus/internal/tools/naabu"
 	"heph4estus/internal/tui/core"
 )
 
@@ -155,6 +156,7 @@ func buildMenuItems() []list.Item {
 	}
 
 	var items []list.Item
+	naabuAdded := false
 	for _, mod := range reg.List() {
 		switch {
 		case mod.Name == "nmap":
@@ -164,6 +166,15 @@ func buildMenuItems() []list.Item {
 				enabled: true,
 				target:  core.ViewNmapConfig,
 			})
+		case mod.Name == naabutool.ModuleNaabu || mod.Name == naabutool.ModuleNaabuNmap:
+			if !naabuAdded {
+				items = append(items, menuItem{
+					title:   "naabu — Fast port discovery + nmap pipeline",
+					enabled: true,
+					target:  core.ViewNaabuConfig,
+				})
+				naabuAdded = true
+			}
 		case mod.InputType == modules.InputTypeWordlist:
 			// Wordlist modules route to the generic config flow.
 			items = append(items, menuItem{

--- a/internal/tui/views/menu/model_test.go
+++ b/internal/tui/views/menu/model_test.go
@@ -6,6 +6,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"heph4estus/internal/modules"
+	naabutool "heph4estus/internal/tools/naabu"
 	"heph4estus/internal/tui/core"
 )
 
@@ -80,6 +81,62 @@ func TestMenuNmapRoutesToNmapConfig(t *testing.T) {
 	}
 	if nav.Target != core.ViewNmapConfig {
 		t.Fatalf("expected ViewNmapConfig, got %v", nav.Target)
+	}
+}
+
+func TestMenuNaabuRoutesToNaabuConfig(t *testing.T) {
+	items := buildMenuItems()
+	naabuIdx := -1
+	for i, item := range items {
+		mi, ok := item.(menuItem)
+		if ok && mi.target == core.ViewNaabuConfig {
+			naabuIdx = i
+			break
+		}
+	}
+	if naabuIdx == -1 {
+		t.Fatal("naabu entry not found in menu items")
+	}
+
+	m := New()
+	for i := 0; i < naabuIdx; i++ {
+		m.Update(tea.KeyPressMsg{Code: 'j'})
+	}
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected command from selecting naabu")
+	}
+	msg := cmd()
+	nav, ok := msg.(core.NavigateMsg)
+	if !ok {
+		t.Fatalf("expected NavigateMsg, got %T", msg)
+	}
+	if nav.Target != core.ViewNaabuConfig {
+		t.Fatalf("expected ViewNaabuConfig, got %v", nav.Target)
+	}
+}
+
+func TestMenuHidesRawNaabuModules(t *testing.T) {
+	items := buildMenuItems()
+	var naabuEntries int
+	for _, item := range items {
+		mi, ok := item.(menuItem)
+		if !ok {
+			continue
+		}
+		if strings.Contains(mi.title, naabutool.ModuleNaabuNmap) {
+			t.Fatalf("menu should not expose raw %q entry", naabutool.ModuleNaabuNmap)
+		}
+		if mi.target == core.ViewNaabuConfig {
+			naabuEntries++
+		}
+		if mi.toolName == naabutool.ModuleNaabu || mi.toolName == naabutool.ModuleNaabuNmap {
+			t.Fatalf("menu should not route raw naabu module %q through generic config", mi.toolName)
+		}
+	}
+	if naabuEntries != 1 {
+		t.Fatalf("naabu menu entries = %d, want 1", naabuEntries)
 	}
 }
 
@@ -174,8 +231,8 @@ func TestBuildMenuItemsContainsAllModules(t *testing.T) {
 	}
 
 	items := buildMenuItems()
-	// Should have one item per module + Settings.
-	expectedCount := len(reg.List()) + 1
+	// Raw naabu modules collapse into one dedicated entry, plus Settings.
+	expectedCount := len(reg.List())
 	if len(items) != expectedCount {
 		t.Errorf("expected %d menu items, got %d", expectedCount, len(items))
 	}

--- a/internal/tui/views/naabu/config.go
+++ b/internal/tui/views/naabu/config.go
@@ -1,0 +1,425 @@
+package naabu
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"charm.land/bubbles/v2/help"
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"heph4estus/internal/cloud"
+	"heph4estus/internal/cloud/factory"
+	"heph4estus/internal/fleet"
+	"heph4estus/internal/infra"
+	"heph4estus/internal/operator"
+	naabutool "heph4estus/internal/tools/naabu"
+	targetlisttool "heph4estus/internal/tools/targetlist"
+	"heph4estus/internal/tui/core"
+)
+
+type targetListReadMsg struct {
+	path string
+	meta *targetlisttool.Metadata
+	err  error
+}
+
+type configKeyMap struct {
+	Tab   key.Binding
+	Enter key.Binding
+	Back  key.Binding
+	Quit  key.Binding
+}
+
+func (k configKeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Tab, k.Enter, k.Back, k.Quit}
+}
+
+func (k configKeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{{k.Tab, k.Enter, k.Back, k.Quit}}
+}
+
+var configKeys = configKeyMap{
+	Tab:   key.NewBinding(key.WithKeys("tab", "shift+tab"), key.WithHelp("tab", "next field")),
+	Enter: key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "submit/toggle")),
+	Back:  key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "back")),
+	Quit:  key.NewBinding(key.WithKeys("ctrl+c"), key.WithHelp("ctrl+c", "quit")),
+}
+
+const (
+	fieldTargetFile = iota
+	fieldMode
+	fieldNmapOptions
+	fieldWorkerCount
+	fieldComputeMode
+	fieldCloud
+	fieldSubmit
+	fieldCount
+)
+
+// ConfigModel is the Naabu configuration form view.
+type ConfigModel struct {
+	inputs     [5]textinput.Model
+	mode       naabutool.Mode
+	focusIndex int
+	help       help.Model
+	width      int
+	height     int
+	errMsg     string
+}
+
+// NewConfig creates a Naabu config view with combined mode selected by default.
+func NewConfig() *ConfigModel {
+	cfg, _ := operator.LoadConfig()
+
+	targetInput := textinput.New()
+	targetInput.Placeholder = "/path/to/targets.txt"
+	targetInput.Focus()
+	targetInput.CharLimit = 256
+
+	optsInput := textinput.New()
+	optsInput.Placeholder = "-Pn -T4"
+	optsInput.CharLimit = 256
+
+	workers := operator.ResolveWorkers(0, cfg)
+	computeMode := operator.ResolveComputeMode("", cfg)
+
+	workerInput := textinput.New()
+	workerInput.Placeholder = "10"
+	workerInput.SetValue(strconv.Itoa(workers))
+	workerInput.CharLimit = 6
+
+	modeInput := textinput.New()
+	modeInput.Placeholder = "auto"
+	modeInput.SetValue(computeMode)
+	modeInput.CharLimit = 7
+
+	savedCloud := ""
+	if cfg != nil {
+		savedCloud = normalizeCloudValue(cfg.Cloud)
+	}
+	cloudInput := textinput.New()
+	cloudInput.Placeholder = "aws"
+	if savedCloud != "" {
+		cloudInput.SetValue(savedCloud)
+	}
+	cloudInput.CharLimit = 12
+
+	h := help.New()
+	h.Styles = help.Styles{
+		ShortKey:       lipgloss.NewStyle().Foreground(core.Steel),
+		ShortDesc:      lipgloss.NewStyle().Foreground(core.Steel),
+		ShortSeparator: lipgloss.NewStyle().Foreground(core.Steel),
+		FullKey:        lipgloss.NewStyle().Foreground(core.Steel),
+		FullDesc:       lipgloss.NewStyle().Foreground(core.Steel),
+		FullSeparator:  lipgloss.NewStyle().Foreground(core.Steel),
+		Ellipsis:       lipgloss.NewStyle().Foreground(core.Steel),
+	}
+
+	return &ConfigModel{
+		inputs: [5]textinput.Model{targetInput, optsInput, workerInput, modeInput, cloudInput},
+		mode:   naabutool.ModeCombined,
+		help:   h,
+	}
+}
+
+func (m *ConfigModel) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (m *ConfigModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.help.SetWidth(msg.Width)
+
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "esc":
+			return m, func() tea.Msg {
+				return core.NavigateMsg{Target: core.ViewMenu}
+			}
+		case "tab", "down":
+			m.focusIndex = (m.focusIndex + 1) % fieldCount
+			return m, m.updateFocus()
+		case "shift+tab", "up":
+			m.focusIndex = (m.focusIndex - 1 + fieldCount) % fieldCount
+			return m, m.updateFocus()
+		case "enter":
+			if m.focusIndex == fieldSubmit {
+				return m, m.submit()
+			}
+			if m.focusIndex == fieldMode {
+				m.toggleMode()
+				return m, nil
+			}
+			m.focusIndex = (m.focusIndex + 1) % fieldCount
+			return m, m.updateFocus()
+		case " ":
+			if m.focusIndex == fieldMode {
+				m.toggleMode()
+				return m, nil
+			}
+		}
+
+	case targetListReadMsg:
+		return m, m.handleTargetListFileRead(msg)
+	}
+
+	inputIdx, ok := inputIndexForField(m.focusIndex)
+	if ok {
+		var cmd tea.Cmd
+		m.inputs[inputIdx], cmd = m.inputs[inputIdx].Update(msg)
+		return m, cmd
+	}
+	return m, nil
+}
+
+func (m *ConfigModel) View() string {
+	var b strings.Builder
+
+	titleBar := core.TitleBarStyle.Render("  Naabu Scanner  ")
+	b.WriteString(titleBar)
+	b.WriteString("\n\n")
+
+	labelStyle := lipgloss.NewStyle().Foreground(core.Gold).Width(18)
+	focusedLabel := lipgloss.NewStyle().Foreground(core.Ember).Width(18).Bold(true)
+
+	m.renderInputRow(&b, labelStyle, focusedLabel, fieldTargetFile, "Target File:*", inputTargetFile)
+	m.renderModeRow(&b, labelStyle, focusedLabel)
+	m.renderInputRow(&b, labelStyle, focusedLabel, fieldNmapOptions, "Nmap Options:", inputNmapOptions)
+	m.renderInputRow(&b, labelStyle, focusedLabel, fieldWorkerCount, "Worker Count:", inputWorkerCount)
+	m.renderInputRow(&b, labelStyle, focusedLabel, fieldComputeMode, "Compute Mode:", inputComputeMode)
+	m.renderInputRow(&b, labelStyle, focusedLabel, fieldCloud, "Cloud:", inputCloud)
+
+	b.WriteString("\n")
+	submitStyle := core.MutedStyle
+	if m.focusIndex == fieldSubmit {
+		submitStyle = core.SelectedStyle
+	}
+	b.WriteString("  " + submitStyle.Render("[ Submit ]"))
+	b.WriteString("\n")
+
+	if m.errMsg != "" {
+		b.WriteString("\n")
+		b.WriteString("  " + core.ErrorStyle.Render(m.errMsg))
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+	b.WriteString(core.StatusBarStyle.Render(m.help.View(configKeys)))
+
+	content := b.String()
+	if m.width > 0 && m.height > 0 {
+		content = lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, content)
+	}
+	return content
+}
+
+func (m *ConfigModel) renderInputRow(b *strings.Builder, labelStyle, focusedLabel lipgloss.Style, field int, label string, inputIdx int) {
+	ls := labelStyle
+	if m.focusIndex == field {
+		ls = focusedLabel
+	}
+	fmt.Fprintf(b, "  %s%s", ls.Render(label), m.inputs[inputIdx].View())
+	if field == fieldNmapOptions && m.mode == naabutool.ModeDiscovery {
+		b.WriteString(" " + core.MutedStyle.Render("(ignored in discovery)"))
+	}
+	b.WriteString("\n")
+}
+
+func (m *ConfigModel) renderModeRow(b *strings.Builder, labelStyle, focusedLabel lipgloss.Style) {
+	ls := labelStyle
+	if m.focusIndex == fieldMode {
+		ls = focusedLabel
+	}
+	combined := "[ ] combined"
+	discovery := "[ ] discovery"
+	if m.mode == naabutool.ModeCombined {
+		combined = "[x] combined"
+	} else {
+		discovery = "[x] discovery"
+	}
+	fmt.Fprintf(b, "  %s%s  %s\n", ls.Render("Mode:"), combined, discovery)
+}
+
+func (m *ConfigModel) submit() tea.Cmd {
+	path := strings.TrimSpace(m.inputs[inputTargetFile].Value())
+	if path == "" {
+		m.errMsg = "Target file is required"
+		return nil
+	}
+	workerCount, _ := strconv.Atoi(m.inputs[inputWorkerCount].Value())
+	if workerCount <= 0 {
+		workerCount = 10
+	}
+	m.errMsg = ""
+	return func() tea.Msg {
+		meta, err := targetlisttool.InspectFile(path, targetlisttool.Policy{WorkerCount: workerCount})
+		if err != nil {
+			return targetListReadMsg{err: err}
+		}
+		return targetListReadMsg{path: path, meta: meta}
+	}
+}
+
+func (m *ConfigModel) handleTargetListFileRead(msg targetListReadMsg) tea.Cmd {
+	if msg.err != nil {
+		m.errMsg = fmt.Sprintf("Error reading target file: %v", msg.err)
+		return nil
+	}
+
+	workerCount, _ := strconv.Atoi(m.inputs[inputWorkerCount].Value())
+	if workerCount <= 0 {
+		workerCount = 10
+	}
+	computeMode := strings.TrimSpace(m.inputs[inputComputeMode].Value())
+	if computeMode == "" {
+		computeMode = "auto"
+	}
+	cloudKind, cloudErr := cloud.ParseKind(strings.TrimSpace(m.inputs[inputCloud].Value()))
+	if cloudErr != nil {
+		m.errMsg = fmt.Sprintf("Invalid cloud: %v", cloudErr)
+		return nil
+	}
+	if err := cloud.ValidateComputeMode(cloudKind, computeMode); err != nil {
+		m.errMsg = err.Error()
+		return nil
+	}
+
+	opCfg, _ := operator.LoadConfig()
+	cleanupPolicy := operator.ResolveCleanupPolicy("", opCfg)
+	outputDir := operator.ResolveOutputDir("", opCfg)
+	placement, placementErr := operator.ResolvePlacementPolicy(fleet.PlacementPolicy{}, opCfg, workerCount)
+	if placementErr != nil {
+		m.errMsg = placementErr.Error()
+		return nil
+	}
+
+	toolName := m.mode.ModuleName()
+	toolOptions := ""
+	if m.mode == naabutool.ModeCombined {
+		toolOptions = strings.TrimSpace(m.inputs[inputNmapOptions].Value())
+	}
+
+	if cloudKind.IsSelfhostedFamily() && !cloudKind.IsProviderNative() {
+		shCfg := factory.SelfhostedConfigFromEnv()
+		if shCfg.QueueID == "" || shCfg.Bucket == "" {
+			m.errMsg = fmt.Sprintf("%s requires SELFHOSTED_QUEUE_ID and SELFHOSTED_BUCKET environment variables", cloudKind.Canonical())
+			return nil
+		}
+		return func() tea.Msg {
+			return core.NavigateWithDataMsg{
+				Target: core.ViewGenericStatus,
+				Data: core.InfraOutputs{
+					Cloud:         cloudKind,
+					SQSQueueURL:   shCfg.QueueID,
+					S3BucketName:  shCfg.Bucket,
+					TargetsPath:   msg.path,
+					TargetCount:   msg.meta.TotalTargets,
+					TargetChunks:  msg.meta.EffectiveChunks,
+					WorkerCount:   workerCount,
+					ComputeMode:   computeMode,
+					Placement:     placement,
+					ToolName:      toolName,
+					ToolOptions:   toolOptions,
+					CleanupPolicy: cleanupPolicy,
+					OutputDir:     outputDir,
+					Selfhosted: &core.SelfhostedRuntime{
+						WorkerHosts: shCfg.WorkerHosts,
+						SSHUser:     shCfg.SSHUser,
+						DockerImage: shCfg.DockerImage,
+					},
+				},
+			}
+		}
+	}
+
+	tc, err := infra.ResolveToolConfig(toolName, cloudKind)
+	if err != nil {
+		m.errMsg = fmt.Sprintf("Error resolving tool config: %v", err)
+		return nil
+	}
+	return func() tea.Msg {
+		return core.NavigateWithDataMsg{
+			Target: core.ViewDeploy,
+			Data: core.DeployConfig{
+				Cloud:          cloudKind,
+				TerraformDir:   tc.TerraformDir,
+				Dockerfile:     tc.Dockerfile,
+				DockerContext:  tc.DockerCtx,
+				DockerTag:      tc.DockerTag,
+				ECRRepoName:    tc.ECRRepoName,
+				AWSRegion:      infra.AWSRegion(),
+				BuildArgs:      tc.BuildArgs,
+				TerraformVars:  tc.TerraformVars,
+				TargetsPath:    msg.path,
+				TargetCount:    msg.meta.TotalTargets,
+				TargetChunks:   msg.meta.EffectiveChunks,
+				WorkerCount:    workerCount,
+				ComputeMode:    computeMode,
+				Placement:      placement,
+				ToolName:       toolName,
+				ToolOptions:    toolOptions,
+				PostDeployView: core.ViewGenericStatus,
+				CleanupPolicy:  cleanupPolicy,
+				OutputDir:      outputDir,
+			},
+		}
+	}
+}
+
+func (m *ConfigModel) updateFocus() tea.Cmd {
+	var cmds []tea.Cmd
+	for i := range m.inputs {
+		m.inputs[i].Blur()
+	}
+	if inputIdx, ok := inputIndexForField(m.focusIndex); ok {
+		cmds = append(cmds, m.inputs[inputIdx].Focus())
+	}
+	return tea.Batch(cmds...)
+}
+
+func (m *ConfigModel) toggleMode() {
+	if m.mode == naabutool.ModeCombined {
+		m.mode = naabutool.ModeDiscovery
+	} else {
+		m.mode = naabutool.ModeCombined
+	}
+}
+
+const (
+	inputTargetFile = iota
+	inputNmapOptions
+	inputWorkerCount
+	inputComputeMode
+	inputCloud
+)
+
+func inputIndexForField(field int) (int, bool) {
+	switch field {
+	case fieldTargetFile:
+		return inputTargetFile, true
+	case fieldNmapOptions:
+		return inputNmapOptions, true
+	case fieldWorkerCount:
+		return inputWorkerCount, true
+	case fieldComputeMode:
+		return inputComputeMode, true
+	case fieldCloud:
+		return inputCloud, true
+	default:
+		return 0, false
+	}
+}
+
+func normalizeCloudValue(value string) string {
+	kind, err := cloud.ParseKind(value)
+	if err != nil {
+		return strings.TrimSpace(value)
+	}
+	return string(kind.Canonical())
+}

--- a/internal/tui/views/naabu/config_test.go
+++ b/internal/tui/views/naabu/config_test.go
@@ -1,0 +1,191 @@
+package naabu
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"heph4estus/internal/cloud"
+	naabutool "heph4estus/internal/tools/naabu"
+	targetlisttool "heph4estus/internal/tools/targetlist"
+	"heph4estus/internal/tui/core"
+)
+
+func targetListMsg(path string, targets int) targetListReadMsg {
+	return targetListReadMsg{
+		path: path,
+		meta: &targetlisttool.Metadata{
+			Path:            path,
+			TotalTargets:    targets,
+			EffectiveChunks: targets,
+		},
+	}
+}
+
+func TestNaabuConfigDefaultView(t *testing.T) {
+	m := NewConfig()
+	v := m.View()
+	for _, want := range []string{"Naabu", "[x] combined", "Nmap Options", "Target File"} {
+		if !strings.Contains(v, want) {
+			t.Fatalf("expected %q in view:\n%s", want, v)
+		}
+	}
+}
+
+func TestNaabuConfigTogglesMode(t *testing.T) {
+	m := NewConfig()
+	m.focusIndex = fieldMode
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatal("expected no navigation command when toggling mode")
+	}
+	if m.mode != naabutool.ModeDiscovery {
+		t.Fatalf("mode = %q, want discovery", m.mode)
+	}
+	if !strings.Contains(m.View(), "[x] discovery") {
+		t.Fatal("expected discovery mode in view")
+	}
+	if !strings.Contains(m.View(), "ignored in discovery") {
+		t.Fatal("expected discovery nmap options hint")
+	}
+}
+
+func TestNaabuConfigCombinedFileRead(t *testing.T) {
+	m := NewConfig()
+	m.inputs[inputNmapOptions].SetValue("-Pn")
+	m.inputs[inputComputeMode].SetValue("auto")
+	m.inputs[inputCloud].SetValue("aws")
+
+	_, cmd := m.Update(targetListMsg("/tmp/targets.txt", 2))
+	if cmd == nil {
+		t.Fatal("expected navigation command after target metadata read")
+	}
+	msg := cmd()
+	nav, ok := msg.(core.NavigateWithDataMsg)
+	if !ok {
+		t.Fatalf("expected NavigateWithDataMsg, got %T", msg)
+	}
+	if nav.Target != core.ViewDeploy {
+		t.Fatalf("expected ViewDeploy, got %v", nav.Target)
+	}
+	cfg, ok := nav.Data.(core.DeployConfig)
+	if !ok {
+		t.Fatalf("expected DeployConfig, got %T", nav.Data)
+	}
+	if cfg.ToolName != naabutool.ModuleNaabuNmap {
+		t.Fatalf("ToolName = %q, want %q", cfg.ToolName, naabutool.ModuleNaabuNmap)
+	}
+	if cfg.ToolOptions != "-Pn" {
+		t.Fatalf("ToolOptions = %q, want -Pn", cfg.ToolOptions)
+	}
+	if cfg.PostDeployView != core.ViewGenericStatus {
+		t.Fatal("expected PostDeployView to be ViewGenericStatus")
+	}
+	if cfg.TargetsPath != "/tmp/targets.txt" || cfg.TargetCount != 2 {
+		t.Fatalf("target metadata = path %q count %d", cfg.TargetsPath, cfg.TargetCount)
+	}
+	if cfg.BuildArgs == nil {
+		t.Fatal("expected BuildArgs to be set")
+	}
+}
+
+func TestNaabuConfigDiscoveryFileRead(t *testing.T) {
+	m := NewConfig()
+	m.mode = naabutool.ModeDiscovery
+	m.inputs[inputNmapOptions].SetValue("-Pn")
+	m.inputs[inputComputeMode].SetValue("auto")
+	m.inputs[inputCloud].SetValue("aws")
+
+	_, cmd := m.Update(targetListMsg("/tmp/targets.txt", 1))
+	if cmd == nil {
+		t.Fatal("expected navigation command after target metadata read")
+	}
+	msg := cmd()
+	nav, ok := msg.(core.NavigateWithDataMsg)
+	if !ok {
+		t.Fatalf("expected NavigateWithDataMsg, got %T", msg)
+	}
+	cfg, ok := nav.Data.(core.DeployConfig)
+	if !ok {
+		t.Fatalf("expected DeployConfig, got %T", nav.Data)
+	}
+	if cfg.ToolName != naabutool.ModuleNaabu {
+		t.Fatalf("ToolName = %q, want %q", cfg.ToolName, naabutool.ModuleNaabu)
+	}
+	if cfg.ToolOptions != "" {
+		t.Fatalf("ToolOptions = %q, want empty discovery options", cfg.ToolOptions)
+	}
+}
+
+func TestNaabuConfigManualNavigatesToGenericStatus(t *testing.T) {
+	t.Setenv("SELFHOSTED_QUEUE_ID", "test-stream")
+	t.Setenv("SELFHOSTED_BUCKET", "test-bucket")
+	t.Setenv("SELFHOSTED_WORKER_HOSTS", "10.0.0.1")
+	t.Setenv("SELFHOSTED_SSH_USER", "heph")
+	t.Setenv("SELFHOSTED_DOCKER_IMAGE", "worker:latest")
+
+	m := NewConfig()
+	m.inputs[inputComputeMode].SetValue("auto")
+	m.inputs[inputCloud].SetValue("manual")
+	_, cmd := m.Update(targetListMsg("/tmp/targets.txt", 1))
+	if cmd == nil {
+		t.Fatal("expected navigation command for manual provider")
+	}
+	msg := cmd()
+	nav, ok := msg.(core.NavigateWithDataMsg)
+	if !ok {
+		t.Fatalf("expected NavigateWithDataMsg, got %T", msg)
+	}
+	if nav.Target != core.ViewGenericStatus {
+		t.Fatalf("expected ViewGenericStatus, got %v", nav.Target)
+	}
+	infra, ok := nav.Data.(core.InfraOutputs)
+	if !ok {
+		t.Fatalf("expected InfraOutputs, got %T", nav.Data)
+	}
+	if infra.Cloud != cloud.KindManual {
+		t.Fatalf("Cloud = %q, want manual", infra.Cloud)
+	}
+	if infra.ToolName != naabutool.ModuleNaabuNmap {
+		t.Fatalf("ToolName = %q, want %q", infra.ToolName, naabutool.ModuleNaabuNmap)
+	}
+}
+
+func TestNaabuConfigInvalidComputeMode(t *testing.T) {
+	m := NewConfig()
+	m.inputs[inputCloud].SetValue("manual")
+	m.inputs[inputComputeMode].SetValue("fargate")
+
+	_, cmd := m.Update(targetListMsg("/tmp/targets.txt", 1))
+	if cmd != nil {
+		t.Fatal("expected nil command for manual + fargate")
+	}
+	if !strings.Contains(m.View(), `provider "manual" only supports`) {
+		t.Fatal("expected provider mode rejection error")
+	}
+}
+
+func TestNaabuConfigSubmitBadFileShowsError(t *testing.T) {
+	m := NewConfig()
+	m.inputs[inputTargetFile].SetValue("/nonexistent/file.txt")
+	m.focusIndex = fieldSubmit
+
+	_, cmd := m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected command for file read")
+	}
+	msg := cmd()
+	readMsg, ok := msg.(targetListReadMsg)
+	if !ok {
+		t.Fatalf("expected targetListReadMsg, got %T", msg)
+	}
+	if readMsg.err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+
+	m.Update(readMsg)
+	if m.errMsg == "" {
+		t.Fatal("expected error message in view")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `heph naabu` as a thin CLI adapter over the generic scan path
- Map combined mode to `naabu-nmap` and discovery mode to `naabu`
- Add a dedicated Naabu TUI config view and route one consolidated menu entry to it
- Hide raw `naabu` and `naabu-nmap` entries from the TUI menu while keeping generic scan support available

## Testing
- `go test ./cmd/heph ./internal/tui ./internal/tui/views/menu ./internal/tui/views/naabu`
- `go test ./...`
- `go vet ./...`
- `git diff --check`