### PR TITLE
PR 10.2: Add optional AWS multi-NAT routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Heph4estus is a TUI/CLI app that handles cloud infrastructure deployment and dis
 
 - **Go 1.26+**: For building the application
 - **Docker**: For building container images (managed by heph4estus)
-- **Terraform 1.0+**: For infrastructure provisioning (managed by heph4estus)
+- **Terraform 1.1+**: For infrastructure provisioning (managed by heph4estus)
 - **AWS CLI**: Configured with appropriate credentials and permissions (AWS path only)
 
 ## Quick Start
@@ -105,16 +105,21 @@ Both scan commands also accept provider/runtime flags including `--cloud`, `--wo
 ./bin/heph scan --tool httpx --file targets.txt --cloud hetzner --workers 25 --min-unique-ips 25
 ```
 
-#### AWS IPv6 Networking
+#### AWS IPv6 And Multi-NAT Networking
 
-The AWS generic Terraform environment supports optional dual-stack VPC networking. It is disabled by default, so existing AWS deployments keep the current IPv4/NAT behavior unless IPv6 is explicitly enabled.
+The AWS generic Terraform environment supports optional dual-stack VPC networking and optional multi-NAT IPv4 egress. Both are disabled by default, so existing AWS deployments keep the current single-NAT IPv4 behavior unless these features are explicitly enabled.
 
 ```bash
 cd deployments/aws/generic/environments/dev
 TF_VAR_tool_name=nmap TF_VAR_enable_ipv6=true terraform plan
+
+# IPv4 source diversity: one NAT gateway and EIP per AZ
+TF_VAR_tool_name=nmap TF_VAR_multi_nat=true terraform plan
 ```
 
 When `enable_ipv6` is true, Terraform assigns an AWS-generated IPv6 CIDR to the VPC, gives public and private subnets IPv6 `/64` blocks, routes public IPv6 egress through the internet gateway, and routes private IPv6 egress through an egress-only internet gateway. IPv4 NAT remains present and unchanged.
+
+When `multi_nat` is true, Terraform creates one NAT gateway and one Elastic IP per availability zone, then routes each private subnet through the NAT gateway in the same AZ. This improves IPv4 source IP diversity, but it also increases AWS NAT Gateway and Elastic IP costs.
 
 Before relying on IPv6 egress from ECS tasks, enable the ECS `dualStackIPv6` account setting in the target AWS account and region, for example:
 
