### PR TITLE
PR 11.3: Immutable AWS ECR image publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ make tf-security
 
 Use Trivy (`make tf-security`) for Terraform security scanning. `tfsec` is legacy and should not be used for new checks. Phase 11 separates Terraform lint cleanup from AWS security hardening, so Trivy findings are handled in dedicated follow-up PRs.
 
-The AWS generic dev environment uses a customer-managed KMS key for CloudWatch log groups, ECR repositories, SQS queues, and the S3 result bucket. The result bucket also writes S3 server access logs to a dedicated log bucket that uses SSE-S3, which is required for S3 log delivery destinations.
+The AWS generic dev environment uses a customer-managed KMS key for CloudWatch log groups, ECR repositories, SQS queues, and the S3 result bucket. The result bucket also writes S3 server access logs to a dedicated log bucket that uses SSE-S3, which is required for S3 log delivery destinations. AWS worker images are published with generated immutable ECR tags and ECS task definitions reference the full immutable image.
 
-After the encryption and logging baseline, expected remaining Trivy findings are tracked separately: ECR tag immutability is PR 11.3, and networking/IAM audit findings are PR 11.4.
+After the encryption, logging, and immutable image-publishing baseline, expected remaining Trivy findings are tracked separately as networking/IAM audit findings for PR 11.4.
 
 ### 5. VPS Scan Execution
 

--- a/cmd/heph/aws_image.go
+++ b/cmd/heph/aws_image.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+func awsImageTagFromOutputs(outputs map[string]string) (string, error) {
+	tag := strings.TrimSpace(outputs["image_tag"])
+	if tag == "" {
+		return "", fmt.Errorf("terraform outputs missing image_tag")
+	}
+	return tag, nil
+}

