### PR TITLE
PR 11.1: Add AWS Terraform lint baseline

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,4 @@
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ CONTAINER_CONTEXT ?= .
 TOOL_IMAGE_PREFIX ?= heph
 TOOL_IMAGE_SUFFIX ?= worker
 TOOL_IMAGE_TAG ?= latest
+TFLINT_CONFIG ?= $(CURDIR)/.tflint.hcl
 
 TOOL_IMAGES := nmap nuclei subfinder httpx masscan naabu naabu-nmap
 
@@ -23,7 +24,7 @@ NAABU_SMOKE_ARGS := -version
 
 tool_image = $(TOOL_IMAGE_PREFIX)-$(1)-$(TOOL_IMAGE_SUFFIX):$(TOOL_IMAGE_TAG)
 
-.PHONY: all build test lint docker-build docker-build-all docker-build-nmap docker-build-nmap-generic docker-build-nuclei docker-build-subfinder docker-build-httpx docker-build-masscan docker-build-naabu docker-build-naabu-nmap docker-smoke-all docker-smoke-nmap docker-smoke-nuclei docker-smoke-subfinder docker-smoke-httpx docker-smoke-masscan docker-smoke-naabu docker-smoke-naabu-nmap container-smoke tf-validate clean
+.PHONY: all build test lint docker-build docker-build-all docker-build-nmap docker-build-nmap-generic docker-build-nuclei docker-build-subfinder docker-build-httpx docker-build-masscan docker-build-naabu docker-build-naabu-nmap docker-smoke-all docker-smoke-nmap docker-smoke-nuclei docker-smoke-subfinder docker-smoke-httpx docker-smoke-masscan docker-smoke-naabu docker-smoke-naabu-nmap container-smoke tf-fmt tf-lint tf-security tf-validate clean
 
 all: build test lint
 
@@ -114,6 +115,15 @@ docker-smoke-all: $(addprefix docker-smoke-,$(TOOL_IMAGES))
 
 container-smoke: docker-build-all
 	$(MAKE) docker-smoke-all
+
+tf-fmt:
+	terraform fmt -check -recursive deployments/aws
+
+tf-lint:
+	tflint --config "$(TFLINT_CONFIG)" --recursive --chdir deployments/aws
+
+tf-security:
+	trivy config deployments/aws
 
 tf-validate:
 	cd deployments/aws/generic/environments/dev && terraform init -backend=false && terraform validate

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Heph4estus is a TUI/CLI app that handles cloud infrastructure deployment and dis
 
 - **Go 1.26+**: For building the application
 - **Docker**: For building container images (managed by heph4estus)
-- **Terraform 1.1+**: For infrastructure provisioning (managed by heph4estus)
+- **Terraform 1.5+**: For infrastructure provisioning (managed by heph4estus)
 - **AWS CLI**: Configured with appropriate credentials and permissions (AWS path only)
 
 ## Quick Start