@@ -122,7 +127,7 @@ Before relying on IPv6 egress from ECS tasks, enable the ECS `dualStackIPv6` acc
 aws ecs put-account-setting-default --name dualStackIPv6 --value enabled
 ```
 
-This networking support only provisions the IPv6-capable VPC path. CLI/TUI controls and network status display are tracked separately.
+This networking support only provisions the IPv6-capable VPC path and multi-NAT infrastructure. CLI/TUI controls and network status display are tracked separately.
 
 ### 5. VPS Scan Execution
 

--- a/deployments/aws/generic/environments/dev/main.tf
+++ b/deployments/aws/generic/environments/dev/main.tf
@@ -15,6 +15,7 @@ module "networking" {
   name_prefix = var.name_prefix
   environment = local.environment
   enable_ipv6 = var.enable_ipv6
+  multi_nat   = var.multi_nat
 }
 
 # Create storage for results

--- a/deployments/aws/generic/environments/dev/outputs.tf
+++ b/deployments/aws/generic/environments/dev/outputs.tf
@@ -53,6 +53,11 @@ output "public_subnet_ipv6_cidr_blocks" {
   value       = module.networking.public_subnet_ipv6_cidr_blocks
 }
 
+output "nat_gateway_public_ips" {
+  description = "Public IPv4 addresses assigned to NAT gateways"
+  value       = module.networking.nat_gateway_public_ips
+}
+
 output "egress_only_internet_gateway_id" {
   description = "ID of the egress-only internet gateway when IPv6 is enabled"
   value       = module.networking.egress_only_internet_gateway_id

--- a/deployments/aws/generic/environments/dev/variables.tf
+++ b/deployments/aws/generic/environments/dev/variables.tf
@@ -33,6 +33,12 @@ variable "enable_ipv6" {
   default     = false
 }
 
+variable "multi_nat" {
+  description = "Create one NAT gateway per availability zone for IPv4 source IP diversity"
+  type        = bool
+  default     = false
+}
+
 variable "log_retention_days" {
   description = "Number of days to retain logs"
   type        = number

--- a/deployments/aws/shared/networking/main.tf
+++ b/deployments/aws/shared/networking/main.tf
@@ -2,6 +2,26 @@ data "aws_availability_zones" "available" {
   state = "available"
 }
 
+locals {
+  nat_gateway_count         = var.multi_nat ? var.az_count : 1
+  private_route_table_count = var.multi_nat ? var.az_count : 1
+}
+
+moved {
+  from = aws_eip.nat
+  to   = aws_eip.nat[0]
+}
+
+moved {
+  from = aws_nat_gateway.this
+  to   = aws_nat_gateway.this[0]
+}
+
+moved {
+  from = aws_route_table.private
+  to   = aws_route_table.private[0]
+}
+
 # VPC for the application
 resource "aws_vpc" "this" {
   cidr_block                       = var.vpc_cidr
@@ -74,10 +94,11 @@ resource "aws_egress_only_internet_gateway" "this" {
 
 # Elastic IP for NAT Gateway
 resource "aws_eip" "nat" {
+  count  = local.nat_gateway_count
   domain = "vpc"
 
   tags = {
-    Name        = "${var.name_prefix}-nat-eip"
+    Name        = var.multi_nat ? "${var.name_prefix}-nat-eip-${count.index + 1}" : "${var.name_prefix}-nat-eip"
     Environment = var.environment
     Terraform   = "true"
   }
@@ -85,11 +106,12 @@ resource "aws_eip" "nat" {
 
 # NAT Gateway
 resource "aws_nat_gateway" "this" {
-  allocation_id = aws_eip.nat.id
-  subnet_id     = aws_subnet.public[0].id # Place in first public subnet
+  count         = local.nat_gateway_count
+  allocation_id = aws_eip.nat[count.index].id
+  subnet_id     = aws_subnet.public[count.index].id
 
   tags = {
-    Name        = "${var.name_prefix}-nat"
+    Name        = var.multi_nat ? "${var.name_prefix}-nat-${count.index + 1}" : "${var.name_prefix}-nat"
     Environment = var.environment
     Terraform   = "true"
   }
@@ -124,11 +146,12 @@ resource "aws_route_table" "public" {
 
 # Route table for private subnets
 resource "aws_route_table" "private" {
+  count  = local.private_route_table_count
   vpc_id = aws_vpc.this.id
 
   route {
     cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.this.id
+    nat_gateway_id = aws_nat_gateway.this[var.multi_nat ? count.index : 0].id
   }
 
   dynamic "route" {
@@ -141,7 +164,7 @@ resource "aws_route_table" "private" {
   }
 
   tags = {
-    Name        = "${var.name_prefix}-private-rt"
+    Name        = var.multi_nat ? "${var.name_prefix}-private-rt-${count.index + 1}" : "${var.name_prefix}-private-rt"
     Environment = var.environment
     Terraform   = "true"
   }
@@ -158,7 +181,7 @@ resource "aws_route_table_association" "public" {
 resource "aws_route_table_association" "private" {
   count          = var.az_count
   subnet_id      = aws_subnet.private[count.index].id
-  route_table_id = aws_route_table.private.id
+  route_table_id = aws_route_table.private[var.multi_nat ? count.index : 0].id
 }
 
 # Security group for ECS tasks

--- a/deployments/aws/shared/networking/outputs.tf
+++ b/deployments/aws/shared/networking/outputs.tf
@@ -28,6 +28,11 @@ output "public_subnet_ipv6_cidr_blocks" {
   value       = var.enable_ipv6 ? aws_subnet.public[*].ipv6_cidr_block : []
 }
 
+output "nat_gateway_public_ips" {
+  description = "Public IPv4 addresses assigned to NAT gateways"
+  value       = aws_eip.nat[*].public_ip
+}
+
 output "ecs_security_group_id" {
   description = "ID of the security group for ECS tasks"
   value       = aws_security_group.ecs_tasks.id

--- a/deployments/aws/shared/networking/variables.tf
+++ b/deployments/aws/shared/networking/variables.tf
@@ -27,3 +27,9 @@ variable "enable_ipv6" {
   type        = bool
   default     = false
 }
+
+variable "multi_nat" {
+  description = "Create one NAT gateway per availability zone for IPv4 source IP diversity"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Summary
- Add optional `multi_nat` support to the AWS shared networking module.
- Preserve existing single-NAT state using Terraform `moved` blocks.
- When enabled, provision one NAT gateway and EIP per AZ and route each private subnet through its same-AZ NAT gateway.
- Add `nat_gateway_public_ips` output and pass it through the AWS generic dev environment.
- Document `TF_VAR_multi_nat=true`, NAT/EIP cost impact, and Terraform 1.1+ requirement for moved blocks.

## Tests
- `terraform fmt -check deployments/aws/shared/networking deployments/aws/generic/environments/dev`
- `terraform validate` in `deployments/aws/generic/environments/dev`
- `env GOCACHE=/tmp/heph-go-build go test ./...`
- `git diff --check`

## Notes
- `multi_nat` is disabled by default; existing single-NAT behavior is unchanged.
- `terraform init` / `terraform validate` required sandbox escalation for provider registry/plugin execution.
- TFLint/Trivy were run for awareness and still show the existing Phase 11 baseline findings; no new finding category came from multi-NAT.