--- a/cmd/heph/aws_image_test.go
+++ b/cmd/heph/aws_image_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAWSImageTagFromOutputs(t *testing.T) {
+	tag, err := awsImageTagFromOutputs(map[string]string{
+		"image_tag": " heph-nmap-worker-20260608T032422Z-a1b2c3d4 ",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tag != "heph-nmap-worker-20260608T032422Z-a1b2c3d4" {
+		t.Fatalf("tag = %q", tag)
+	}
+}
+
+func TestAWSImageTagFromOutputsMissing(t *testing.T) {
+	_, err := awsImageTagFromOutputs(map[string]string{})
+	if err == nil {
+		t.Fatal("expected missing image_tag error")
+	}
+	if !strings.Contains(err.Error(), "image_tag") {
+		t.Fatalf("error = %v, want image_tag", err)
+	}
+}

--- a/cmd/heph/cmd_lifecycle_test.go
+++ b/cmd/heph/cmd_lifecycle_test.go
@@ -93,6 +93,8 @@ func testOutputs() map[string]string {
 		"sqs_queue_url":        "queue-url",
 		"s3_bucket_name":       "results-bucket",
 		"ecr_repo_url":         "123.dkr.ecr.us-east-1.amazonaws.com/repo",
+		"image_tag":            "heph-nmap-worker-20260608T032422Z-a1b2c3d4",
+		"docker_image":         "123.dkr.ecr.us-east-1.amazonaws.com/repo:heph-nmap-worker-20260608T032422Z-a1b2c3d4",
 		"ecs_cluster_name":     "cluster",
 		"task_definition_arn":  "task-def",
 		"subnet_ids":           "[subnet-a subnet-b]",

--- a/cmd/heph/cmd_nmap.go
+++ b/cmd/heph/cmd_nmap.go
@@ -369,9 +369,13 @@ func runNmapScanWithDeps(ctx context.Context, tasks []nmap.ScanTask, workers int
 		useSpot := !isSelfhosted && resolveComputeMode(computeMode, workers)
 		if useSpot {
 			ecrURL := outputs["ecr_repo_url"]
+			imageTag, err := awsImageTagFromOutputs(outputs)
+			if err != nil {
+				return false, err
+			}
 			userData := awscloud.GenerateUserData(awscloud.UserDataOpts{
 				ECRRepoURL: ecrURL,
-				ImageTag:   "latest",
+				ImageTag:   imageTag,
 				Region:     regionFromECR(ecrURL),
 				EnvVars:    workerEnv,
 			})

--- a/cmd/heph/cmd_scan.go
+++ b/cmd/heph/cmd_scan.go
@@ -557,9 +557,13 @@ func launchGenericWorkers(ctx context.Context, tool string, workers int, compute
 	useSpot := !cloudKind.IsSelfhostedFamily() && resolveComputeMode(computeMode, workers)
 	if useSpot {
 		ecrURL := outputs["ecr_repo_url"]
+		imageTag, err := awsImageTagFromOutputs(outputs)
+		if err != nil {
+			return err
+		}
 		userData := awscloud.GenerateUserData(awscloud.UserDataOpts{
 			ECRRepoURL: ecrURL,
-			ImageTag:   "latest",
+			ImageTag:   imageTag,
 			Region:     regionFromECR(ecrURL),
 			EnvVars:    workerEnv,
 		})

--- a/deployments/aws/generic/compute/main.tf
+++ b/deployments/aws/generic/compute/main.tf
@@ -48,7 +48,7 @@ resource "aws_cloudwatch_log_group" "worker_logs" {
 # ECR repository for container images
 resource "aws_ecr_repository" "worker" {
   name                 = "${var.name_prefix}-${var.tool_name}"
-  image_tag_mutability = "MUTABLE"
+  image_tag_mutability = "IMMUTABLE"
   force_delete         = true
 
   encryption_configuration {
@@ -118,7 +118,7 @@ resource "aws_ecs_task_definition" "worker" {
   container_definitions = jsonencode([
     {
       name        = "${var.tool_name}-worker"
-      image       = "${aws_ecr_repository.worker.repository_url}:latest"
+      image       = "${aws_ecr_repository.worker.repository_url}:${var.image_tag}"
       environment = local.all_env
       logConfiguration = {
         logDriver = "awslogs"

--- a/deployments/aws/generic/compute/outputs.tf
+++ b/deployments/aws/generic/compute/outputs.tf
@@ -3,6 +3,16 @@ output "ecr_repository_url" {
   value       = aws_ecr_repository.worker.repository_url
 }
 
+output "image_tag" {
+  description = "Immutable image tag used by ECS tasks"
+  value       = var.image_tag
+}
+
+output "docker_image" {
+  description = "Full immutable worker image reference"
+  value       = "${aws_ecr_repository.worker.repository_url}:${var.image_tag}"
+}
+
 output "ecs_cluster_arn" {
   description = "ARN of the ECS cluster"
   value       = aws_ecs_cluster.worker.arn

--- a/deployments/aws/generic/compute/variables.tf
+++ b/deployments/aws/generic/compute/variables.tf
@@ -25,6 +25,11 @@ variable "kms_key_arn" {
   type        = string
 }
 
+variable "image_tag" {
+  description = "Immutable ECR image tag used by ECS tasks"
+  type        = string
+}
+
 variable "task_cpu" {
   description = "CPU units for the ECS task"
   type        = number

--- a/deployments/aws/generic/environments/dev/main.tf
+++ b/deployments/aws/generic/environments/dev/main.tf
@@ -150,6 +150,7 @@ module "compute" {
   name_prefix            = var.name_prefix
   environment            = local.environment
   aws_region             = var.aws_region
+  image_tag              = var.image_tag
   log_retention_days     = var.log_retention_days
   kms_key_arn            = aws_kms_key.infrastructure.arn
   task_cpu               = var.task_cpu

--- a/deployments/aws/generic/environments/dev/outputs.tf
+++ b/deployments/aws/generic/environments/dev/outputs.tf
@@ -18,6 +18,16 @@ output "ecr_repo_url" {
   value       = module.compute.ecr_repository_url
 }
 
+output "image_tag" {
+  description = "Immutable image tag used by AWS workers"
+  value       = module.compute.image_tag
+}
+
+output "docker_image" {
+  description = "Full immutable worker image reference"
+  value       = module.compute.docker_image
+}
+
 output "s3_bucket_name" {
   description = "Name of the S3 bucket for results"
   value       = module.storage.bucket_id

--- a/deployments/aws/generic/environments/dev/variables.tf
+++ b/deployments/aws/generic/environments/dev/variables.tf
@@ -15,6 +15,11 @@ variable "tool_name" {
   type        = string
 }
 
+variable "image_tag" {
+  description = "Immutable ECR image tag to deploy"
+  type        = string
+}
+
 variable "vpc_cidr" {
   description = "CIDR block for VPC"
   type        = string

--- a/internal/infra/lifecycle_test.go
+++ b/internal/infra/lifecycle_test.go
@@ -11,11 +11,15 @@ import (
 
 // fullOutputs returns a complete set of terraform outputs for testing.
 func fullOutputs(tool string) map[string]string {
+	repoURL := "123.dkr.ecr.us-east-1.amazonaws.com/" + tool
+	imageTag := testAWSImageTag(tool)
 	return map[string]string{
 		"tool_name":            tool,
 		"sqs_queue_url":        "https://sqs.example.com/q",
 		"s3_bucket_name":       "results-bucket",
-		"ecr_repo_url":         "123.dkr.ecr.us-east-1.amazonaws.com/" + tool,
+		"ecr_repo_url":         repoURL,
+		"image_tag":            imageTag,
+		"docker_image":         repoURL + ":" + imageTag,
 		"ecs_cluster_name":     "cluster",
 		"task_definition_arn":  "arn:aws:ecs:td",
 		"subnet_ids":           "[subnet-a subnet-b]",
@@ -25,12 +29,18 @@ func fullOutputs(tool string) map[string]string {
 	}
 }
 
+func testAWSImageTag(tool string) string {
+	return "heph-" + tool + "-worker-20260608T032422Z-a1b2c3d4"
+}
+
 func TestProbe_Ready(t *testing.T) {
 	outputJSON := `{
 		"tool_name":{"value":"nmap"},
 		"sqs_queue_url":{"value":"https://sqs.example.com/q"},
 		"s3_bucket_name":{"value":"bucket"},
 		"ecr_repo_url":{"value":"123.dkr.ecr.us-east-1.amazonaws.com/nmap"},
+		"image_tag":{"value":"heph-nmap-worker-20260608T032422Z-a1b2c3d4"},
+		"docker_image":{"value":"123.dkr.ecr.us-east-1.amazonaws.com/nmap:heph-nmap-worker-20260608T032422Z-a1b2c3d4"},
 		"ecs_cluster_name":{"value":"cluster"},
 		"task_definition_arn":{"value":"arn:aws:ecs:td"},
 		"subnet_ids":{"value":"[subnet-a]"},
@@ -70,6 +80,8 @@ func TestProbe_Mismatch(t *testing.T) {
 		"sqs_queue_url":{"value":"https://sqs.example.com/q"},
 		"s3_bucket_name":{"value":"bucket"},
 		"ecr_repo_url":{"value":"123.dkr.ecr.us-east-1.amazonaws.com/httpx"},
+		"image_tag":{"value":"heph-httpx-worker-20260608T032422Z-a1b2c3d4"},
+		"docker_image":{"value":"123.dkr.ecr.us-east-1.amazonaws.com/httpx:heph-httpx-worker-20260608T032422Z-a1b2c3d4"},
 		"ecs_cluster_name":{"value":"cluster"},
 		"task_definition_arn":{"value":"arn:aws:ecs:td"},
 		"subnet_ids":{"value":"[subnet-a]"},
@@ -116,6 +128,8 @@ func TestProbe_LegacyNoToolName(t *testing.T) {
 		"sqs_queue_url":{"value":"https://sqs.example.com/q"},
 		"s3_bucket_name":{"value":"bucket"},
 		"ecr_repo_url":{"value":"123.dkr.ecr.us-east-1.amazonaws.com/old"},
+		"image_tag":{"value":"heph-old-worker-20260608T032422Z-a1b2c3d4"},
+		"docker_image":{"value":"123.dkr.ecr.us-east-1.amazonaws.com/old:heph-old-worker-20260608T032422Z-a1b2c3d4"},
 		"ecs_cluster_name":{"value":"cluster"},
 		"task_definition_arn":{"value":"arn:aws:ecs:td"},
 		"subnet_ids":{"value":"[subnet-a]"},
@@ -151,6 +165,8 @@ func TestProbe_MissingSpotOutputs(t *testing.T) {
 		"sqs_queue_url":{"value":"https://sqs.example.com/q"},
 		"s3_bucket_name":{"value":"bucket"},
 		"ecr_repo_url":{"value":"123.dkr.ecr.us-east-1.amazonaws.com/nmap"},
+		"image_tag":{"value":"heph-nmap-worker-20260608T032422Z-a1b2c3d4"},
+		"docker_image":{"value":"123.dkr.ecr.us-east-1.amazonaws.com/nmap:heph-nmap-worker-20260608T032422Z-a1b2c3d4"},
 		"ecs_cluster_name":{"value":"cluster"},
 		"task_definition_arn":{"value":"arn:aws:ecs:td"},
 		"subnet_ids":{"value":"[subnet-a]"},
@@ -294,6 +310,8 @@ func TestRequiredOutputKeysForCloud_AWS(t *testing.T) {
 	want := map[string]bool{
 		"sqs_queue_url":        true,
 		"ecr_repo_url":         true,
+		"image_tag":            true,
+		"docker_image":         true,
 		"ecs_cluster_name":     true,
 		"ami_id":               true,
 		"instance_profile_arn": true,
@@ -529,6 +547,8 @@ func TestProbe_CloudMismatch_IgnoredForAWS(t *testing.T) {
 		"sqs_queue_url":{"value":"https://sqs.example.com/q"},
 		"s3_bucket_name":{"value":"bucket"},
 		"ecr_repo_url":{"value":"123.dkr.ecr.us-east-1.amazonaws.com/nmap"},
+		"image_tag":{"value":"heph-nmap-worker-20260608T032422Z-a1b2c3d4"},
+		"docker_image":{"value":"123.dkr.ecr.us-east-1.amazonaws.com/nmap:heph-nmap-worker-20260608T032422Z-a1b2c3d4"},
 		"ecs_cluster_name":{"value":"cluster"},
 		"task_definition_arn":{"value":"arn:aws:ecs:td"},
 		"subnet_ids":{"value":"[subnet-a]"},

--- a/internal/infra/publish.go
+++ b/internal/infra/publish.go
@@ -19,17 +19,18 @@ type ImagePublisher interface {
 	Authenticate(ctx context.Context) error
 
 	// Publish tags the local image and pushes it to the remote registry.
-	// Returns the remote image reference (e.g. "123.dkr.ecr.../nmap:latest"
+	// Returns the remote image reference (e.g. "123.dkr.ecr.../nmap:tag"
 	// or "10.0.1.5:5000/heph-nmap-worker:latest").
 	Publish(ctx context.Context, localTag string, stream io.Writer) (remoteRef string, err error)
 }
 
 // ECRPublisher publishes images to AWS Elastic Container Registry.
 type ECRPublisher struct {
-	ECR     *ECRClient
-	Docker  *DockerClient
-	Region  string
-	RepoURL string // ecr_repo_url from terraform outputs
+	ECR      *ECRClient
+	Docker   *DockerClient
+	Region   string
+	RepoURL  string // ecr_repo_url from terraform outputs
+	ImageTag string // image_tag from terraform outputs
 }
 
 func (p *ECRPublisher) Authenticate(ctx context.Context) error {
@@ -40,7 +41,10 @@ func (p *ECRPublisher) Publish(ctx context.Context, localTag string, stream io.W
 	if p.RepoURL == "" {
 		return "", fmt.Errorf("ecr_repo_url is required for AWS image publish")
 	}
-	remoteTag := p.RepoURL + ":latest"
+	if p.ImageTag == "" {
+		return "", fmt.Errorf("image_tag is required for AWS image publish")
+	}
+	remoteTag := p.RepoURL + ":" + p.ImageTag
 	if err := p.Docker.Tag(ctx, localTag, remoteTag); err != nil {
 		return "", err
 	}
@@ -94,10 +98,11 @@ func NewPublisher(kind cloud.Kind, docker *DockerClient, ecr *ECRClient, outputs
 		}
 	}
 	return &ECRPublisher{
-		ECR:     ecr,
-		Docker:  docker,
-		Region:  region,
-		RepoURL: outputs["ecr_repo_url"],
+		ECR:      ecr,
+		Docker:   docker,
+		Region:   region,
+		RepoURL:  outputs["ecr_repo_url"],
+		ImageTag: outputs["image_tag"],
 	}
 }
 

--- a/internal/infra/publish_test.go
+++ b/internal/infra/publish_test.go
@@ -32,15 +32,16 @@ func TestECRPublisher_Publish(t *testing.T) {
 	cap, exec := newCapturingExecutor("")
 	docker := &DockerClient{runCmd: exec, logger: nopLogger{}}
 	pub := &ECRPublisher{
-		Docker:  docker,
-		RepoURL: "123.dkr.ecr.us-east-1.amazonaws.com/nmap",
+		Docker:   docker,
+		RepoURL:  "123.dkr.ecr.us-east-1.amazonaws.com/nmap",
+		ImageTag: "heph-nmap-worker-20260608T032422Z-a1b2c3d4",
 	}
 
 	ref, err := pub.Publish(context.Background(), "heph-nmap-worker:latest", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	expected := "123.dkr.ecr.us-east-1.amazonaws.com/nmap:latest"
+	expected := "123.dkr.ecr.us-east-1.amazonaws.com/nmap:heph-nmap-worker-20260608T032422Z-a1b2c3d4"
 	if ref != expected {
 		t.Fatalf("expected ref %q, got %q", expected, ref)
 	}
@@ -54,11 +55,23 @@ func TestECRPublisher_Publish(t *testing.T) {
 
 func TestECRPublisher_Publish_MissingRepoURL(t *testing.T) {
 	pub := &ECRPublisher{
-		Docker: &DockerClient{runCmd: newMockExecutor("", "", 0, nil), logger: nopLogger{}},
+		Docker:   &DockerClient{runCmd: newMockExecutor("", "", 0, nil), logger: nopLogger{}},
+		ImageTag: "heph-nmap-worker-20260608T032422Z-a1b2c3d4",
 	}
 	_, err := pub.Publish(context.Background(), "img:latest", nil)
 	if err == nil {
 		t.Fatal("expected error for missing ecr_repo_url")
+	}
+}
+
+func TestECRPublisher_Publish_MissingImageTag(t *testing.T) {
+	pub := &ECRPublisher{
+		Docker:  &DockerClient{runCmd: newMockExecutor("", "", 0, nil), logger: nopLogger{}},
+		RepoURL: "123.dkr.ecr.us-east-1.amazonaws.com/nmap",
+	}
+	_, err := pub.Publish(context.Background(), "img:latest", nil)
+	if err == nil {
+		t.Fatal("expected error for missing image_tag")
 	}
 }
 
@@ -155,13 +168,20 @@ func TestRegistryPublisher_Publish_MissingRegistryURL(t *testing.T) {
 }
 
 func TestNewPublisher_AWS(t *testing.T) {
-	outputs := map[string]string{"ecr_repo_url": "123.dkr.ecr.us-east-1.amazonaws.com/nmap"}
+	outputs := map[string]string{
+		"ecr_repo_url": "123.dkr.ecr.us-east-1.amazonaws.com/nmap",
+		"image_tag":    "heph-nmap-worker-20260608T032422Z-a1b2c3d4",
+	}
 	docker := &DockerClient{runCmd: newMockExecutor("", "", 0, nil), logger: nopLogger{}}
 	ecr := &ECRClient{runCmd: newMockExecutor("", "", 0, nil), logger: nopLogger{}}
 
 	pub := NewPublisher(cloud.KindAWS, docker, ecr, outputs, "us-east-1")
-	if _, ok := pub.(*ECRPublisher); !ok {
+	ecrPub, ok := pub.(*ECRPublisher)
+	if !ok {
 		t.Fatalf("expected *ECRPublisher, got %T", pub)
+	}
+	if ecrPub.ImageTag != outputs["image_tag"] {
+		t.Fatalf("ImageTag = %q, want %q", ecrPub.ImageTag, outputs["image_tag"])
 	}
 }
 
@@ -188,13 +208,20 @@ func TestNewPublisher_Selfhosted(t *testing.T) {
 }
 
 func TestNewPublisher_EmptyKindDefaultsToAWS(t *testing.T) {
-	outputs := map[string]string{"ecr_repo_url": "123.dkr.ecr.us-east-1.amazonaws.com/nmap"}
+	outputs := map[string]string{
+		"ecr_repo_url": "123.dkr.ecr.us-east-1.amazonaws.com/nmap",
+		"image_tag":    "heph-nmap-worker-20260608T032422Z-a1b2c3d4",
+	}
 	docker := &DockerClient{runCmd: newMockExecutor("", "", 0, nil), logger: nopLogger{}}
 	ecr := &ECRClient{runCmd: newMockExecutor("", "", 0, nil), logger: nopLogger{}}
 
 	pub := NewPublisher("", docker, ecr, outputs, "us-east-1")
-	if _, ok := pub.(*ECRPublisher); !ok {
+	ecrPub, ok := pub.(*ECRPublisher)
+	if !ok {
 		t.Fatalf("empty kind should default to ECRPublisher, got %T", pub)
+	}
+	if ecrPub.ImageTag != outputs["image_tag"] {
+		t.Fatalf("ImageTag = %q, want %q", ecrPub.ImageTag, outputs["image_tag"])
 	}
 }
 

--- a/internal/infra/runtime.go
+++ b/internal/infra/runtime.go
@@ -12,6 +12,8 @@ var AWSRequiredOutputKeys = []string{
 	"sqs_queue_url",
 	"s3_bucket_name",
 	"ecr_repo_url",
+	"image_tag",
+	"docker_image",
 	"ecs_cluster_name",
 	"task_definition_arn",
 	"subnet_ids",

--- a/internal/infra/toolconfig.go
+++ b/internal/infra/toolconfig.go
@@ -1,10 +1,13 @@
 package infra
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"heph4estus/internal/cloud"
 	"heph4estus/internal/modules"
@@ -68,15 +71,34 @@ func ResolveToolConfig(tool string, kind ...cloud.Kind) (*ToolConfig, error) {
 		cfg.TerraformDir = "deployments/vultr"
 		cfg.TerraformVars = providerNativeTerraformVars(cloudKind, tool, cfg.DockerTag)
 	default:
+		imageTag, err := NewAWSImageTag(tool)
+		if err != nil {
+			return nil, err
+		}
 		cfg.TerraformDir = "deployments/aws/generic/environments/dev"
 		cfg.TerraformVars = map[string]string{
 			"tool_name":   tool,
+			"image_tag":   imageTag,
 			"task_cpu":    fmt.Sprintf("%d", mod.DefaultCPU),
 			"task_memory": fmt.Sprintf("%d", mod.DefaultMemory),
 		}
 	}
 
 	return cfg, nil
+}
+
+// NewAWSImageTag returns a unique ECR tag for a single AWS deploy. It does
+// not include a repository name, so it is safe to pass directly to Terraform.
+func NewAWSImageTag(tool string) (string, error) {
+	var suffix [4]byte
+	if _, err := rand.Read(suffix[:]); err != nil {
+		return "", fmt.Errorf("generating AWS image tag suffix: %w", err)
+	}
+	return formatAWSImageTag(tool, time.Now().UTC(), hex.EncodeToString(suffix[:])), nil
+}
+
+func formatAWSImageTag(tool string, ts time.Time, suffix string) string {
+	return fmt.Sprintf("heph-%s-worker-%s-%s", tool, ts.UTC().Format("20060102T150405Z"), suffix)
 }
 
 func providerNativeTerraformVars(kind cloud.Kind, tool, dockerTag string) map[string]string {

--- a/internal/infra/toolconfig_test.go
+++ b/internal/infra/toolconfig_test.go
@@ -2,8 +2,10 @@ package infra
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"heph4estus/internal/cloud"
 	naabutool "heph4estus/internal/tools/naabu"
@@ -25,6 +27,27 @@ func TestResolveToolConfig_Nmap(t *testing.T) {
 	}
 	if cfg.TerraformVars["tool_name"] != "nmap" {
 		t.Errorf("TerraformVars[tool_name] = %q", cfg.TerraformVars["tool_name"])
+	}
+	assertAWSImageTag(t, "nmap", cfg.TerraformVars["image_tag"])
+	if cfg.DockerTag != "heph-nmap-worker:latest" {
+		t.Errorf("DockerTag = %q, want heph-nmap-worker:latest", cfg.DockerTag)
+	}
+}
+
+func TestFormatAWSImageTag(t *testing.T) {
+	ts := time.Date(2026, 6, 8, 3, 24, 22, 0, time.FixedZone("PDT", -7*60*60))
+	got := formatAWSImageTag("nmap", ts, "a1b2c3d4")
+	want := "heph-nmap-worker-20260608T102422Z-a1b2c3d4"
+	if got != want {
+		t.Fatalf("formatAWSImageTag() = %q, want %q", got, want)
+	}
+}
+
+func assertAWSImageTag(t *testing.T, tool, tag string) {
+	t.Helper()
+	pattern := fmt.Sprintf(`^heph-%s-worker-\d{8}T\d{6}Z-[0-9a-f]{8}$`, regexp.QuoteMeta(tool))
+	if !regexp.MustCompile(pattern).MatchString(tag) {
+		t.Fatalf("image_tag = %q, want pattern %s", tag, pattern)
 	}
 }
 

--- a/internal/tui/core/types.go
+++ b/internal/tui/core/types.go
@@ -114,6 +114,7 @@ type InfraOutputs struct {
 
 	SQSQueueURL       string
 	ECRRepoURL        string
+	ImageTag          string
 	S3BucketName      string
 	S3Endpoint        string
 	S3Region          string

--- a/internal/tui/views/deploy/model.go
+++ b/internal/tui/views/deploy/model.go
@@ -434,6 +434,7 @@ func (m *Model) emitNavigateToStatus() tea.Cmd {
 				FleetWorkerCount:      parseInt(outputs["worker_count"]),
 				SQSQueueURL:           outputs["sqs_queue_url"],
 				ECRRepoURL:            outputs["ecr_repo_url"],
+				ImageTag:              outputs["image_tag"],
 				S3BucketName:          outputs["s3_bucket_name"],
 				S3Endpoint:            outputs["s3_endpoint"],
 				S3Region:              outputs["s3_region"],

--- a/internal/tui/views/deploy/model_test.go
+++ b/internal/tui/views/deploy/model_test.go
@@ -94,6 +94,8 @@ func TestDeployModel_LifecycleReuse(t *testing.T) {
 	outputs := map[string]string{
 		"sqs_queue_url":       "https://sqs.example.com/q",
 		"ecr_repo_url":        "123.dkr.ecr.us-east-1.amazonaws.com/nmap",
+		"image_tag":           "heph-nmap-worker-20260608T032422Z-a1b2c3d4",
+		"docker_image":        "123.dkr.ecr.us-east-1.amazonaws.com/nmap:heph-nmap-worker-20260608T032422Z-a1b2c3d4",
 		"s3_bucket_name":      "results-bucket",
 		"ecs_cluster_name":    "nmap-cluster",
 		"task_definition_arn": "arn:aws:ecs:td",
@@ -126,6 +128,13 @@ func TestDeployModel_LifecycleReuse(t *testing.T) {
 		}
 		if nav.Target != core.ViewNmapStatus {
 			t.Fatalf("expected ViewNmapStatus, got %v", nav.Target)
+		}
+		infraOut, ok := nav.Data.(core.InfraOutputs)
+		if !ok {
+			t.Fatalf("expected InfraOutputs, got %T", nav.Data)
+		}
+		if infraOut.ImageTag != outputs["image_tag"] {
+			t.Fatalf("ImageTag = %q, want %q", infraOut.ImageTag, outputs["image_tag"])
 		}
 	}
 }
@@ -173,6 +182,8 @@ func TestDeployModel_FullPipeline(t *testing.T) {
 		readOutputs: map[string]string{
 			"sqs_queue_url":       "https://sqs.example.com/q",
 			"ecr_repo_url":        "123.dkr.ecr.us-east-1.amazonaws.com/nmap",
+			"image_tag":           "heph-nmap-worker-20260608T032422Z-a1b2c3d4",
+			"docker_image":        "123.dkr.ecr.us-east-1.amazonaws.com/nmap:heph-nmap-worker-20260608T032422Z-a1b2c3d4",
 			"s3_bucket_name":      "results-bucket",
 			"ecs_cluster_name":    "nmap-cluster",
 			"task_definition_arn": "arn:aws:ecs:td",
@@ -321,6 +332,8 @@ func TestDeployModel_GenericPostDeployNavigation(t *testing.T) {
 		readOutputs: map[string]string{
 			"sqs_queue_url":       "https://sqs.example.com/q",
 			"ecr_repo_url":        "123.dkr.ecr.us-east-1.amazonaws.com/httpx",
+			"image_tag":           "heph-httpx-worker-20260608T032422Z-a1b2c3d4",
+			"docker_image":        "123.dkr.ecr.us-east-1.amazonaws.com/httpx:heph-httpx-worker-20260608T032422Z-a1b2c3d4",
 			"s3_bucket_name":      "results-bucket",
 			"ecs_cluster_name":    "cluster",
 			"task_definition_arn": "arn:aws:ecs:td",
@@ -541,6 +554,8 @@ func TestDeployModel_ReuseCarriesCleanupFields(t *testing.T) {
 	outputs := map[string]string{
 		"sqs_queue_url":       "https://sqs.example.com/q",
 		"ecr_repo_url":        "123.dkr.ecr.us-east-1.amazonaws.com/nmap",
+		"image_tag":           "heph-nmap-worker-20260608T032422Z-a1b2c3d4",
+		"docker_image":        "123.dkr.ecr.us-east-1.amazonaws.com/nmap:heph-nmap-worker-20260608T032422Z-a1b2c3d4",
 		"s3_bucket_name":      "bucket",
 		"ecs_cluster_name":    "cluster",
 		"task_definition_arn": "arn:aws:ecs:td",
@@ -585,6 +600,8 @@ func TestDeployModel_FreshDeployCarriesCleanupFields(t *testing.T) {
 		readOutputs: map[string]string{
 			"sqs_queue_url":       "https://sqs/q",
 			"ecr_repo_url":        "123.dkr.ecr.us-east-1.amazonaws.com/nmap",
+			"image_tag":           "heph-nmap-worker-20260608T032422Z-a1b2c3d4",
+			"docker_image":        "123.dkr.ecr.us-east-1.amazonaws.com/nmap:heph-nmap-worker-20260608T032422Z-a1b2c3d4",
 			"s3_bucket_name":      "bucket",
 			"ecs_cluster_name":    "cluster",
 			"task_definition_arn": "arn:td",
@@ -667,6 +684,8 @@ func TestDeployModel_ReuseCarriesCloudKind(t *testing.T) {
 	outputs := map[string]string{
 		"sqs_queue_url":       "https://sqs.example.com/q",
 		"ecr_repo_url":        "123.dkr.ecr.us-east-1.amazonaws.com/nmap",
+		"image_tag":           "heph-nmap-worker-20260608T032422Z-a1b2c3d4",
+		"docker_image":        "123.dkr.ecr.us-east-1.amazonaws.com/nmap:heph-nmap-worker-20260608T032422Z-a1b2c3d4",
 		"s3_bucket_name":      "bucket",
 		"ecs_cluster_name":    "cluster",
 		"task_definition_arn": "arn:aws:ecs:td",

--- a/internal/tui/views/generic/status.go
+++ b/internal/tui/views/generic/status.go
@@ -808,9 +808,16 @@ func (m *StatusModel) launchSpotWorkers() tea.Cmd {
 	infra := m.infra
 	sub := m.submitter
 	return func() tea.Msg {
+		imageTag := strings.TrimSpace(infra.ImageTag)
+		if imageTag == "" {
+			return spotLaunchMsg{launchProgressMsg: launchProgressMsg{
+				total: infra.WorkerCount,
+				err:   fmt.Errorf("terraform outputs missing image_tag"),
+			}}
+		}
 		userData := awscloud.GenerateUserData(awscloud.UserDataOpts{
 			ECRRepoURL: infra.ECRRepoURL,
-			ImageTag:   "latest",
+			ImageTag:   imageTag,
 			Region:     regionFromECR(infra.ECRRepoURL),
 			EnvVars: map[string]string{
 				"QUEUE_URL":          infra.SQSQueueURL,

--- a/internal/tui/views/generic/status_test.go
+++ b/internal/tui/views/generic/status_test.go
@@ -76,6 +76,8 @@ func (t *mockTracker) CountResults(_ context.Context, _, _ string) (int, error) 
 func testInfra() core.InfraOutputs {
 	return core.InfraOutputs{
 		SQSQueueURL:    "https://sqs.example.com/q",
+		ECRRepoURL:     "123.dkr.ecr.us-east-1.amazonaws.com/httpx-worker",
+		ImageTag:       "heph-httpx-worker-20260608T032422Z-a1b2c3d4",
 		S3BucketName:   "test-bucket",
 		ECSClusterName: "test-cluster",
 		ToolName:       "httpx",

--- a/internal/tui/views/nmap/status.go
+++ b/internal/tui/views/nmap/status.go
@@ -592,9 +592,16 @@ func (m *StatusModel) launchSpotWorkers() tea.Cmd {
 	infra := m.infra
 	sub := m.submitter
 	return func() tea.Msg {
+		imageTag := strings.TrimSpace(infra.ImageTag)
+		if imageTag == "" {
+			return spotLaunchMsg{launchProgressMsg: launchProgressMsg{
+				total: infra.WorkerCount,
+				err:   fmt.Errorf("terraform outputs missing image_tag"),
+			}}
+		}
 		userData := awscloud.GenerateUserData(awscloud.UserDataOpts{
 			ECRRepoURL: infra.ECRRepoURL,
-			ImageTag:   "latest",
+			ImageTag:   imageTag,
 			Region:     regionFromECR(infra.ECRRepoURL),
 			EnvVars: map[string]string{
 				"QUEUE_URL":          infra.SQSQueueURL,

--- a/internal/tui/views/nmap/status_test.go
+++ b/internal/tui/views/nmap/status_test.go
@@ -49,6 +49,8 @@ func (t *mockTracker) CountResults(_ context.Context, _, _ string) (int, error) 
 func testInfra() core.InfraOutputs {
 	return core.InfraOutputs{
 		SQSQueueURL:       "https://sqs/q",
+		ECRRepoURL:        "123.dkr.ecr.us-east-1.amazonaws.com/nmap-worker",
+		ImageTag:          "heph-nmap-worker-20260608T032422Z-a1b2c3d4",
 		S3BucketName:      "bucket",
 		ECSClusterName:    "cluster",
 		TaskDefinitionARN: "arn:td",
@@ -455,7 +457,6 @@ func TestUseSpot_EmptyDefaultsToAuto(t *testing.T) {
 func TestStatusModel_SpotLaunch(t *testing.T) {
 	infra := testInfra()
 	infra.ComputeMode = "spot"
-	infra.ECRRepoURL = "123.dkr.ecr.us-east-1.amazonaws.com/nmap-worker"
 	infra.AMIID = "ami-test"
 	infra.InstanceProfileARN = "arn:profile"
 


### PR DESCRIPTION
## Summary
- generate per-deploy immutable AWS ECR image tags and pass them through Terraform
- set AWS ECR repos to IMMUTABLE and expose image_tag/docker_image outputs
- publish AWS images to ecr_repo_url:image_tag and use the same tag for CLI/TUI spot userdata
- update docs and tests for the new AWS output contract

## Validation
- go test ./...
- terraform fmt -check -recursive deployments/aws
- make tf-validate (passes with existing AWS provider deprecation warnings in spot module)
- PATH=/tmp/heph-tools/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make tf-lint
- TRIVY_CACHE_DIR=/tmp/heph-tools/trivy-cache PATH=/tmp/heph-tools/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make tf-security (ECR immutability finding gone; expected PR 11.4 networking/IAM findings remain)