### PR TITLE
PR 10.1: Add optional AWS IPv6 egress networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,25 @@ Both scan commands also accept provider/runtime flags including `--cloud`, `--wo
 ./bin/heph scan --tool httpx --file targets.txt --cloud hetzner --workers 25 --min-unique-ips 25
 ```
 
+#### AWS IPv6 Networking
+
+The AWS generic Terraform environment supports optional dual-stack VPC networking. It is disabled by default, so existing AWS deployments keep the current IPv4/NAT behavior unless IPv6 is explicitly enabled.
+
+```bash
+cd deployments/aws/generic/environments/dev
+TF_VAR_tool_name=nmap TF_VAR_enable_ipv6=true terraform plan
+```
+
+When `enable_ipv6` is true, Terraform assigns an AWS-generated IPv6 CIDR to the VPC, gives public and private subnets IPv6 `/64` blocks, routes public IPv6 egress through the internet gateway, and routes private IPv6 egress through an egress-only internet gateway. IPv4 NAT remains present and unchanged.
+
+Before relying on IPv6 egress from ECS tasks, enable the ECS `dualStackIPv6` account setting in the target AWS account and region, for example:
+
+```bash
+aws ecs put-account-setting-default --name dualStackIPv6 --value enabled
+```
+
+This networking support only provisions the IPv6-capable VPC path. CLI/TUI controls and network status display are tracked separately.
+
 ### 5. VPS Scan Execution
 
 The VPS-family path is intentionally split in two:

--- a/deployments/aws/generic/environments/dev/main.tf
+++ b/deployments/aws/generic/environments/dev/main.tf
@@ -14,6 +14,7 @@ module "networking" {
   az_count    = var.az_count
   name_prefix = var.name_prefix
   environment = local.environment
+  enable_ipv6 = var.enable_ipv6
 }
 
 # Create storage for results

--- a/deployments/aws/generic/environments/dev/outputs.tf
+++ b/deployments/aws/generic/environments/dev/outputs.tf
@@ -3,6 +3,11 @@ output "vpc_id" {
   value       = module.networking.vpc_id
 }
 
