### PR TITLE
PR 9.2: Add result formatters per tool

### DIFF
--- a/cmd/heph/cmd_results.go
+++ b/cmd/heph/cmd_results.go
@@ -16,6 +16,7 @@ import (
 	"heph4estus/internal/jobs"
 	"heph4estus/internal/logger"
 	"heph4estus/internal/operator"
+	resultfmt "heph4estus/internal/results"
 	"heph4estus/internal/worker"
 )
 
@@ -146,6 +147,7 @@ func runResultsExport(args []string, log logger.Logger, deps resultsDeps) error 
 	fs.StringVar(&jobID, "job", "", "Job ID to export results for")
 	fs.StringVar(&jobID, "job-id", "", "Job ID to export results for")
 	format := fs.String("format", "jsonl", "Output format: json, jsonl, or csv")
+	view := fs.String("view", "records", "Export view: records or findings")
 	cloudFlag := fs.String("cloud", "", "Override cloud provider used to read results")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -153,8 +155,13 @@ func runResultsExport(args []string, log logger.Logger, deps resultsDeps) error 
 	if strings.TrimSpace(jobID) == "" {
 		return fmt.Errorf("--job flag is required")
 	}
-	if *format != "json" && *format != "jsonl" && *format != "csv" {
-		return fmt.Errorf("--format must be json, jsonl, or csv")
+	exportFormat, err := resultfmt.ParseFormat(*format)
+	if err != nil {
+		return fmt.Errorf("--%s", err.Error())
+	}
+	viewValue := strings.ToLower(strings.TrimSpace(*view))
+	if viewValue != "records" && viewValue != "findings" {
+		return fmt.Errorf("--view must be records or findings")
 	}
 
 	ctx, err := loadResultsContext(context.Background(), jobID, *cloudFlag, log, deps)
@@ -164,6 +171,9 @@ func runResultsExport(args []string, log logger.Logger, deps resultsDeps) error 
 	results, err := loadWorkerResults(context.Background(), ctx.storage, ctx.bucket, ctx.resultPrefix)
 	if err != nil {
 		return err
+	}
+	if viewValue == "findings" {
+		return outputWorkerResultFindings(context.Background(), ctx.storage, ctx.bucket, ctx.tool, ctx.jobID, results, exportFormat)
 	}
 
 	switch *format {
@@ -393,6 +403,71 @@ func outputWorkerResultsCSV(results []keyedWorkerResult) error {
 	}
 	w.Flush()
 	return w.Error()
+}
+
+func outputWorkerResultFindings(ctx context.Context, storage cloud.Storage, bucket, tool, jobID string, results []keyedWorkerResult, format resultfmt.Format) error {
+	if _, ok := resultfmt.FormatterForTool(tool); !ok {
+		return fmt.Errorf("findings export is not available for tool %q; use --view records", tool)
+	}
+
+	records := make([]resultfmt.Record, 0)
+	for _, keyed := range results {
+		result := keyed.Result
+		toolName := firstNonEmptyString(result.ToolName, tool)
+		formatter, ok := resultfmt.FormatterForTool(toolName)
+		if !ok {
+			return fmt.Errorf("findings export is not available for tool %q in %s; use --view records", toolName, keyed.Key)
+		}
+		data, artifactKey, err := resultArtifactData(ctx, storage, bucket, keyed)
+		if err != nil {
+			return err
+		}
+		input := resultfmt.ArtifactInput{
+			ToolName:    toolName,
+			JobID:       firstNonEmptyString(result.JobID, jobID),
+			Target:      result.Target,
+			SourceKey:   keyed.Key,
+			ArtifactKey: artifactKey,
+			Data:        data,
+		}
+		formatted, err := formatter.Records(input)
+		if err != nil {
+			return fmt.Errorf("formatting %s: %w", keyed.Key, err)
+		}
+		records = append(records, formatted...)
+	}
+
+	out, err := resultfmt.RenderRecords(records, format)
+	if err != nil {
+		return err
+	}
+	_, err = os.Stdout.Write(out)
+	return err
+}
+
+func resultArtifactData(ctx context.Context, storage cloud.Storage, bucket string, keyed keyedWorkerResult) ([]byte, string, error) {
+	outputKey := strings.TrimSpace(keyed.Result.OutputKey)
+	if outputKey != "" {
+		data, err := storage.Download(ctx, bucket, outputKey)
+		if err != nil {
+			return nil, outputKey, fmt.Errorf("downloading artifact %s for %s: %w", outputKey, keyed.Key, err)
+		}
+		return data, outputKey, nil
+	}
+	if strings.TrimSpace(keyed.Result.Output) != "" {
+		return []byte(keyed.Result.Output), "", nil
+	}
+	return nil, "", fmt.Errorf("result %s has no artifact output_key or inline output for findings export", keyed.Key)
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func s3ObjectURI(bucket, key string) string {

--- a/cmd/heph/cmd_results_test.go
+++ b/cmd/heph/cmd_results_test.go
@@ -88,6 +88,16 @@ func TestRunResultsInvalidFormats(t *testing.T) {
 	}
 }
 
+func TestRunResultsInvalidExportView(t *testing.T) {
+	err := runResultsWithDeps([]string{"export", "--job", "job-1", "--view", "raw"}, testLogger(), resultsDeps{})
+	if err == nil {
+		t.Fatal("expected invalid view error")
+	}
+	if !strings.Contains(err.Error(), "--view must be records or findings") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRunResultsDownloadRequiresOutput(t *testing.T) {
 	err := runResultsWithDeps([]string{"download", "--job", "job-1"}, testLogger(), resultsDeps{})
 	if err == nil {
@@ -262,6 +272,107 @@ func TestRunResultsExportCSV(t *testing.T) {
 	}
 }
 
+func TestRunResultsExportFindingsJSON(t *testing.T) {
+	store := operator.NewJobStoreAt(t.TempDir())
+	createResultsJob(t, store, "job-1", "nmap")
+	resultKey := jobs.ResultKey("nmap", "job-1", "example.com", "", 0, 0, 100, "json")
+	artifactKey := jobs.ArtifactKey("nmap", "job-1", "example.com", "", 0, 0, 100, "xml")
+	storage := &resultsTestStorage{objects: map[string][]byte{
+		resultKey:          mustResultJSONWithOutput(t, "nmap", "job-1", "example.com", artifactKey, "", ""),
+		artifactKey:        []byte(`<nmaprun><host><address addr="192.0.2.10" addrtype="ipv4"/><hostnames><hostname name="example.com"/></hostnames><ports><port protocol="tcp" portid="443"><state state="open"/><service name="https" product="nginx" version="1.25"/></port><port protocol="tcp" portid="25"><state state="filtered"/></port></ports></host></nmaprun>`),
+		resultKey + ".bak": []byte(`ignored`),
+	}}
+	deps := testResultsDeps(store, storage)
+
+	out, err := captureStdout(func() error {
+		return runResultsWithDeps([]string{"export", "--job", "job-1", "--view", "findings", "--format", "json"}, testLogger(), deps)
+	})
+	if err != nil {
+		t.Fatalf("runResults export findings json: %v", err)
+	}
+	var records []map[string]any
+	if err := json.Unmarshal([]byte(out), &records); err != nil {
+		t.Fatalf("decode findings json: %v\n%s", err, out)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %d, want 1", len(records))
+	}
+	record := records[0]
+	if record["tool"] != "nmap" || record["target"] != "example.com" || record["service"] != "https" {
+		t.Fatalf("unexpected record: %#v", record)
+	}
+	if record["port"] != float64(443) || record["artifact_key"] != artifactKey || record["source_key"] != resultKey {
+		t.Fatalf("unexpected metadata: %#v", record)
+	}
+}
+
+func TestRunResultsExportFindingsCSV(t *testing.T) {
+	store := operator.NewJobStoreAt(t.TempDir())
+	createResultsJob(t, store, "job-1", "naabu")
+	resultKey := jobs.ResultKey("naabu", "job-1", "example.com", "", 0, 0, 100, "json")
+	artifactKey := jobs.ArtifactKey("naabu", "job-1", "example.com", "", 0, 0, 100, "jsonl")
+	storage := &resultsTestStorage{objects: map[string][]byte{
+		resultKey:   mustResultJSONWithOutput(t, "naabu", "job-1", "example.com", artifactKey, "", ""),
+		artifactKey: []byte(`{"host":"example.com","ip":"192.0.2.10","port":443,"tls":true,"cdn":true,"cdn-name":"cloudflare"}` + "\n"),
+	}}
+	deps := testResultsDeps(store, storage)
+
+	out, err := captureStdout(func() error {
+		return runResultsWithDeps([]string{"export", "--job", "job-1", "--view", "findings", "--format", "csv"}, testLogger(), deps)
+	})
+	if err != nil {
+		t.Fatalf("runResults export findings csv: %v", err)
+	}
+	rows, err := csv.NewReader(strings.NewReader(out)).ReadAll()
+	if err != nil {
+		t.Fatalf("decode findings csv: %v\n%s", err, out)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("csv rows = %d, want 2", len(rows))
+	}
+	if rows[0][0] != "tool" || rows[0][6] != "port" || rows[0][12] != "cdn_name" {
+		t.Fatalf("unexpected header: %#v", rows[0])
+	}
+	if rows[1][0] != "naabu" || rows[1][6] != "443" || rows[1][10] != "true" || rows[1][12] != "cloudflare" {
+		t.Fatalf("unexpected row: %#v", rows[1])
+	}
+}
+
+func TestRunResultsExportFindingsUnsupportedTool(t *testing.T) {
+	store := operator.NewJobStoreAt(t.TempDir())
+	createResultsJob(t, store, "job-1", "httpx")
+	deps := testResultsDeps(store, &resultsTestStorage{objects: resultObjects(t, "httpx", "job-1")})
+
+	_, err := captureStdout(func() error {
+		return runResultsWithDeps([]string{"export", "--job", "job-1", "--view", "findings"}, testLogger(), deps)
+	})
+	if err == nil {
+		t.Fatal("expected unsupported findings tool error")
+	}
+	if !strings.Contains(err.Error(), "findings export is not available for tool") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunResultsExportFindingsMissingArtifactData(t *testing.T) {
+	store := operator.NewJobStoreAt(t.TempDir())
+	createResultsJob(t, store, "job-1", "nmap")
+	resultKey := jobs.ResultKey("nmap", "job-1", "example.com", "", 0, 0, 100, "json")
+	deps := testResultsDeps(store, &resultsTestStorage{objects: map[string][]byte{
+		resultKey: mustResultJSONWithOutput(t, "nmap", "job-1", "example.com", "", "", ""),
+	}})
+
+	_, err := captureStdout(func() error {
+		return runResultsWithDeps([]string{"export", "--job", "job-1", "--view", "findings"}, testLogger(), deps)
+	})
+	if err == nil {
+		t.Fatal("expected missing artifact data error")
+	}
+	if !strings.Contains(err.Error(), "no artifact output_key or inline output") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRunResultsExportMalformedJSON(t *testing.T) {
 	store := operator.NewJobStoreAt(t.TempDir())
 	createResultsJob(t, store, "job-1", "httpx")
@@ -359,11 +470,17 @@ func resultObjects(t *testing.T, tool, jobID string) map[string][]byte {
 
 func mustResultJSON(t *testing.T, tool, jobID, target, resultErr string) []byte {
 	t.Helper()
+	return mustResultJSONWithOutput(t, tool, jobID, target, jobs.ArtifactKey(tool, jobID, target, "", 0, 0, 100, "jsonl"), "", resultErr)
+}
+
+func mustResultJSONWithOutput(t *testing.T, tool, jobID, target, outputKey, output, resultErr string) []byte {
+	t.Helper()
 	data, err := json.Marshal(worker.Result{
 		ToolName:    tool,
 		JobID:       jobID,
 		Target:      target,
-		OutputKey:   jobs.ArtifactKey(tool, jobID, target, "", 0, 0, 100, "jsonl"),
+		Output:      output,
+		OutputKey:   outputKey,
 		Error:       resultErr,
 		Timestamp:   time.Date(2026, 6, 7, 12, 0, 0, 0, time.UTC),
 		ChunkIdx:    0,

--- a/internal/results/formatters.go
+++ b/internal/results/formatters.go
@@ -1,0 +1,296 @@
+package results
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	naabutool "heph4estus/internal/tools/naabu"
+)
+
+const (
+	ToolNmap      = "nmap"
+	ToolNaabu     = "naabu"
+	ToolNaabuNmap = "naabu-nmap"
+)
+
+type Format string
+
+const (
+	FormatJSON  Format = "json"
+	FormatJSONL Format = "jsonl"
+	FormatCSV   Format = "csv"
+)
+
+type ArtifactInput struct {
+	ToolName    string
+	JobID       string
+	Target      string
+	SourceKey   string
+	ArtifactKey string
+	Data        []byte
+}
+
+type Record map[string]any
+
+type Formatter interface {
+	Records(input ArtifactInput) ([]Record, error)
+}
+
+type OpenPort = naabutool.OpenPort
+
+var openPortColumns = []string{
+	"tool",
+	"job_id",
+	"target",
+	"host",
+	"ip",
+	"protocol",
+	"port",
+	"service",
+	"product",
+	"version",
+	"tls",
+	"cdn",
+	"cdn_name",
+	"timestamp",
+	"source_key",
+	"artifact_key",
+}
+
+func ParseFormat(value string) (Format, error) {
+	switch Format(strings.ToLower(strings.TrimSpace(value))) {
+	case FormatJSON:
+		return FormatJSON, nil
+	case FormatJSONL:
+		return FormatJSONL, nil
+	case FormatCSV:
+		return FormatCSV, nil
+	default:
+		return "", fmt.Errorf("format must be json, jsonl, or csv")
+	}
+}
+
+func FormatterForTool(tool string) (Formatter, bool) {
+	switch normalizedTool(tool) {
+	case ToolNmap:
+		return nmapFormatter{}, true
+	case ToolNaabu:
+		return naabuFormatter{}, true
+	case ToolNaabuNmap:
+		return naabuNmapFormatter{}, true
+	default:
+		return nil, false
+	}
+}
+
+func OpenPortsForArtifact(input ArtifactInput) ([]OpenPort, error) {
+	switch normalizedTool(input.ToolName) {
+	case ToolNmap, ToolNaabuNmap:
+		return naabutool.ParseNmapXML(input.Data, input.Target)
+	case ToolNaabu:
+		return parseNaabuDiscovery(input.Data)
+	default:
+		return nil, fmt.Errorf("no result formatter for tool %q", input.ToolName)
+	}
+}
+
+func RecordsForOpenPorts(input ArtifactInput, ports []OpenPort) []Record {
+	records := make([]Record, 0, len(ports))
+	for _, port := range ports {
+		records = append(records, Record{
+			"tool":         firstNonEmpty(input.ToolName, normalizedTool(input.ToolName)),
+			"job_id":       input.JobID,
+			"target":       input.Target,
+			"host":         strings.TrimSpace(port.Host),
+			"ip":           strings.TrimSpace(port.IP),
+			"protocol":     firstNonEmpty(port.Protocol, "tcp"),
+			"port":         port.Port,
+			"service":      strings.TrimSpace(port.Service),
+			"product":      strings.TrimSpace(port.Product),
+			"version":      strings.TrimSpace(port.Version),
+			"tls":          port.TLS,
+			"cdn":          port.CDN,
+			"cdn_name":     strings.TrimSpace(port.CDNName),
+			"timestamp":    strings.TrimSpace(port.Timestamp),
+			"source_key":   input.SourceKey,
+			"artifact_key": input.ArtifactKey,
+		})
+	}
+	return records
+}
+
+func RenderRecords(records []Record, format Format) ([]byte, error) {
+	if records == nil {
+		records = []Record{}
+	}
+	var buf bytes.Buffer
+	switch format {
+	case FormatJSON:
+		enc := json.NewEncoder(&buf)
+		if err := enc.Encode(records); err != nil {
+			return nil, err
+		}
+	case FormatJSONL:
+		enc := json.NewEncoder(&buf)
+		for _, record := range records {
+			if err := enc.Encode(record); err != nil {
+				return nil, err
+			}
+		}
+	case FormatCSV:
+		writer := csv.NewWriter(&buf)
+		columns := csvColumns(records)
+		if err := writer.Write(columns); err != nil {
+			return nil, err
+		}
+		for _, record := range records {
+			row := make([]string, 0, len(columns))
+			for _, column := range columns {
+				row = append(row, csvValue(record[column]))
+			}
+			if err := writer.Write(row); err != nil {
+				return nil, err
+			}
+		}
+		writer.Flush()
+		if err := writer.Error(); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("format must be json, jsonl, or csv")
+	}
+	return buf.Bytes(), nil
+}
+
+type nmapFormatter struct{}
+
+func (nmapFormatter) Records(input ArtifactInput) ([]Record, error) {
+	input.ToolName = firstNonEmpty(input.ToolName, ToolNmap)
+	ports, err := OpenPortsForArtifact(input)
+	if err != nil {
+		return nil, err
+	}
+	return RecordsForOpenPorts(input, ports), nil
+}
+
+type naabuFormatter struct{}
+
+func (naabuFormatter) Records(input ArtifactInput) ([]Record, error) {
+	input.ToolName = firstNonEmpty(input.ToolName, ToolNaabu)
+	ports, err := OpenPortsForArtifact(input)
+	if err != nil {
+		return nil, err
+	}
+	return RecordsForOpenPorts(input, ports), nil
+}
+
+type naabuNmapFormatter struct{}
+
+func (naabuNmapFormatter) Records(input ArtifactInput) ([]Record, error) {
+	input.ToolName = firstNonEmpty(input.ToolName, ToolNaabuNmap)
+	ports, err := OpenPortsForArtifact(input)
+	if err != nil {
+		return nil, err
+	}
+	return RecordsForOpenPorts(input, ports), nil
+}
+
+func parseNaabuDiscovery(data []byte) ([]OpenPort, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	if trimmed[0] == '[' {
+		var discoveries []naabutool.DiscoveryResult
+		if err := json.Unmarshal(trimmed, &discoveries); err != nil {
+			return nil, err
+		}
+		return discoveryResultsToOpenPorts(discoveries), nil
+	}
+	return naabutool.ParseDiscoveryJSONL(data)
+}
+
+func discoveryResultsToOpenPorts(discoveries []naabutool.DiscoveryResult) []OpenPort {
+	ports := make([]OpenPort, 0, len(discoveries))
+	for _, discovery := range discoveries {
+		ports = append(ports, OpenPort{
+			Host:      strings.TrimSpace(discovery.Host),
+			IP:        strings.TrimSpace(discovery.IP),
+			Protocol:  normalizeProtocol(discovery.Protocol),
+			Port:      discovery.Port,
+			TLS:       discovery.TLS,
+			CDN:       discovery.CDN,
+			CDNName:   strings.TrimSpace(discovery.CDNName),
+			Timestamp: strings.TrimSpace(discovery.Timestamp),
+		})
+	}
+	return ports
+}
+
+func normalizeProtocol(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return "tcp"
+	}
+	return value
+}
+
+func csvColumns(records []Record) []string {
+	seen := make(map[string]bool, len(openPortColumns))
+	columns := make([]string, 0, len(openPortColumns))
+	for _, column := range openPortColumns {
+		seen[column] = true
+		columns = append(columns, column)
+	}
+
+	var extra []string
+	for _, record := range records {
+		for column := range record {
+			if !seen[column] {
+				seen[column] = true
+				extra = append(extra, column)
+			}
+		}
+	}
+	sort.Strings(extra)
+	return append(columns, extra...)
+}
+
+func csvValue(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return typed
+	case bool:
+		return strconv.FormatBool(typed)
+	case int:
+		if typed == 0 {
+			return ""
+		}
+		return strconv.Itoa(typed)
+	case int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return fmt.Sprint(typed)
+	default:
+		return fmt.Sprint(typed)
+	}
+}
+
+func normalizedTool(tool string) string {
+	return strings.ToLower(strings.TrimSpace(tool))
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/results/formatters_test.go
+++ b/internal/results/formatters_test.go
@@ -1,0 +1,168 @@
+package results
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestNmapFormatterRecordsOpenPorts(t *testing.T) {
+	formatter, ok := FormatterForTool("nmap")
+	if !ok {
+		t.Fatal("expected nmap formatter")
+	}
+	artifact := []byte(`<nmaprun><host><address addr="192.0.2.10" addrtype="ipv4"/><hostnames><hostname name="example.com"/></hostnames><ports><port protocol="tcp" portid="80"><state state="open"/><service name="http" product="nginx" version="1.25"/></port><port protocol="tcp" portid="22"><state state="closed"/></port></ports></host></nmaprun>`)
+
+	records, err := formatter.Records(ArtifactInput{
+		ToolName:    "nmap",
+		JobID:       "job-1",
+		Target:      "example.com",
+		SourceKey:   "scans/nmap/job-1/results/example.com.json",
+		ArtifactKey: "scans/nmap/job-1/artifacts/example.com.xml",
+		Data:        artifact,
+	})
+	if err != nil {
+		t.Fatalf("Records: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %d, want 1", len(records))
+	}
+	record := records[0]
+	if record["host"] != "example.com" || record["ip"] != "192.0.2.10" {
+		t.Fatalf("unexpected host fields: %#v", record)
+	}
+	if record["protocol"] != "tcp" || record["port"] != 80 {
+		t.Fatalf("unexpected port fields: %#v", record)
+	}
+	if record["service"] != "http" || record["product"] != "nginx" || record["version"] != "1.25" {
+		t.Fatalf("unexpected service fields: %#v", record)
+	}
+}
+
+func TestNaabuFormatterSupportsJSONLAndJSONArray(t *testing.T) {
+	tests := []struct {
+		name     string
+		artifact []byte
+	}{
+		{
+			name:     "jsonl",
+			artifact: []byte(`{"host":"example.com","ip":"192.0.2.10","port":443,"tls":true,"cdn":true,"cdn-name":"cloudflare","timestamp":"2026-06-07T12:00:00Z"}` + "\n"),
+		},
+		{
+			name:     "array",
+			artifact: []byte(`[{"host":"example.com","ip":"192.0.2.10","port":443,"tls":true,"cdn":true,"cdn-name":"cloudflare","timestamp":"2026-06-07T12:00:00Z"}]`),
+		},
+	}
+
+	formatter, ok := FormatterForTool("naabu")
+	if !ok {
+		t.Fatal("expected naabu formatter")
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			records, err := formatter.Records(ArtifactInput{ToolName: "naabu", JobID: "job-1", Target: "example.com", Data: tt.artifact})
+			if err != nil {
+				t.Fatalf("Records: %v", err)
+			}
+			if len(records) != 1 {
+				t.Fatalf("records = %d, want 1", len(records))
+			}
+			record := records[0]
+			if record["protocol"] != "tcp" || record["port"] != 443 {
+				t.Fatalf("unexpected port fields: %#v", record)
+			}
+			if record["tls"] != true || record["cdn"] != true || record["cdn_name"] != "cloudflare" {
+				t.Fatalf("unexpected optional fields: %#v", record)
+			}
+		})
+	}
+}
+
+func TestNaabuNmapFormatterUsesNmapXML(t *testing.T) {
+	formatter, ok := FormatterForTool("naabu-nmap")
+	if !ok {
+		t.Fatal("expected naabu-nmap formatter")
+	}
+	records, err := formatter.Records(ArtifactInput{
+		ToolName: "naabu-nmap",
+		Target:   "fallback.example",
+		Data:     []byte(`<nmaprun><host><ports><port protocol="tcp" portid="8080"><state state="open"/><service name="http-proxy"/></port></ports></host></nmaprun>`),
+	})
+	if err != nil {
+		t.Fatalf("Records: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records = %d, want 1", len(records))
+	}
+	if records[0]["ip"] != "fallback.example" || records[0]["service"] != "http-proxy" {
+		t.Fatalf("unexpected record: %#v", records[0])
+	}
+}
+
+func TestFormatterErrors(t *testing.T) {
+	if _, ok := FormatterForTool("httpx"); ok {
+		t.Fatal("did not expect httpx formatter in PR 9.2")
+	}
+	formatter, ok := FormatterForTool("nmap")
+	if !ok {
+		t.Fatal("expected nmap formatter")
+	}
+	if _, err := formatter.Records(ArtifactInput{ToolName: "nmap", Data: []byte(`<nmaprun><host>`)}); err == nil {
+		t.Fatal("expected malformed XML error")
+	}
+}
+
+func TestRenderRecords(t *testing.T) {
+	records := []Record{{
+		"tool":         "nmap",
+		"job_id":       "job-1",
+		"target":       "example.com",
+		"host":         "example.com",
+		"ip":           "192.0.2.10",
+		"protocol":     "tcp",
+		"port":         443,
+		"service":      "https",
+		"source_key":   "result.json",
+		"artifact_key": "artifact.xml",
+		"extra":        "value",
+	}}
+
+	jsonOut, err := RenderRecords(records, FormatJSON)
+	if err != nil {
+		t.Fatalf("RenderRecords json: %v", err)
+	}
+	var decoded []Record
+	if err := json.Unmarshal(jsonOut, &decoded); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+	if len(decoded) != 1 || decoded[0]["target"] != "example.com" {
+		t.Fatalf("unexpected json records: %#v", decoded)
+	}
+
+	jsonlOut, err := RenderRecords(records, FormatJSONL)
+	if err != nil {
+		t.Fatalf("RenderRecords jsonl: %v", err)
+	}
+	if got := strings.Count(strings.TrimSpace(string(jsonlOut)), "\n") + 1; got != 1 {
+		t.Fatalf("jsonl rows = %d, want 1: %q", got, string(jsonlOut))
+	}
+
+	csvOut, err := RenderRecords(records, FormatCSV)
+	if err != nil {
+		t.Fatalf("RenderRecords csv: %v", err)
+	}
+	rows, err := csv.NewReader(strings.NewReader(string(csvOut))).ReadAll()
+	if err != nil {
+		t.Fatalf("decode csv: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("csv rows = %d, want 2", len(rows))
+	}
+	if rows[0][0] != "tool" || rows[0][len(rows[0])-1] != "extra" {
+		t.Fatalf("unexpected csv header: %#v", rows[0])
+	}
+	if rows[1][6] != "443" || rows[1][len(rows[1])-1] != "value" {
+		t.Fatalf("unexpected csv row: %#v", rows[1])
+	}
+}

--- a/internal/tui/views/generic/resultfmt.go
+++ b/internal/tui/views/generic/resultfmt.go
@@ -5,12 +5,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"encoding/xml"
 	"fmt"
 	"sort"
 	"strings"
 
-	naabutool "heph4estus/internal/tools/naabu"
+	resultfmt "heph4estus/internal/results"
 	"heph4estus/internal/tui/core"
 	"heph4estus/internal/worker"
 )
@@ -97,13 +96,13 @@ func outputRef(bucket, key string) string {
 
 func formatToolArtifact(r worker.Result, artifact []byte) (string, string, error) {
 	switch strings.ToLower(strings.TrimSpace(r.ToolName)) {
-	case naabutool.ModuleNaabuNmap:
+	case resultfmt.ToolNaabuNmap:
 		body, err := formatNaabuNmapArtifact(r, artifact)
 		return "Naabu + Nmap Open Ports", body, err
-	case naabutool.ModuleNaabu:
+	case resultfmt.ToolNaabu:
 		body, err := formatNaabuDiscoveryArtifact(artifact)
 		return "Naabu Open Ports", body, err
-	case "nmap":
+	case resultfmt.ToolNmap:
 		body, err := formatNmapArtifact(r, artifact)
 		return "Nmap Open Ports", body, err
 	case "nuclei":
@@ -123,103 +122,42 @@ func formatToolArtifact(r worker.Result, artifact []byte) (string, string, error
 	}
 }
 
-type nmapXMLRun struct {
-	Hosts []nmapXMLHost `xml:"host"`
-}
-
-type nmapXMLHost struct {
-	Addresses []nmapXMLAddress `xml:"address"`
-	Ports     []nmapXMLPort    `xml:"ports>port"`
-}
-
-type nmapXMLAddress struct {
-	Addr     string `xml:"addr,attr"`
-	AddrType string `xml:"addrtype,attr"`
-}
-
-type nmapXMLPort struct {
-	Protocol string          `xml:"protocol,attr"`
-	PortID   string          `xml:"portid,attr"`
-	State    nmapXMLState    `xml:"state"`
-	Service  nmapXMLService  `xml:"service"`
-	Scripts  []nmapXMLScript `xml:"script"`
-}
-
-type nmapXMLState struct {
-	State string `xml:"state,attr"`
-}
-
-type nmapXMLService struct {
-	Name    string `xml:"name,attr"`
-	Product string `xml:"product,attr"`
-	Version string `xml:"version,attr"`
-}
-
-type nmapXMLScript struct {
-	ID     string `xml:"id,attr"`
-	Output string `xml:"output,attr"`
-}
-
 func formatNmapArtifact(r worker.Result, artifact []byte) (string, error) {
-	var parsed nmapXMLRun
-	if err := xml.Unmarshal(artifact, &parsed); err != nil {
+	ports, err := resultfmt.OpenPortsForArtifact(resultfmt.ArtifactInput{
+		ToolName: resultfmt.ToolNmap,
+		Target:   r.Target,
+		Data:     artifact,
+	})
+	if err != nil {
 		return "", err
 	}
-
-	lines := []string{
-		fmt.Sprintf("%-24s %-9s %s", "HOST", "PORT", "SERVICE"),
-		fmt.Sprintf("%-24s %-9s %s", strings.Repeat("-", 24), strings.Repeat("-", 9), strings.Repeat("-", 40)),
-	}
-	for _, host := range parsed.Hosts {
-		hostLabel := nmapHostLabel(host, r.Target)
-		for _, port := range host.Ports {
-			if !strings.EqualFold(port.State.State, "open") {
-				continue
-			}
-			service := strings.TrimSpace(strings.Join(nonEmpty(port.Service.Name, port.Service.Product, port.Service.Version), " "))
-			if service == "" {
-				service = "-"
-			}
-			lines = append(lines, fmt.Sprintf("%-24s %-9s %s", clipText(hostLabel, 24), port.Protocol+"/"+port.PortID, service))
-		}
-	}
-	if len(lines) == 2 {
-		return "No open ports found.", nil
-	}
-	return strings.Join(lines, "\n"), nil
-}
-
-func nmapHostLabel(host nmapXMLHost, fallback string) string {
-	for _, addr := range host.Addresses {
-		if addr.Addr != "" && (addr.AddrType == "" || addr.AddrType == "ipv4") {
-			return addr.Addr
-		}
-	}
-	for _, addr := range host.Addresses {
-		if addr.Addr != "" {
-			return addr.Addr
-		}
-	}
-	return fallback
+	return formatOpenPorts(ports, "No open ports found."), nil
 }
 
 func formatNaabuNmapArtifact(r worker.Result, artifact []byte) (string, error) {
-	ports, err := naabutool.ParseNmapXML(artifact, r.Target)
+	ports, err := resultfmt.OpenPortsForArtifact(resultfmt.ArtifactInput{
+		ToolName: resultfmt.ToolNaabuNmap,
+		Target:   r.Target,
+		Data:     artifact,
+	})
 	if err != nil {
 		return "", err
 	}
-	return formatNaabuOpenPorts(ports, "No open ports found."), nil
+	return formatOpenPorts(ports, "No open ports found."), nil
 }
 
 func formatNaabuDiscoveryArtifact(artifact []byte) (string, error) {
-	ports, err := naabutool.ParseDiscoveryJSONL(artifact)
+	ports, err := resultfmt.OpenPortsForArtifact(resultfmt.ArtifactInput{
+		ToolName: resultfmt.ToolNaabu,
+		Data:     artifact,
+	})
 	if err != nil {
 		return "", err
 	}
-	return formatNaabuOpenPorts(ports, "No naabu ports found."), nil
+	return formatOpenPorts(ports, "No naabu ports found."), nil
 }
 
-func formatNaabuOpenPorts(ports []naabutool.OpenPort, emptyMessage string) string {
+func formatOpenPorts(ports []resultfmt.OpenPort, emptyMessage string) string {
 	if len(ports) == 0 {
 		return emptyMessage
 	}
@@ -231,15 +169,15 @@ func formatNaabuOpenPorts(ports []naabutool.OpenPort, emptyMessage string) strin
 	for _, port := range ports {
 		lines = append(lines, fmt.Sprintf("%-24s %-9s %-30s %s",
 			clipText(firstNonEmpty(port.Host, port.IP, "-"), 24),
-			formatNaabuPort(port),
-			clipText(formatNaabuService(port), 30),
-			clipText(formatNaabuDetails(port), 80),
+			formatOpenPort(port),
+			clipText(formatOpenPortService(port), 30),
+			clipText(formatOpenPortDetails(port), 80),
 		))
 	}
 	return strings.Join(lines, "\n")
 }
 
-func formatNaabuPort(port naabutool.OpenPort) string {
+func formatOpenPort(port resultfmt.OpenPort) string {
 	protocol := firstNonEmpty(port.Protocol, "tcp")
 	if port.Port <= 0 {
 		return protocol + "/-"
@@ -247,7 +185,7 @@ func formatNaabuPort(port naabutool.OpenPort) string {
 	return fmt.Sprintf("%s/%d", protocol, port.Port)
 }
 
-func formatNaabuService(port naabutool.OpenPort) string {
+func formatOpenPortService(port resultfmt.OpenPort) string {
 	service := strings.TrimSpace(strings.Join(nonEmpty(port.Service, port.Product, port.Version), " "))
 	if service == "" {
 		return "-"
@@ -255,7 +193,7 @@ func formatNaabuService(port naabutool.OpenPort) string {
 	return service
 }
 
-func formatNaabuDetails(port naabutool.OpenPort) string {
+func formatOpenPortDetails(port resultfmt.OpenPort) string {
 	parts := make([]string, 0, 4)
 	if port.Host != "" && port.IP != "" && port.Host != port.IP {
 		parts = append(parts, "ip="+port.IP)


### PR DESCRIPTION
## Summary
- Add internal/results formatter registry and deterministic JSON, JSONL, and CSV record rendering.
- Support normalized open-port findings for nmap, naabu, and naabu-nmap artifacts.
- Add heph results export --view findings while preserving records as the default export view.
- Reuse shared open-port parsing in the generic TUI result formatter.

## Tests
- env GOCACHE=/tmp/heph-go-build go test ./...
