### PR TITLE
PR 12.1: Formatting and tooling baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,15 @@ jobs:
           go-version: "1.26"
       - run: make build
 
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+      - run: make fmt-check
+
   container-images:
     runs-on: ubuntu-latest
     steps:
@@ -40,7 +49,7 @@ jobs:
           go-version: "1.26"
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.10
+          version: v2.12.2
 
   tf-validate:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,11 @@ TOOL_IMAGE_PREFIX ?= heph
 TOOL_IMAGE_SUFFIX ?= worker
 TOOL_IMAGE_TAG ?= latest
 TFLINT_CONFIG ?= $(CURDIR)/.tflint.hcl
+GOLANGCI_LINT_VERSION ?= v2.12.2
+GOLANGCI_LINT_TOOLCHAIN ?= go1.26.0
 
 TOOL_IMAGES := nmap nuclei subfinder httpx masscan naabu naabu-nmap
+GO_FILES := $(shell git ls-files '*.go')
 
 NMAP_INSTALL_CMD := apk add --no-cache nmap nmap-scripts
 NUCLEI_INSTALL_CMD := go install github.com/projectdiscovery/nuclei/v3/cmd/nuclei@v3.7.1
@@ -24,7 +27,7 @@ NAABU_SMOKE_ARGS := -version
 
 tool_image = $(TOOL_IMAGE_PREFIX)-$(1)-$(TOOL_IMAGE_SUFFIX):$(TOOL_IMAGE_TAG)
 
-.PHONY: all build test lint docker-build docker-build-all docker-build-nmap docker-build-nmap-generic docker-build-nuclei docker-build-subfinder docker-build-httpx docker-build-masscan docker-build-naabu docker-build-naabu-nmap docker-smoke-all docker-smoke-nmap docker-smoke-nuclei docker-smoke-subfinder docker-smoke-httpx docker-smoke-masscan docker-smoke-naabu docker-smoke-naabu-nmap container-smoke tf-fmt tf-lint tf-security tf-validate clean
+.PHONY: all build test fmt fmt-check vet lint install-lint docker-build docker-build-all docker-build-nmap docker-build-nmap-generic docker-build-nuclei docker-build-subfinder docker-build-httpx docker-build-masscan docker-build-naabu docker-build-naabu-nmap docker-smoke-all docker-smoke-nmap docker-smoke-nuclei docker-smoke-subfinder docker-smoke-httpx docker-smoke-masscan docker-smoke-naabu docker-smoke-naabu-nmap container-smoke tf-fmt tf-lint tf-security tf-validate clean
 
 all: build test lint
 
@@ -37,8 +40,25 @@ build:
 test:
 	go test ./...
 
+fmt:
+	gofmt -w $(GO_FILES)
+
+fmt-check:
+	@files="$$(gofmt -l $(GO_FILES))"; \
+	if [ -n "$$files" ]; then \
+		echo "gofmt needed for:"; \
+		echo "$$files"; \
+		exit 1; \
+	fi
+
+vet:
+	go vet ./...
+
 lint:
 	golangci-lint run ./...
