### PR TITLE
PR 11.4: AWS networking and IAM audit hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,11 @@ make tf-security
 
 Use Trivy (`make tf-security`) for Terraform security scanning. `tfsec` is legacy and should not be used for new checks. Phase 11 separates Terraform lint cleanup from AWS security hardening, so Trivy findings are handled in dedicated follow-up PRs.
 
-The AWS generic dev environment uses a customer-managed KMS key for CloudWatch log groups, ECR repositories, SQS queues, and the S3 result bucket. The result bucket also writes S3 server access logs to a dedicated log bucket that uses SSE-S3, which is required for S3 log delivery destinations. AWS worker images are published with generated immutable ECR tags and ECS task definitions reference the full immutable image.
+The AWS generic dev environment uses a customer-managed KMS key for CloudWatch log groups, VPC Flow Logs, ECR repositories, SQS queues, and the S3 result bucket. The result bucket also writes S3 server access logs to a dedicated log bucket that uses SSE-S3, which is required for S3 log delivery destinations. AWS worker images are published with generated immutable ECR tags and ECS task definitions reference the full immutable image.
 
-After the encryption, logging, and immutable image-publishing baseline, expected remaining Trivy findings are tracked separately as networking/IAM audit findings for PR 11.4.
+Scanner worker egress defaults to arbitrary IPv4 targets because scan targets are user-supplied and may be anywhere on the public internet. Constrained environments can set `scanner_egress_ipv4_cidr_blocks` and `scanner_egress_ipv6_cidr_blocks` Terraform variables to narrower CIDR lists. The unrestricted default is explicitly documented in Terraform as an intentional scanner exception.
+
+After the encryption, logging, immutable image-publishing, networking, and IAM baseline, `make tf-security` should have no unreviewed AWS findings.
 
 ### 5. VPS Scan Execution
 

--- a/deployments/aws/generic/environments/dev/main.tf
+++ b/deployments/aws/generic/environments/dev/main.tf
@@ -110,6 +110,11 @@ module "networking" {
   environment = local.environment
   enable_ipv6 = var.enable_ipv6
   multi_nat   = var.multi_nat
+  kms_key_arn = aws_kms_key.infrastructure.arn
+
+  log_retention_days              = var.log_retention_days
+  scanner_egress_ipv4_cidr_blocks = var.scanner_egress_ipv4_cidr_blocks
+  scanner_egress_ipv6_cidr_blocks = var.scanner_egress_ipv6_cidr_blocks
 }
 
 # Create storage for results

--- a/deployments/aws/generic/environments/dev/variables.tf
+++ b/deployments/aws/generic/environments/dev/variables.tf
@@ -44,6 +44,18 @@ variable "multi_nat" {
   default     = false
 }
 
