### PR TITLE
PR 11.2: Add AWS encryption and audit logging baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ make tf-security
 
 Use Trivy (`make tf-security`) for Terraform security scanning. `tfsec` is legacy and should not be used for new checks. Phase 11 separates Terraform lint cleanup from AWS security hardening, so Trivy findings are handled in dedicated follow-up PRs.
 
+The AWS generic dev environment uses a customer-managed KMS key for CloudWatch log groups, ECR repositories, SQS queues, and the S3 result bucket. The result bucket also writes S3 server access logs to a dedicated log bucket that uses SSE-S3, which is required for S3 log delivery destinations.
+
+After the encryption and logging baseline, expected remaining Trivy findings are tracked separately: ECR tag immutability is PR 11.3, and networking/IAM audit findings are PR 11.4.
+
 ### 5. VPS Scan Execution
 
 The VPS-family path is intentionally split in two:

--- a/deployments/aws/generic/compute/main.tf
+++ b/deployments/aws/generic/compute/main.tf
@@ -35,6 +35,7 @@ locals {
 # CloudWatch log group for ECS tasks
 resource "aws_cloudwatch_log_group" "worker_logs" {
   name              = "/ecs/${var.name_prefix}-${var.tool_name}"
+  kms_key_id        = var.kms_key_arn
   retention_in_days = var.log_retention_days
 
   tags = {
@@ -49,6 +50,11 @@ resource "aws_ecr_repository" "worker" {
   name                 = "${var.name_prefix}-${var.tool_name}"
   image_tag_mutability = "MUTABLE"
   force_delete         = true
+
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = var.kms_key_arn
+  }
 
   image_scanning_configuration {
     scan_on_push = true

--- a/deployments/aws/generic/compute/variables.tf
+++ b/deployments/aws/generic/compute/variables.tf
@@ -20,6 +20,11 @@ variable "log_retention_days" {
   default     = 30
 }
 
+variable "kms_key_arn" {
+  description = "ARN of the customer-managed KMS key used for logs and repository encryption"
+  type        = string
+}
+
 variable "task_cpu" {
   description = "CPU units for the ECS task"
   type        = number

--- a/deployments/aws/generic/environments/dev/main.tf
+++ b/deployments/aws/generic/environments/dev/main.tf
@@ -13,8 +13,91 @@ provider "aws" {
   region = var.aws_region
 }
 
+data "aws_caller_identity" "current" {}
+
 locals {
   environment = "dev"
+}
+
+# Customer-managed key for AWS service encryption in the dev environment
+resource "aws_kms_key" "infrastructure" {
+  description             = "${var.name_prefix} AWS infrastructure encryption"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "EnableAccountAdministration"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowCloudWatchLogsUse"
+        Effect = "Allow"
+        Principal = {
+          Service = "logs.${var.aws_region}.amazonaws.com"
+        }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey"
+        ]
+        Resource = "*"
+        Condition = {
+          ArnLike = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:*"
+          }
+        }
+      },
+      {
+        Sid    = "AllowIntegratedServiceUse"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action = [
+          "kms:CreateGrant",
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey",
+          "kms:ListGrants",
+          "kms:RetireGrant"
+        ]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "kms:CallerAccount" = data.aws_caller_identity.current.account_id
+            "kms:ViaService" = [
+              "ecr.${var.aws_region}.amazonaws.com",
+              "s3.${var.aws_region}.amazonaws.com",
+              "sqs.${var.aws_region}.amazonaws.com"
+            ]
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "${var.name_prefix}-infrastructure-key"
+    Environment = local.environment
+    Terraform   = "true"
+  }
+}
+
+resource "aws_kms_alias" "infrastructure" {
+  name          = "alias/${var.name_prefix}-infrastructure"
+  target_key_id = aws_kms_key.infrastructure.key_id
 }
 
 # Create network infrastructure
@@ -36,7 +119,8 @@ module "storage" {
   name_prefix            = var.name_prefix
   environment            = local.environment
   force_destroy_bucket   = true # Make it easier to clean up in dev
-  results_retention_days = 30   # Only keep results for 30 days in dev
+  kms_key_arn            = aws_kms_key.infrastructure.arn
+  results_retention_days = 30 # Only keep results for 30 days in dev
 }
 
 # Create messaging infrastructure
@@ -45,6 +129,7 @@ module "messaging" {
 
   name_prefix = var.name_prefix
   environment = local.environment
+  kms_key_arn = aws_kms_key.infrastructure.arn
 }
 
 # Create security roles and policies
@@ -53,6 +138,7 @@ module "security" {
 
   name_prefix   = var.name_prefix
   environment   = local.environment
+  kms_key_arn   = aws_kms_key.infrastructure.arn
   sqs_queue_arn = module.messaging.queue_arn
   s3_bucket_arn = module.storage.bucket_arn
 }
@@ -65,6 +151,7 @@ module "compute" {
   environment            = local.environment
   aws_region             = var.aws_region
   log_retention_days     = var.log_retention_days
+  kms_key_arn            = aws_kms_key.infrastructure.arn
   task_cpu               = var.task_cpu
   task_memory            = var.task_memory
   ecs_execution_role_arn = module.security.ecs_execution_role_arn

--- a/deployments/aws/generic/messaging/main.tf
+++ b/deployments/aws/generic/messaging/main.tf
@@ -12,6 +12,7 @@ terraform {
 # Main SQS queue for tasks
 resource "aws_sqs_queue" "tasks" {
   name                       = "${var.name_prefix}-tasks"
+  kms_master_key_id          = var.kms_key_arn
   visibility_timeout_seconds = 900   # 15 minutes
   message_retention_seconds  = 86400 # 1 day
 
@@ -30,6 +31,7 @@ resource "aws_sqs_queue" "tasks" {
 # Dead letter queue for failed tasks
 resource "aws_sqs_queue" "dlq" {
   name                      = "${var.name_prefix}-tasks-dlq"
+  kms_master_key_id         = var.kms_key_arn
   message_retention_seconds = 1209600 # 14 days
 
   tags = {

--- a/deployments/aws/generic/messaging/variables.tf
+++ b/deployments/aws/generic/messaging/variables.tf
@@ -8,3 +8,8 @@ variable "environment" {
   type        = string
   default     = "dev"
 }
+
+variable "kms_key_arn" {
+  description = "ARN of the customer-managed KMS key used for queue encryption"
+  type        = string
+}

--- a/deployments/aws/generic/storage/main.tf
+++ b/deployments/aws/generic/storage/main.tf
@@ -14,6 +14,8 @@ terraform {
   }
 }
 
+data "aws_caller_identity" "current" {}
+
 resource "random_string" "bucket_suffix" {
   length  = 8
   special = false
@@ -32,6 +34,19 @@ resource "aws_s3_bucket" "results" {
   }
 }
 
+# S3 server access logs should not recursively log themselves.
+#trivy:ignore:AVD-AWS-0089
+resource "aws_s3_bucket" "access_logs" {
+  bucket        = "${var.name_prefix}-access-logs-${random_string.bucket_suffix.result}"
+  force_destroy = var.force_destroy_bucket
+
+  tags = {
+    Name        = "${var.name_prefix}-access-logs"
+    Environment = var.environment
+    Terraform   = "true"
+  }
+}
+
 # Block all public access to the S3 bucket
 resource "aws_s3_bucket_public_access_block" "results" {
   bucket = aws_s3_bucket.results.id
@@ -42,9 +57,26 @@ resource "aws_s3_bucket_public_access_block" "results" {
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_public_access_block" "access_logs" {
+  bucket = aws_s3_bucket.access_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
 # Configure bucket versioning
 resource "aws_s3_bucket_versioning" "results" {
   bucket = aws_s3_bucket.results.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "access_logs" {
+  bucket = aws_s3_bucket.access_logs.id
 
   versioning_configuration {
     status = "Enabled"
@@ -65,13 +97,64 @@ resource "aws_s3_bucket_lifecycle_configuration" "results" {
   }
 }
 
-# Enable server-side encryption
+# Enable server-side encryption for result data
 resource "aws_s3_bucket_server_side_encryption_configuration" "results" {
   bucket = aws_s3_bucket.results.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = var.kms_key_arn
+      sse_algorithm     = "aws:kms"
+    }
+
+    bucket_key_enabled = true
+  }
+}
+
+# S3 server access logging destination buckets must use SSE-S3, not SSE-KMS.
+#trivy:ignore:AVD-AWS-0132
+resource "aws_s3_bucket_server_side_encryption_configuration" "access_logs" {
+  bucket = aws_s3_bucket.access_logs.id
 
   rule {
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
     }
   }
+}
+
+resource "aws_s3_bucket_policy" "access_logs" {
+  bucket = aws_s3_bucket.access_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowS3ServerAccessLogs"
+        Effect = "Allow"
+        Principal = {
+          Service = "logging.s3.amazonaws.com"
+        }
+        Action   = "s3:PutObject"
+        Resource = "${aws_s3_bucket.access_logs.arn}/results/*"
+        Condition = {
+          ArnLike = {
+            "aws:SourceArn" = aws_s3_bucket.results.arn
+          }
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_s3_bucket_logging" "results" {
+  bucket = aws_s3_bucket.results.id
+
+  target_bucket = aws_s3_bucket.access_logs.id
+  target_prefix = "results/"
+
+  depends_on = [aws_s3_bucket_policy.access_logs]
 }

--- a/deployments/aws/generic/storage/variables.tf
+++ b/deployments/aws/generic/storage/variables.tf
@@ -15,6 +15,11 @@ variable "force_destroy_bucket" {
   default     = false
 }
 
+variable "kms_key_arn" {
+  description = "ARN of the customer-managed KMS key used for result bucket encryption"
+  type        = string
+}
+
 variable "results_retention_days" {
   description = "Number of days to retain results before deletion"
   type        = number

--- a/deployments/aws/shared/security/main.tf
+++ b/deployments/aws/shared/security/main.tf
@@ -12,6 +12,15 @@ terraform {
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
+locals {
+  kms_key_actions = [
+    "kms:Decrypt",
+    "kms:Encrypt",
+    "kms:GenerateDataKey*",
+    "kms:DescribeKey"
+  ]
+}
+
 # ===== Step Functions Role =====
 resource "aws_iam_role" "step_functions" {
   name = "${var.name_prefix}-step-functions-role"
@@ -88,6 +97,11 @@ resource "aws_iam_policy" "step_functions_services" {
           "events:DescribeRule"
         ]
         Resource = "*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = local.kms_key_actions
+        Resource = var.kms_key_arn
       }
     ]
   })
@@ -160,6 +174,11 @@ resource "aws_iam_policy" "ecs_execution_custom" {
           "logs:CreateLogGroup"
         ]
         Resource = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = local.kms_key_actions
+        Resource = var.kms_key_arn
       }
     ]
   })
@@ -216,6 +235,11 @@ resource "aws_iam_policy" "ecs_task_custom" {
           "s3:GetObject"
         ]
         Resource = "${var.s3_bucket_arn}/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = local.kms_key_actions
+        Resource = var.kms_key_arn
       }
     ]
   })