+
+install-lint:
+	GOTOOLCHAIN=$(GOLANGCI_LINT_TOOLCHAIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 docker-build:
 ifndef TOOL

--- a/README.md
+++ b/README.md
@@ -360,6 +360,22 @@ Future nmap results will land under the generic job-scoped prefixes (`scans/nmap
 
 ## Development
 
+Before opening a PR, run the fast local checks:
+
+```bash
+make fmt-check
+make vet
+make test
+make lint
+```
+
+If `make lint` fails because the installed `golangci-lint` binary was built with an older Go version than the module targets, install the repo-pinned linter and rerun it:
+
+```bash
+make install-lint
+make lint
+```
+
 For manual infrastructure management during development:
 
 ```bash

--- a/internal/cloud/aws/sqs.go
+++ b/internal/cloud/aws/sqs.go
@@ -83,7 +83,7 @@ func (c *SQSClient) Receive(ctx context.Context, queueID string) (*cloud.Message
 		QueueUrl:            &queueID,
 		MaxNumberOfMessages: 1,
 		WaitTimeSeconds:     20,
-		AttributeNames: []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameAll},
+		AttributeNames:      []sqstypes.QueueAttributeName{sqstypes.QueueAttributeNameAll},
 	})
 	if err != nil {
 		return nil, err

--- a/internal/infra/lifecycle.go
+++ b/internal/infra/lifecycle.go
@@ -152,12 +152,12 @@ func (d Decision) String() string {
 type Reason int
 
 const (
-	ReasonInfraReady        Reason = iota // matching infra exists
-	ReasonInfraMissing                    // no infra deployed
-	ReasonInfraStale                      // outputs incomplete
-	ReasonToolMismatch                    // different tool deployed
-	ReasonProbeError                      // terraform failed
-	ReasonBlockedByPolicy                 // --no-deploy prevents action
+	ReasonInfraReady      Reason = iota // matching infra exists
+	ReasonInfraMissing                  // no infra deployed
+	ReasonInfraStale                    // outputs incomplete
+	ReasonToolMismatch                  // different tool deployed
+	ReasonProbeError                    // terraform failed
+	ReasonBlockedByPolicy               // --no-deploy prevents action
 )
 
 func (r Reason) String() string {

--- a/internal/operator/export.go
+++ b/internal/operator/export.go
@@ -13,9 +13,9 @@ import (
 
 // ExportResult summarises what was written to the local output directory.
 type ExportResult struct {
-	Dir            string // root output dir: <out>/<tool>/<job_id>
-	ResultCount    int
-	ArtifactCount  int
+	Dir           string // root output dir: <out>/<tool>/<job_id>
+	ResultCount   int
+	ArtifactCount int
 }
 
 // ExportJob downloads results and artifacts from S3 to a predictable local

--- a/internal/operator/export_test.go
+++ b/internal/operator/export_test.go
@@ -36,8 +36,8 @@ func (s *stubStorage) Download(_ context.Context, _, key string) ([]byte, error)
 
 func TestExportJobWritesResultsAndArtifacts(t *testing.T) {
 	store := &stubStorage{objects: map[string][]byte{
-		"scans/httpx/job-1/results/example.com_123.json": []byte(`{"target":"example.com"}`),
-		"scans/httpx/job-1/results/test.com_456.json":    []byte(`{"target":"test.com"}`),
+		"scans/httpx/job-1/results/example.com_123.json":  []byte(`{"target":"example.com"}`),
+		"scans/httpx/job-1/results/test.com_456.json":     []byte(`{"target":"test.com"}`),
 		"scans/httpx/job-1/artifacts/example.com_123.xml": []byte("<xml/>"),
 	}}
 

--- a/internal/tools/nmap/portparse_test.go
+++ b/internal/tools/nmap/portparse_test.go
@@ -282,11 +282,11 @@ func TestFormatPortSpec(t *testing.T) {
 
 func TestExtractPortFlag(t *testing.T) {
 	tests := []struct {
-		name              string
-		options           string
-		wantPortSpec      string
-		wantRemaining     string
-		wantFound         bool
+		name          string
+		options       string
+		wantPortSpec  string
+		wantRemaining string
+		wantFound     bool
 	}{
 		{
 			name:          "separate -p flag",
@@ -379,10 +379,10 @@ func TestParseFormatRoundTrip(t *testing.T) {
 		{"22,80,443", "22,80,443"},
 		{"1-5", "1-5"},
 		{"22,80,100-103,443", "22,80,100-103,443"},
-		{"443,22,80", "22,80,443"},                   // sorted
-		{"80,80,443,80", "80,443"},                    // deduplicated
-		{"1-5,3-8", "1-8"},                            // overlapping ranges collapsed
-		{"5,4,3,2,1", "1-5"},                          // reversed individual ports → range
+		{"443,22,80", "22,80,443"}, // sorted
+		{"80,80,443,80", "80,443"}, // deduplicated
+		{"1-5,3-8", "1-8"},         // overlapping ranges collapsed
+		{"5,4,3,2,1", "1-5"},       // reversed individual ports → range
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Normalizes tracked Go formatting so the repo starts Phase 12 from a clean gofmt baseline.
- Adds Makefile targets for Go formatting checks, vetting, and installing the pinned golangci-lint version.
- Adds a CI fmt job and aligns golangci-lint with a Go 1.26-compatible release.
- Documents the local development check workflow in the README.

## Commits
- style(go): normalize tracked go formatting
- chore(tooling): add go formatting and vet targets
- docs(dev): document formatting and lint workflow

## Validation
- make fmt-check
- env GOCACHE=/tmp/heph-go-build make vet
- env GOCACHE=/tmp/heph-go-build make test
- env XDG_CACHE_HOME=/tmp/heph-cache GOCACHE=/tmp/heph-go-build make lint
- git diff --check

## Notes
- This PR intentionally avoids behavior changes and package restructuring.
- Existing untracked local roadmap/docs artifacts were left out of the branch.