+variable "scanner_egress_ipv4_cidr_blocks" {
+  description = "IPv4 CIDR blocks scanner workers may egress to"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "scanner_egress_ipv6_cidr_blocks" {
+  description = "IPv6 CIDR blocks scanner workers may egress to when IPv6 is enabled"
+  type        = list(string)
+  default     = ["::/0"]
+}
+
 variable "log_retention_days" {
   description = "Number of days to retain logs"
   type        = number

--- a/deployments/aws/shared/networking/main.tf
+++ b/deployments/aws/shared/networking/main.tf
@@ -54,7 +54,7 @@ resource "aws_subnet" "public" {
   cidr_block                      = cidrsubnet(var.vpc_cidr, 8, count.index + var.az_count)
   ipv6_cidr_block                 = var.enable_ipv6 ? cidrsubnet(aws_vpc.this.ipv6_cidr_block, 8, count.index + var.az_count) : null
   availability_zone               = data.aws_availability_zones.available.names[count.index]
-  map_public_ip_on_launch         = true
+  map_public_ip_on_launch         = false
   assign_ipv6_address_on_creation = var.enable_ipv6
 
   tags = {
@@ -195,28 +195,114 @@ resource "aws_route_table_association" "private" {
   route_table_id = aws_route_table.private[var.multi_nat ? count.index : 0].id
 }
 
+resource "aws_cloudwatch_log_group" "vpc_flow_logs" {
+  name              = "/aws/vpc-flow-logs/${var.name_prefix}"
+  retention_in_days = var.log_retention_days
+  kms_key_id        = var.kms_key_arn
+
+  tags = {
+    Name        = "${var.name_prefix}-vpc-flow-logs"
+    Environment = var.environment
+    Terraform   = "true"
+  }
+}
+
+resource "aws_iam_role" "vpc_flow_logs" {
+  name = "${var.name_prefix}-vpc-flow-logs-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "vpc-flow-logs.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "${var.name_prefix}-vpc-flow-logs-role"
+    Environment = var.environment
+    Terraform   = "true"
+  }
+}
+
+resource "aws_iam_policy" "vpc_flow_logs" {
+  name        = "${var.name_prefix}-vpc-flow-logs-policy"
+  description = "Allow VPC Flow Logs to write to CloudWatch Logs"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams"
+        ]
+        Resource = "${aws_cloudwatch_log_group.vpc_flow_logs.arn}:*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:DescribeLogGroups"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "vpc_flow_logs" {
+  role       = aws_iam_role.vpc_flow_logs.name
+  policy_arn = aws_iam_policy.vpc_flow_logs.arn
+}
+
+resource "aws_flow_log" "vpc" {
+  iam_role_arn    = aws_iam_role.vpc_flow_logs.arn
+  log_destination = aws_cloudwatch_log_group.vpc_flow_logs.arn
+  traffic_type    = "ALL"
+  vpc_id          = aws_vpc.this.id
+
+  tags = {
+    Name        = "${var.name_prefix}-vpc-flow-log"
+    Environment = var.environment
+    Terraform   = "true"
+  }
+
+  depends_on = [aws_iam_role_policy_attachment.vpc_flow_logs]
+}
+
 # Security group for ECS tasks
+# Scanner workers need arbitrary target reachability by default. Operators can
+# narrow scanner_egress_ipv4_cidr_blocks for constrained environments.
+#trivy:ignore:AVD-AWS-0104
 resource "aws_security_group" "ecs_tasks" {
   name        = "${var.name_prefix}-ecs-tasks-sg"
   description = "Security group for Nmap scanner ECS tasks"
   vpc_id      = aws_vpc.this.id
 
-  # Allow outbound internet access for Nmap scanning
   egress {
+    description = "Allow scanner egress to configured IPv4 targets"
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.scanner_egress_ipv4_cidr_blocks
   }
 
   dynamic "egress" {
     for_each = var.enable_ipv6 ? [1] : []
 
     content {
+      description      = "Allow scanner egress to configured IPv6 targets"
       from_port        = 0
       to_port          = 0
       protocol         = "-1"
-      ipv6_cidr_blocks = ["::/0"]
+      ipv6_cidr_blocks = var.scanner_egress_ipv6_cidr_blocks
     }
   }
 

--- a/deployments/aws/shared/networking/variables.tf
+++ b/deployments/aws/shared/networking/variables.tf
@@ -33,3 +33,26 @@ variable "multi_nat" {
   type        = bool
   default     = false
 }
+
+variable "kms_key_arn" {
+  description = "ARN of the customer-managed KMS key used by encrypted AWS networking logs"
+  type        = string
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain VPC Flow Logs"
+  type        = number
+  default     = 30
+}
+
+variable "scanner_egress_ipv4_cidr_blocks" {
+  description = "IPv4 CIDR blocks scanner workers may egress to"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "scanner_egress_ipv6_cidr_blocks" {
+  description = "IPv6 CIDR blocks scanner workers may egress to when IPv6 is enabled"
+  type        = list(string)
+  default     = ["::/0"]
+}

--- a/deployments/aws/shared/security/main.tf
+++ b/deployments/aws/shared/security/main.tf
@@ -76,7 +76,9 @@ resource "aws_iam_policy" "step_functions_logs" {
   })
 }
 
-# Custom policy for Step Functions to interact with other services
+# Step Functions needs PassRole to run ECS tasks. The PassRole statement below
+# is scoped to this module's ECS roles and ecs-tasks.amazonaws.com.
+#trivy:ignore:AVD-AWS-0342
 resource "aws_iam_policy" "step_functions_services" {
   name        = "${var.name_prefix}-step-functions-services-policy"
   description = "Policy for Step Functions to interact with other AWS services"
@@ -91,12 +93,26 @@ resource "aws_iam_policy" "step_functions_services" {
           "ecs:RunTask",
           "ecs:StopTask",
           "ecs:DescribeTasks",
-          "iam:PassRole",
           "events:PutTargets",
           "events:PutRule",
           "events:DescribeRule"
         ]
         Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "iam:PassRole"
+        ]
+        Resource = [
+          aws_iam_role.ecs_execution.arn,
+          aws_iam_role.ecs_task.arn
+        ]
+        Condition = {
+          StringEquals = {
+            "iam:PassedToService" = "ecs-tasks.amazonaws.com"
+          }
+        }
       },
       {
         Effect   = "Allow"


### PR DESCRIPTION
## Summary
- disable automatic public IP assignment on AWS public subnets while preserving explicit NAT EIPs
- add encrypted CloudWatch VPC Flow Logs for the shared AWS VPC
- make scanner worker egress CIDRs configurable and document the intentional unrestricted default
- scope Step Functions iam:PassRole to the ECS task/execution roles with iam:PassedToService
- document the completed networking/IAM audit baseline

## Validation
- GOCACHE=/tmp/heph-go-build go test ./...
- terraform fmt -check -recursive deployments/aws
- git diff --check
- make tf-validate (passes with existing spot-module AWS provider deprecation warnings)
- PATH=/tmp/heph-tools/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make tf-lint
- TRIVY_CACHE_DIR=/tmp/heph-tools/trivy-cache PATH=/tmp/heph-tools/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin make tf-security (0 AWS misconfigurations; reviewed inline ignores only)