--- a/deployments/aws/shared/security/variables.tf
+++ b/deployments/aws/shared/security/variables.tf
@@ -10,6 +10,11 @@ variable "environment" {
   default     = "dev"
 }
 
+variable "kms_key_arn" {
+  description = "ARN of the customer-managed KMS key used by encrypted AWS services"
+  type        = string
+}
+
 variable "sqs_queue_arn" {
   description = "ARN of the SQS queue for tasks"
   type        = string


### PR DESCRIPTION
## Summary
- Add a shared customer-managed KMS key and alias for the AWS generic dev environment.
- Use the KMS key for CloudWatch log groups, ECR repository encryption, SQS task/DLQ queue encryption, and S3 result bucket SSE-KMS.
- Add S3 result bucket server access logging with a dedicated access-log bucket.
- Document the encryption/audit baseline and the expected remaining Phase 11 findings.

## Tests
- `terraform fmt -check -recursive deployments/aws`
- `make tf-fmt`
- `terraform init -backend=false` in `deployments/aws/generic/environments/dev`
- `terraform validate` in `deployments/aws/generic/environments/dev`
- `make tf-validate`
- `PATH=/tmp/heph-tools/bin:$PATH make tf-lint`
- `TRIVY_CACHE_DIR=/tmp/heph-tools/trivy-cache PATH=/tmp/heph-tools/bin:$PATH make tf-security`
- `env GOCACHE=/tmp/heph-go-build go test ./...`
- `git diff --check`

## Notes
- Trivy now only shows the expected follow-ups: `AWS-0031` for PR 11.3, plus networking/IAM audit findings for PR 11.4.
- The access-log bucket has scoped Trivy ignores for recursive self-logging and SSE-KMS, since S3 server access log destinations should not recursively log themselves and must use SSE-S3.
- Terraform validation still reports the existing AWS provider deprecation warning for `data.aws_region.current.name`.
- Terraform/TFLint/Trivy validation required sandbox escalation locally for provider/plugin execution.