@@ -128,6 +128,19 @@ aws ecs put-account-setting-default --name dualStackIPv6 --value enabled
 ```
 
 This networking support only provisions the IPv6-capable VPC path and multi-NAT infrastructure. CLI/TUI controls and network status display are tracked separately.
+
+#### AWS Terraform Quality Checks
+
+AWS Terraform modules declare Terraform `>= 1.5.0`, `hashicorp/aws` `~> 6.0`, and `hashicorp/random` `~> 3.0` where used. Run these checks before changing AWS infrastructure:
+
+```bash
+make tf-fmt
+make tf-validate
+make tf-lint
+make tf-security
+```
+
+Use Trivy (`make tf-security`) for Terraform security scanning. `tfsec` is legacy and should not be used for new checks. Phase 11 separates Terraform lint cleanup from AWS security hardening, so Trivy findings are handled in dedicated follow-up PRs.
 
 ### 5. VPS Scan Execution
 

--- a/deployments/aws/generic/compute/main.tf
+++ b/deployments/aws/generic/compute/main.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
 locals {
   base_env = [
     {

--- a/deployments/aws/generic/environments/dev/main.tf
+++ b/deployments/aws/generic/environments/dev/main.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
 provider "aws" {
   region = var.aws_region
 }

--- a/deployments/aws/generic/messaging/main.tf
+++ b/deployments/aws/generic/messaging/main.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
 # Main SQS queue for tasks
 resource "aws_sqs_queue" "tasks" {
   name                       = "${var.name_prefix}-tasks"

--- a/deployments/aws/generic/messaging/main.tf
+++ b/deployments/aws/generic/messaging/main.tf
@@ -12,8 +12,8 @@ terraform {
 # Main SQS queue for tasks
 resource "aws_sqs_queue" "tasks" {
   name                       = "${var.name_prefix}-tasks"
-  visibility_timeout_seconds = 900  # 15 minutes
-  message_retention_seconds  = 86400  # 1 day
+  visibility_timeout_seconds = 900   # 15 minutes
+  message_retention_seconds  = 86400 # 1 day
 
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.dlq.arn
@@ -30,7 +30,7 @@ resource "aws_sqs_queue" "tasks" {
 # Dead letter queue for failed tasks
 resource "aws_sqs_queue" "dlq" {
   name                      = "${var.name_prefix}-tasks-dlq"
-  message_retention_seconds = 1209600  # 14 days
+  message_retention_seconds = 1209600 # 14 days
 
   tags = {
     Name        = "${var.name_prefix}-tasks-dlq"

--- a/deployments/aws/generic/spot/main.tf
+++ b/deployments/aws/generic/spot/main.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 

--- a/deployments/aws/generic/storage/main.tf
+++ b/deployments/aws/generic/storage/main.tf
@@ -1,3 +1,19 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
 resource "random_string" "bucket_suffix" {
   length  = 8
   special = false

--- a/deployments/aws/shared/networking/main.tf
+++ b/deployments/aws/shared/networking/main.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
 data "aws_availability_zones" "available" {
   state = "available"
 }

--- a/deployments/aws/shared/security/main.tf
+++ b/deployments/aws/shared/security/main.tf
@@ -40,7 +40,7 @@ resource "aws_iam_role" "step_functions" {
 resource "aws_iam_policy" "step_functions_logs" {
   name        = "${var.name_prefix}-step-functions-logs-policy"
   description = "Policy for Step Functions logs and X-Ray"
-  
+
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -71,7 +71,7 @@ resource "aws_iam_policy" "step_functions_logs" {
 resource "aws_iam_policy" "step_functions_services" {
   name        = "${var.name_prefix}-step-functions-services-policy"
   description = "Policy for Step Functions to interact with other AWS services"
-  
+
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -138,7 +138,7 @@ resource "aws_iam_role_policy_attachment" "ecs_execution_policy" {
 resource "aws_iam_policy" "ecs_execution_custom" {
   name        = "${var.name_prefix}-ecs-execution-custom-policy"
   description = "Custom policy for ECS execution role"
-  
+
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -196,7 +196,7 @@ resource "aws_iam_role" "ecs_task" {
 resource "aws_iam_policy" "ecs_task_custom" {
   name        = "${var.name_prefix}-ecs-task-custom-policy"
   description = "Custom policy for ECS task role"
-  
+
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/deployments/aws/shared/security/main.tf
+++ b/deployments/aws/shared/security/main.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 


### PR DESCRIPTION
## Summary
- Add explicit AWS Terraform version/provider constraints across AWS roots and modules.
- Add a repo-root TFLint config using the Terraform recommended ruleset.
- Add `make tf-fmt`, `make tf-lint`, and `make tf-security` for repeatable AWS Terraform checks.
- Document Terraform 1.5+, the new quality commands, and Trivy-over-tfsec guidance.
- Clean the existing AWS Terraform formatting drift.

## Tests
- `terraform fmt -check -recursive deployments/aws`
- `make tf-fmt`
- `terraform init -backend=false` in `deployments/aws/generic/environments/dev`
- `terraform validate` in `deployments/aws/generic/environments/dev`
- `make tf-validate`
- `/tmp/heph-tools/bin/tflint --config /home/jarro/projects/hephaestus/heph4estus/.tflint.hcl --recursive --chdir deployments/aws`
- `PATH=/tmp/heph-tools/bin:$PATH make tf-lint`
- `TRIVY_CACHE_DIR=/tmp/heph-tools/trivy-cache PATH=/tmp/heph-tools/bin:$PATH make tf-security`
- `env GOCACHE=/tmp/heph-go-build go test ./...`
- `git diff --check`

## Notes
- `make tf-security` still reports the existing Phase 11 Trivy backlog; this PR intentionally leaves those findings for PR 11.2-11.4.
- `terraform validate` still reports the pre-existing AWS provider deprecation warning for `data.aws_region.current.name`.
- Terraform/TFLint validation needed sandbox escalation locally for provider/plugin execution.