+output "vpc_ipv6_cidr_block" {
+  description = "Generated IPv6 CIDR block for the VPC when IPv6 is enabled"
+  value       = module.networking.vpc_ipv6_cidr_block
+}
+
 output "sqs_queue_url" {
   description = "URL of the SQS queue"
   value       = module.messaging.queue_url
@@ -36,6 +41,21 @@ output "security_group_id" {
 output "subnet_ids" {
   description = "Private subnet IDs for ECS tasks"
   value       = join(" ", module.networking.private_subnet_ids)
+}
+
+output "private_subnet_ipv6_cidr_blocks" {
+  description = "IPv6 CIDR blocks assigned to private subnets when IPv6 is enabled"
+  value       = module.networking.private_subnet_ipv6_cidr_blocks
+}
+
+output "public_subnet_ipv6_cidr_blocks" {
+  description = "IPv6 CIDR blocks assigned to public subnets when IPv6 is enabled"
+  value       = module.networking.public_subnet_ipv6_cidr_blocks
+}
+
+output "egress_only_internet_gateway_id" {
+  description = "ID of the egress-only internet gateway when IPv6 is enabled"
+  value       = module.networking.egress_only_internet_gateway_id
 }
 
 output "instance_profile_arn" {

--- a/deployments/aws/generic/environments/dev/variables.tf
+++ b/deployments/aws/generic/environments/dev/variables.tf
@@ -27,6 +27,12 @@ variable "az_count" {
   default     = 2
 }
 
+variable "enable_ipv6" {
+  description = "Enable dual-stack IPv6 networking with egress-only internet gateway for private subnet IPv6 egress"
+  type        = bool
+  default     = false
+}
+
 variable "log_retention_days" {
   description = "Number of days to retain logs"
   type        = number

--- a/deployments/aws/shared/networking/main.tf
+++ b/deployments/aws/shared/networking/main.tf
@@ -4,9 +4,10 @@ data "aws_availability_zones" "available" {
 
 # VPC for the application
 resource "aws_vpc" "this" {
-  cidr_block           = var.vpc_cidr
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  cidr_block                       = var.vpc_cidr
+  assign_generated_ipv6_cidr_block = var.enable_ipv6
+  enable_dns_hostnames             = true
+  enable_dns_support               = true
 
   tags = {
     Name        = "${var.name_prefix}-vpc"
@@ -17,11 +18,13 @@ resource "aws_vpc" "this" {
 
 # Public subnets for NAT gateway and internet-facing resources
 resource "aws_subnet" "public" {
-  count                   = var.az_count
-  vpc_id                  = aws_vpc.this.id
-  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index + var.az_count)
-  availability_zone       = data.aws_availability_zones.available.names[count.index]
-  map_public_ip_on_launch = true
+  count                           = var.az_count
+  vpc_id                          = aws_vpc.this.id
+  cidr_block                      = cidrsubnet(var.vpc_cidr, 8, count.index + var.az_count)
+  ipv6_cidr_block                 = var.enable_ipv6 ? cidrsubnet(aws_vpc.this.ipv6_cidr_block, 8, count.index + var.az_count) : null
+  availability_zone               = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch         = true
+  assign_ipv6_address_on_creation = var.enable_ipv6
 
   tags = {
     Name        = "${var.name_prefix}-public-${count.index + 1}"
@@ -32,10 +35,12 @@ resource "aws_subnet" "public" {
 
 # Private subnets for ECS tasks and internal resources
 resource "aws_subnet" "private" {
-  count             = var.az_count
-  vpc_id            = aws_vpc.this.id
-  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index)
-  availability_zone = data.aws_availability_zones.available.names[count.index]
+  count                           = var.az_count
+  vpc_id                          = aws_vpc.this.id
+  cidr_block                      = cidrsubnet(var.vpc_cidr, 8, count.index)
+  ipv6_cidr_block                 = var.enable_ipv6 ? cidrsubnet(aws_vpc.this.ipv6_cidr_block, 8, count.index) : null
+  availability_zone               = data.aws_availability_zones.available.names[count.index]
+  assign_ipv6_address_on_creation = var.enable_ipv6
 
   tags = {
     Name        = "${var.name_prefix}-private-${count.index + 1}"
@@ -50,6 +55,18 @@ resource "aws_internet_gateway" "this" {
 
   tags = {
     Name        = "${var.name_prefix}-igw"
+    Environment = var.environment
+    Terraform   = "true"
+  }
+}
+
+# Egress-only Internet Gateway for private IPv6 egress
+resource "aws_egress_only_internet_gateway" "this" {
+  count  = var.enable_ipv6 ? 1 : 0
+  vpc_id = aws_vpc.this.id
+
+  tags = {
+    Name        = "${var.name_prefix}-eigw"
     Environment = var.environment
     Terraform   = "true"
   }
@@ -89,6 +106,15 @@ resource "aws_route_table" "public" {
     gateway_id = aws_internet_gateway.this.id
   }
 
+  dynamic "route" {
+    for_each = var.enable_ipv6 ? [1] : []
+
+    content {
+      ipv6_cidr_block = "::/0"
+      gateway_id      = aws_internet_gateway.this.id
+    }
+  }
+
   tags = {
     Name        = "${var.name_prefix}-public-rt"
     Environment = var.environment
@@ -103,6 +129,15 @@ resource "aws_route_table" "private" {
   route {
     cidr_block     = "0.0.0.0/0"
     nat_gateway_id = aws_nat_gateway.this.id
+  }
+
+  dynamic "route" {
+    for_each = var.enable_ipv6 ? [1] : []
+
+    content {
+      ipv6_cidr_block        = "::/0"
+      egress_only_gateway_id = aws_egress_only_internet_gateway.this[0].id
+    }
   }
 
   tags = {
@@ -138,6 +173,17 @@ resource "aws_security_group" "ecs_tasks" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  dynamic "egress" {
+    for_each = var.enable_ipv6 ? [1] : []
+
+    content {
+      from_port        = 0
+      to_port          = 0
+      protocol         = "-1"
+      ipv6_cidr_blocks = ["::/0"]
+    }
   }
 
   tags = {

--- a/deployments/aws/shared/networking/outputs.tf
+++ b/deployments/aws/shared/networking/outputs.tf
@@ -3,9 +3,19 @@ output "vpc_id" {
   value       = aws_vpc.this.id
 }
 
+output "vpc_ipv6_cidr_block" {
+  description = "Generated IPv6 CIDR block for the VPC when IPv6 is enabled"
+  value       = var.enable_ipv6 ? aws_vpc.this.ipv6_cidr_block : null
+}
+
 output "private_subnet_ids" {
   description = "IDs of the private subnets"
   value       = aws_subnet.private[*].id
+}
+
+output "private_subnet_ipv6_cidr_blocks" {
+  description = "IPv6 CIDR blocks assigned to private subnets when IPv6 is enabled"
+  value       = var.enable_ipv6 ? aws_subnet.private[*].ipv6_cidr_block : []
 }
 
 output "public_subnet_ids" {
@@ -13,7 +23,17 @@ output "public_subnet_ids" {
   value       = aws_subnet.public[*].id
 }
 
+output "public_subnet_ipv6_cidr_blocks" {
+  description = "IPv6 CIDR blocks assigned to public subnets when IPv6 is enabled"
+  value       = var.enable_ipv6 ? aws_subnet.public[*].ipv6_cidr_block : []
+}
+
 output "ecs_security_group_id" {
   description = "ID of the security group for ECS tasks"
   value       = aws_security_group.ecs_tasks.id
+}
+
+output "egress_only_internet_gateway_id" {
+  description = "ID of the egress-only internet gateway when IPv6 is enabled"
+  value       = var.enable_ipv6 ? aws_egress_only_internet_gateway.this[0].id : null
 }

--- a/deployments/aws/shared/networking/variables.tf
+++ b/deployments/aws/shared/networking/variables.tf
@@ -21,3 +21,9 @@ variable "environment" {
   type        = string
   default     = "dev"
 }
+
+variable "enable_ipv6" {
+  description = "Enable dual-stack IPv6 networking with egress-only internet gateway for private subnet IPv6 egress"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary
- Add optional dual-stack IPv6 support to the AWS shared networking module.
- Assign generated VPC IPv6 CIDR blocks to public and private subnets when enabled.
- Add conditional egress-only internet gateway, IPv6 default routes, and IPv6 ECS task egress.
- Pass `enable_ipv6` and IPv6/EIGW outputs through the AWS generic dev environment.
- Document the `TF_VAR_enable_ipv6=true` flow and ECS `dualStackIPv6` prerequisite.

## Tests
- `terraform fmt -check deployments/aws/shared/networking deployments/aws/generic/environments/dev`
- `terraform validate` in `deployments/aws/generic/environments/dev`
- `env GOCACHE=/tmp/heph-go-build go test ./...`
- `git diff --check`

## Notes
- IPv6 remains disabled by default.
- Existing IPv4 NAT behavior is unchanged.
- `terraform init` / `terraform validate` required sandbox escalation for provider registry/plugin execution.
- Repo-wide `terraform fmt -check -recursive deployments/aws` is still blocked by pre-existing formatting drift in `deployments/aws/generic/messaging/main.tf` and `deployments/aws/shared/security/main.tf`.
- TFLint/Trivy findings were reviewed and are planned for Phase 11 rather than folded into this networking PR.
