### PR TITLE
PR 12.2: Typed infrastructure outputs

### DIFF
--- a/cmd/heph/provider_runtime.go
+++ b/cmd/heph/provider_runtime.go
@@ -3,12 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"heph4estus/internal/cloud"
 	"heph4estus/internal/cloud/factory"
 	"heph4estus/internal/fleet"
+	"heph4estus/internal/infra"
 	"heph4estus/internal/logger"
 )
 
@@ -16,9 +16,10 @@ var waitForProviderNativeFleetFunc = waitForProviderNativeFleet
 
 func buildRuntimeProvider(ctx context.Context, kind cloud.Kind, outputs map[string]string, log logger.Logger) (cloud.Provider, error) {
 	if kind.IsProviderNative() && outputs != nil {
+		typed := infra.DecodeTerraformOutputs(kind, outputs)
 		return factory.Build(factory.Config{
 			Kind:       kind,
-			Selfhosted: factory.SelfhostedConfigFromOutputs(outputs),
+			Selfhosted: factory.SelfhostedConfigFromTypedOutputs(typed.Selfhosted),
 			Logger:     log,
 		})
 	}
@@ -26,12 +27,14 @@ func buildRuntimeProvider(ctx context.Context, kind cloud.Kind, outputs map[stri
 }
 
 func waitForProviderNativeFleet(ctx context.Context, kind cloud.Kind, outputs map[string]string, policy fleet.PlacementPolicy) (int, error) {
-	natsURL := outputs["nats_url"]
+	typed := infra.DecodeTerraformOutputs(kind, outputs)
+	runtime := typed.Selfhosted
+	natsURL := runtime.NATSURL
 	if natsURL == "" {
 		return 0, fmt.Errorf("terraform outputs missing nats_url")
 	}
 
-	desired := fleetWorkerCount(outputs)
+	desired := runtime.WorkerCount
 	if desired <= 0 {
 		desired = 1
 	}
@@ -39,15 +42,15 @@ func waitForProviderNativeFleet(ctx context.Context, kind cloud.Kind, outputs ma
 	mgr, err := fleet.NewNATSFleetManager(fleet.NATSFleetManagerConfig{
 		NATSURL:         natsURL,
 		DesiredWorkers:  desired,
-		ControllerIP:    outputs["controller_ip"],
-		GenerationID:    outputs["generation_id"],
+		ControllerIP:    runtime.ControllerIP,
+		GenerationID:    runtime.GenerationID,
 		Cloud:           string(kind.Canonical()),
 		Placement:       policy,
-		ExpectedVersion: outputs["docker_image"],
-		RootCAPEM:       outputs["controller_ca_pem"],
-		ServerName:      outputs["controller_host"],
-		ClientCertPEM:   outputs["nats_operator_client_cert_pem"],
-		ClientKeyPEM:    outputs["nats_operator_client_key_pem"],
+		ExpectedVersion: runtime.DockerImage,
+		RootCAPEM:       runtime.ControllerCAPEM,
+		ServerName:      runtime.ControllerHost,
+		ClientCertPEM:   runtime.NATSOperatorClientCertPEM,
+		ClientKeyPEM:    runtime.NATSOperatorClientKeyPEM,
 	}, logger.NewSimpleLogger())
 	if err != nil {
 		return 0, fmt.Errorf("starting provider-native fleet manager: %w", err)
@@ -67,18 +70,7 @@ func waitForProviderNativeFleet(ctx context.Context, kind cloud.Kind, outputs ma
 }
 
 func fleetWorkerCount(outputs map[string]string) int {
-	if outputs == nil {
-		return 0
-	}
-	raw := outputs["worker_count"]
-	if raw == "" {
-		return 0
-	}
-	n, err := strconv.Atoi(raw)
-	if err != nil || n <= 0 {
-		return 0
-	}
-	return n
+	return infra.OutputInt(outputs, infra.OutputWorkerCount)
 }
 
 func outputBool(value string) bool {

--- a/cmd/heph/provider_runtime_test.go
+++ b/cmd/heph/provider_runtime_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+func TestFleetWorkerCountUsesTypedOutputParser(t *testing.T) {
+	tests := []struct {
+		name    string
+		outputs map[string]string
+		want    int
+	}{
+		{name: "missing", outputs: nil, want: 0},
+		{name: "valid", outputs: map[string]string{"worker_count": "4"}, want: 4},
+		{name: "invalid", outputs: map[string]string{"worker_count": "nope"}, want: 0},
+		{name: "zero", outputs: map[string]string{"worker_count": "0"}, want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := fleetWorkerCount(tt.outputs); got != tt.want {
+				t.Fatalf("fleetWorkerCount() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cloud/factory/factory.go
+++ b/internal/cloud/factory/factory.go
@@ -13,6 +13,7 @@ import (
 	"heph4estus/internal/cloud"
 	awscloud "heph4estus/internal/cloud/aws"
 	"heph4estus/internal/cloud/selfhosted"
+	"heph4estus/internal/infra"
 	"heph4estus/internal/logger"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
@@ -251,47 +252,45 @@ func BuildForKind(ctx context.Context, kind cloud.Kind, log logger.Logger) (clou
 // controller endpoints and credentials come from deploy outputs rather than
 // operator environment variables.
 func SelfhostedConfigFromOutputs(outputs map[string]string) *SelfhostedConfig {
-	cfg := &SelfhostedConfig{
-		NATSURL:     outputs["nats_url"],
-		StreamName:  outputs["nats_stream"],
-		S3Endpoint:  outputs["s3_endpoint"],
-		S3Region:    outputs["s3_region"],
-		S3AccessKey: outputs["s3_access_key"],
-		S3Secret:    outputs["s3_secret_key"],
-		S3PathStyle: outputs["s3_path_style"] == "true",
-		QueueID:     outputs["sqs_queue_url"],
-		Bucket:      outputs["s3_bucket_name"],
-		DockerImage: registryHost(outputs["registry_url"]) + "/" + outputs["docker_image"],
+	typed := infra.DecodeTerraformOutputs(cloud.KindManual, outputs)
+	return SelfhostedConfigFromTypedOutputs(typed.Selfhosted)
+}
 
-		ControllerSecurityMode: outputs["controller_security_mode"],
-		NATSTLSEnabled:         parseOutputBool(outputs["nats_tls_enabled"]),
-		NATSAuthEnabled:        parseOutputBool(outputs["nats_auth_enabled"]),
-		MinIOTLSEnabled:        parseOutputBool(outputs["minio_tls_enabled"]),
-		MinIOAuthEnabled:       parseOutputBool(outputs["minio_auth_enabled"]),
-		RegistryTLSEnabled:     parseOutputBool(outputs["registry_tls_enabled"]),
-		RegistryAuthEnabled:    parseOutputBool(outputs["registry_auth_enabled"]),
-		ControllerCAPEM:        outputs["controller_ca_pem"],
-		ControllerServerName:   outputs["controller_host"],
-		NATSClientCertPEM:      outputs["nats_operator_client_cert_pem"],
-		NATSClientKeyPEM:       outputs["nats_operator_client_key_pem"],
+// SelfhostedConfigFromTypedOutputs constructs a SelfhostedConfig from the typed
+// provider-native Terraform output contract.
+func SelfhostedConfigFromTypedOutputs(outputs infra.SelfhostedRuntimeOutputs) *SelfhostedConfig {
+	cfg := &SelfhostedConfig{
+		NATSURL:     outputs.NATSURL,
+		StreamName:  outputs.NATSStream,
+		S3Endpoint:  outputs.S3Endpoint,
+		S3Region:    outputs.S3Region,
+		S3AccessKey: outputs.S3AccessKey,
+		S3Secret:    outputs.S3SecretKey,
+		S3PathStyle: outputs.S3PathStyle,
+		QueueID:     outputs.QueueURL,
+		Bucket:      outputs.S3BucketName,
+		DockerImage: registryHost(outputs.RegistryURL) + "/" + outputs.DockerImage,
+
+		ControllerSecurityMode: outputs.ControllerSecurityMode,
+		NATSTLSEnabled:         outputs.NATSTLSEnabled,
+		NATSAuthEnabled:        outputs.NATSAuthEnabled,
+		MinIOTLSEnabled:        outputs.MinIOTLSEnabled,
+		MinIOAuthEnabled:       outputs.MinIOAuthEnabled,
+		RegistryTLSEnabled:     outputs.RegistryTLSEnabled,
+		RegistryAuthEnabled:    outputs.RegistryAuthEnabled,
+		ControllerCAPEM:        outputs.ControllerCAPEM,
+		ControllerServerName:   outputs.ControllerHost,
+		NATSClientCertPEM:      outputs.NATSOperatorClientCertPEM,
+		NATSClientKeyPEM:       outputs.NATSOperatorClientKeyPEM,
 	}
-	if hosts := outputs["worker_hosts"]; hosts != "" {
-		cfg.WorkerHosts = splitCommaList(hosts)
+	if len(outputs.WorkerHosts) > 0 {
+		cfg.WorkerHosts = append([]string(nil), outputs.WorkerHosts...)
 	}
 	return cfg
 }
 
 func registryHost(registryURL string) string {
 	return strings.TrimPrefix(strings.TrimPrefix(registryURL, "https://"), "http://")
-}
-
-func parseOutputBool(value string) bool {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "true", "1", "yes", "y", "on":
-		return true
-	default:
-		return false
-	}
 }
 
 func envOr(key, fallback string) string {

--- a/internal/cloud/factory/factory_test.go
+++ b/internal/cloud/factory/factory_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"heph4estus/internal/cloud"
+	"heph4estus/internal/infra"
 	"heph4estus/internal/logger"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
@@ -382,6 +383,47 @@ func TestSelfhostedConfigFromOutputs(t *testing.T) {
 	}
 	if cfg.NATSTLSEnabled || cfg.MinIOTLSEnabled || cfg.RegistryTLSEnabled || cfg.RegistryAuthEnabled {
 		t.Fatalf("unexpected TLS/auth posture: natsTLS=%t minioTLS=%t registryTLS=%t registryAuth=%t", cfg.NATSTLSEnabled, cfg.MinIOTLSEnabled, cfg.RegistryTLSEnabled, cfg.RegistryAuthEnabled)
+	}
+}
+
+func TestSelfhostedConfigFromTypedOutputs(t *testing.T) {
+	cfg := SelfhostedConfigFromTypedOutputs(infra.SelfhostedRuntimeOutputs{
+		NATSURL:                   "nats://ctrl:4222",
+		NATSStream:                "heph-tasks",
+		S3Endpoint:                "https://ctrl:9000",
+		S3Region:                  "us-east-1",
+		S3AccessKey:               "ak",
+		S3SecretKey:               "sk",
+		S3PathStyle:               true,
+		QueueURL:                  "heph-tasks",
+		S3BucketName:              "heph-results",
+		RegistryURL:               "https://10.0.1.2:5000",
+		DockerImage:               "heph-nmap-worker:latest",
+		WorkerHosts:               []string{"203.0.113.10", "203.0.113.11"},
+		ControllerSecurityMode:    "private-auth",
+		NATSTLSEnabled:            true,
+		NATSAuthEnabled:           true,
+		MinIOTLSEnabled:           true,
+		MinIOAuthEnabled:          true,
+		RegistryTLSEnabled:        true,
+		RegistryAuthEnabled:       true,
+		ControllerCAPEM:           "ca",
+		ControllerHost:            "controller.heph.local",
+		NATSOperatorClientCertPEM: "operator-cert",
+		NATSOperatorClientKeyPEM:  "operator-key",
+	})
+
+	if cfg.DockerImage != "10.0.1.2:5000/heph-nmap-worker:latest" {
+		t.Fatalf("DockerImage = %q", cfg.DockerImage)
+	}
+	if !cfg.S3PathStyle || !cfg.NATSTLSEnabled || !cfg.NATSAuthEnabled || !cfg.MinIOTLSEnabled || !cfg.MinIOAuthEnabled || !cfg.RegistryTLSEnabled || !cfg.RegistryAuthEnabled {
+		t.Fatalf("expected typed security/storage booleans to be preserved")
+	}
+	if len(cfg.WorkerHosts) != 2 {
+		t.Fatalf("WorkerHosts = %v, want 2 entries", cfg.WorkerHosts)
+	}
+	if cfg.NATSClientCertPEM != "operator-cert" || cfg.NATSClientKeyPEM != "operator-key" {
+		t.Fatalf("NATS client cert material = %q/%q", cfg.NATSClientCertPEM, cfg.NATSClientKeyPEM)
 	}
 }
 

--- a/internal/infra/lifecycle.go
+++ b/internal/infra/lifecycle.go
@@ -69,9 +69,10 @@ func Probe(ctx context.Context, tf *TerraformClient, kind cloud.Kind, terraformD
 	if len(outputs) == 0 {
 		return ProbeResult{Status: StatusMissing}
 	}
+	typed := DecodeTerraformOutputs(kind, outputs)
 
 	// Check for tool mismatch.
-	deployedTool := outputs["tool_name"]
+	deployedTool := typed.ToolName
 	if deployedTool != "" && deployedTool != requestedTool {
 		return ProbeResult{
 			Status:       StatusMismatch,
@@ -83,8 +84,8 @@ func Probe(ctx context.Context, tf *TerraformClient, kind cloud.Kind, terraformD
 	// For provider-native clouds, verify the deployed cloud matches. This
 	// prevents silently reusing Hetzner infra when Vultr was requested.
 	if kind.IsProviderNative() {
-		deployedCloud := outputs["cloud"]
-		if deployedCloud != "" && cloud.Kind(deployedCloud).Canonical() != kind.Canonical() {
+		deployedCloud := typed.Cloud
+		if deployedCloud != "" && deployedCloud != kind.Canonical() {
 			return ProbeResult{
 				Status:       StatusMismatch,
 				Outputs:      outputs,
@@ -94,12 +95,7 @@ func Probe(ctx context.Context, tf *TerraformClient, kind cloud.Kind, terraformD
 	}
 
 	// Check for missing required keys.
-	var missing []string
-	for _, key := range RequiredOutputKeysForCloud(kind) {
-		if outputs[key] == "" {
-			missing = append(missing, key)
-		}
-	}
+	missing := typed.ValidateRequired(kind)
 	if len(missing) > 0 {
 		return ProbeResult{
 			Status:       StatusStale,

--- a/internal/infra/lifecycle_test.go
+++ b/internal/infra/lifecycle_test.go
@@ -308,13 +308,13 @@ func TestRequiredOutputKeysForCloud_AWS(t *testing.T) {
 	}
 	// Spot check a few AWS-specific keys.
 	want := map[string]bool{
-		"sqs_queue_url":        true,
-		"ecr_repo_url":         true,
-		"image_tag":            true,
-		"docker_image":         true,
-		"ecs_cluster_name":     true,
-		"ami_id":               true,
-		"instance_profile_arn": true,
+		OutputSQSQueueURL:     true,
+		OutputECRRepoURL:      true,
+		OutputImageTag:        true,
+		OutputDockerImage:     true,
+		OutputECSClusterName:  true,
+		OutputAMIID:           true,
+		OutputInstanceProfile: true,
 	}
 	for _, k := range keys {
 		delete(want, k)
@@ -330,103 +330,75 @@ func TestRequiredOutputKeysForCloud_Selfhosted(t *testing.T) {
 		t.Fatalf("selfhosted keys length = %d, want %d", len(keys), len(SelfhostedRequiredOutputKeys))
 	}
 	// Selfhosted should only require tool_name for mismatch detection.
-	if keys[0] != "tool_name" {
+	if keys[0] != OutputToolName {
 		t.Fatalf("expected tool_name, got %q", keys[0])
 	}
 	// AWS-specific keys must NOT appear in selfhosted set.
 	for _, k := range keys {
-		if k == "sqs_queue_url" || k == "ecr_repo_url" || k == "ecs_cluster_name" {
+		if k == OutputSQSQueueURL || k == OutputECRRepoURL || k == OutputECSClusterName {
 			t.Fatalf("selfhosted should not require AWS key %q", k)
 		}
 	}
 }
 
-func TestRequiredOutputKeysForCloud_Hetzner(t *testing.T) {
-	keys := RequiredOutputKeysForCloud(cloud.KindHetzner)
-	if len(keys) != len(HetznerRequiredOutputKeys) {
-		t.Fatalf("Hetzner keys length = %d, want %d", len(keys), len(HetznerRequiredOutputKeys))
-	}
+func TestRequiredOutputKeysForCloud_ProviderNativeShared(t *testing.T) {
+	kinds := []cloud.Kind{cloud.KindHetzner, cloud.KindLinode, cloud.KindVultr}
 	want := map[string]bool{
-		"controller_security_mode":            true,
-		"credential_scope_version":            true,
-		"nats_url":                            true,
-		"nats_operator_user":                  true,
-		"nats_operator_password":              true,
-		"nats_tls_enabled":                    true,
-		"nats_mtls_enabled":                   true,
-		"nats_auth_enabled":                   true,
-		"nats_operator_client_cert_pem":       true,
-		"nats_operator_client_cert_not_after": true,
-		"nats_operator_client_key_pem":        true,
-		"nats_worker_client_cert_not_after":   true,
-		"minio_tls_enabled":                   true,
-		"minio_auth_enabled":                  true,
-		"s3_operator_access_key":              true,
-		"s3_operator_secret_key":              true,
-		"registry_username":                   true,
-		"registry_password":                   true,
-		"registry_publisher_username":         true,
-		"registry_publisher_password":         true,
-		"registry_tls_enabled":                true,
-		"registry_auth_enabled":               true,
-		"controller_ca_pem":                   true,
-		"controller_ca_fingerprint_sha256":    true,
-		"controller_cert_not_after":           true,
-		"controller_host":                     true,
-		"controller_ip":                       true,
-		"generation_id":                       true,
-		"worker_hosts":                        true,
+		OutputControllerSecurityMode:         true,
+		OutputCredentialScopeVersion:         true,
+		OutputNATSURL:                        true,
+		OutputNATSOperatorUser:               true,
+		OutputNATSOperatorPassword:           true,
+		OutputNATSTLSEnabled:                 true,
+		OutputNATSMTLSEnabled:                true,
+		OutputNATSAuthEnabled:                true,
+		OutputNATSOperatorClientCertPEM:      true,
+		OutputNATSOperatorClientCertNotAfter: true,
+		OutputNATSOperatorClientKeyPEM:       true,
+		OutputNATSWorkerClientCertNotAfter:   true,
+		OutputMinIOTLSEnabled:                true,
+		OutputMinIOAuthEnabled:               true,
+		OutputS3OperatorAccessKey:            true,
+		OutputS3OperatorSecretKey:            true,
+		OutputRegistryUsername:               true,
+		OutputRegistryPassword:               true,
+		OutputRegistryPublisherUsername:      true,
+		OutputRegistryPublisherPassword:      true,
+		OutputRegistryTLSEnabled:             true,
+		OutputRegistryAuthEnabled:            true,
+		OutputControllerCAPEM:                true,
+		OutputControllerCAFingerprintSHA256:  true,
+		OutputControllerCertNotAfter:         true,
+		OutputControllerHost:                 true,
+		OutputControllerIP:                   true,
+		OutputGenerationID:                   true,
+		OutputWorkerHosts:                    true,
 	}
-	for _, k := range keys {
-		delete(want, k)
-	}
-	if len(want) > 0 {
-		t.Fatalf("missing expected Hetzner keys: %v", want)
+
+	for _, kind := range kinds {
+		keys := RequiredOutputKeysForCloud(kind)
+		if len(keys) != len(ProviderNativeRequiredOutputKeys) {
+			t.Fatalf("%s keys length = %d, want %d", kind, len(keys), len(ProviderNativeRequiredOutputKeys))
+		}
+		if &keys[0] != &ProviderNativeRequiredOutputKeys[0] {
+			t.Fatalf("%s should reuse shared provider-native key set", kind)
+		}
+		missing := copyBoolMap(want)
+		for _, k := range keys {
+			delete(missing, k)
+		}
+		if len(missing) > 0 {
+			t.Fatalf("missing expected %s keys: %v", kind, missing)
+		}
 	}
 }
 
-func TestRequiredOutputKeysForCloud_Linode(t *testing.T) {
-	keys := RequiredOutputKeysForCloud(cloud.KindLinode)
-	if len(keys) != len(LinodeRequiredOutputKeys) {
-		t.Fatalf("Linode keys length = %d, want %d", len(keys), len(LinodeRequiredOutputKeys))
+func copyBoolMap(src map[string]bool) map[string]bool {
+	dst := make(map[string]bool, len(src))
+	for k, v := range src {
+		dst[k] = v
 	}
-	want := map[string]bool{
-		"controller_security_mode":            true,
-		"credential_scope_version":            true,
-		"nats_url":                            true,
-		"nats_operator_user":                  true,
-		"nats_operator_password":              true,
-		"nats_tls_enabled":                    true,
-		"nats_mtls_enabled":                   true,
-		"nats_auth_enabled":                   true,
-		"nats_operator_client_cert_pem":       true,
-		"nats_operator_client_cert_not_after": true,
-		"nats_operator_client_key_pem":        true,
-		"nats_worker_client_cert_not_after":   true,
-		"minio_tls_enabled":                   true,
-		"minio_auth_enabled":                  true,
-		"s3_operator_access_key":              true,
-		"s3_operator_secret_key":              true,
-		"registry_username":                   true,
-		"registry_password":                   true,
-		"registry_publisher_username":         true,
-		"registry_publisher_password":         true,
-		"registry_tls_enabled":                true,
-		"registry_auth_enabled":               true,
-		"controller_ca_pem":                   true,
-		"controller_ca_fingerprint_sha256":    true,
-		"controller_cert_not_after":           true,
-		"controller_host":                     true,
-		"controller_ip":                       true,
-		"generation_id":                       true,
-		"worker_hosts":                        true,
-	}
-	for _, k := range keys {
-		delete(want, k)
-	}
-	if len(want) > 0 {
-		t.Fatalf("missing expected Linode keys: %v", want)
-	}
+	return dst
 }
 
 func TestRequiredOutputKeysForCloud_UnknownFallsToAWS(t *testing.T) {

--- a/internal/infra/outputs.go
+++ b/internal/infra/outputs.go
@@ -1,0 +1,324 @@
+package infra
+
+import (
+	"strconv"
+	"strings"
+
+	"heph4estus/internal/cloud"
+)
+
+const (
+	OutputToolName = "tool_name"
+	OutputCloud    = "cloud"
+
+	OutputSQSQueueURL       = "sqs_queue_url"
+	OutputECRRepoURL        = "ecr_repo_url"
+	OutputImageTag          = "image_tag"
+	OutputDockerImage       = "docker_image"
+	OutputS3BucketName      = "s3_bucket_name"
+	OutputS3Endpoint        = "s3_endpoint"
+	OutputS3Region          = "s3_region"
+	OutputS3AccessKey       = "s3_access_key"
+	OutputS3SecretKey       = "s3_secret_key"
+	OutputS3PathStyle       = "s3_path_style"
+	OutputECSClusterName    = "ecs_cluster_name"
+	OutputTaskDefinitionARN = "task_definition_arn"
+	OutputSubnetIDs         = "subnet_ids"
+	OutputSecurityGroupID   = "security_group_id"
+	OutputInstanceProfile   = "instance_profile_arn"
+	OutputAMIID             = "ami_id"
+
+	OutputControllerSecurityMode = "controller_security_mode"
+	OutputCredentialScopeVersion = "credential_scope_version"
+	OutputNATSURL                = "nats_url"
+	OutputNATSStream             = "nats_stream"
+	OutputNATSUser               = "nats_user"
+	OutputNATSPassword           = "nats_password"
+	OutputNATSOperatorUser       = "nats_operator_user"
+	OutputNATSOperatorPassword   = "nats_operator_password"
+	OutputNATSTLSEnabled         = "nats_tls_enabled"
+	OutputNATSMTLSEnabled        = "nats_mtls_enabled"
+	OutputNATSAuthEnabled        = "nats_auth_enabled"
+
+	OutputNATSOperatorClientCertPEM      = "nats_operator_client_cert_pem"
+	OutputNATSOperatorClientCertNotAfter = "nats_operator_client_cert_not_after"
+	OutputNATSOperatorClientKeyPEM       = "nats_operator_client_key_pem"
+	OutputNATSWorkerClientCertNotAfter   = "nats_worker_client_cert_not_after"
+
+	OutputS3OperatorAccessKey = "s3_operator_access_key"
+	OutputS3OperatorSecretKey = "s3_operator_secret_key"
+	OutputMinIOTLSEnabled     = "minio_tls_enabled"
+	OutputMinIOAuthEnabled    = "minio_auth_enabled"
+
+	OutputRegistryURL               = "registry_url"
+	OutputRegistryUsername          = "registry_username"
+	OutputRegistryPassword          = "registry_password"
+	OutputRegistryPublisherUsername = "registry_publisher_username"
+	OutputRegistryPublisherPassword = "registry_publisher_password"
+	OutputRegistryTLSEnabled        = "registry_tls_enabled"
+	OutputRegistryAuthEnabled       = "registry_auth_enabled"
+
+	OutputControllerCAPEM               = "controller_ca_pem"
+	OutputControllerCAFingerprintSHA256 = "controller_ca_fingerprint_sha256"
+	OutputControllerCertNotAfter        = "controller_cert_not_after"
+	OutputControllerHost                = "controller_host"
+	OutputControllerIP                  = "controller_ip"
+	OutputControllerIPv6                = "controller_ipv6"
+	OutputGenerationID                  = "generation_id"
+
+	OutputWorkerCount      = "worker_count"
+	OutputWorkerHosts      = "worker_hosts"
+	OutputWorkerIPs        = "worker_ips"
+	OutputWorkerIPv6s      = "worker_ipv6s"
+	OutputWorkerPrivateIPs = "worker_private_ips"
+	OutputSSHKeyName       = "ssh_key_name"
+)
+
+// TerraformOutputs is the typed view of terraform output -json values. Raw is
+// preserved for compatibility boundaries that still need the original map.
+type TerraformOutputs struct {
+	Raw        map[string]string
+	ToolName   string
+	Cloud      cloud.Kind
+	AWS        AWSRuntimeOutputs
+	Selfhosted SelfhostedRuntimeOutputs
+}
+
+type AWSRuntimeOutputs struct {
+	SQSQueueURL        string
+	ECRRepoURL         string
+	ImageTag           string
+	DockerImage        string
+	S3BucketName       string
+	S3Endpoint         string
+	S3Region           string
+	S3AccessKey        string
+	S3SecretKey        string
+	S3PathStyle        bool
+	ECSClusterName     string
+	TaskDefinitionARN  string
+	SubnetIDs          []string
+	SecurityGroupID    string
+	InstanceProfileARN string
+	AMIID              string
+}
+
+type SelfhostedRuntimeOutputs struct {
+	Cloud                  cloud.Kind
+	ControllerSecurityMode string
+	CredentialScopeVersion string
+
+	NATSURL                        string
+	NATSStream                     string
+	NATSUser                       string
+	NATSPassword                   string
+	NATSOperatorUser               string
+	NATSOperatorPassword           string
+	NATSTLSEnabled                 bool
+	NATSMTLSEnabled                bool
+	NATSAuthEnabled                bool
+	NATSOperatorClientCertPEM      string
+	NATSOperatorClientCertNotAfter string
+	NATSOperatorClientKeyPEM       string
+	NATSWorkerClientCertNotAfter   string
+
+	S3Endpoint          string
+	S3Region            string
+	S3AccessKey         string
+	S3SecretKey         string
+	S3OperatorAccessKey string
+	S3OperatorSecretKey string
+	S3PathStyle         bool
+	S3BucketName        string
+	MinIOTLSEnabled     bool
+	MinIOAuthEnabled    bool
+
+	RegistryURL               string
+	RegistryUsername          string
+	RegistryPassword          string
+	RegistryPublisherUsername string
+	RegistryPublisherPassword string
+	RegistryTLSEnabled        bool
+	RegistryAuthEnabled       bool
+
+	ControllerCAPEM               string
+	ControllerCAFingerprintSHA256 string
+	ControllerCertNotAfter        string
+	ControllerHost                string
+	ControllerIP                  string
+	ControllerIPv6                string
+	GenerationID                  string
+
+	DockerImage string
+	QueueURL    string
+
+	WorkerCount      int
+	WorkerHosts      []string
+	WorkerIPs        []string
+	WorkerIPv6s      []string
+	WorkerPrivateIPs []string
+	SSHKeyName       string
+}
+
+// DecodeTerraformOutputs turns the raw terraform output map into typed runtime
+// views while preserving the original keys and values for compatibility.
+func DecodeTerraformOutputs(kind cloud.Kind, raw map[string]string) TerraformOutputs {
+	copied := copyStringMap(raw)
+	outputCloud := cloud.Kind(OutputString(copied, OutputCloud)).Canonical()
+	if outputCloud == "" {
+		outputCloud = kind.Canonical()
+	}
+
+	return TerraformOutputs{
+		Raw:      copied,
+		ToolName: OutputString(copied, OutputToolName),
+		Cloud:    outputCloud,
+		AWS: AWSRuntimeOutputs{
+			SQSQueueURL:        OutputString(copied, OutputSQSQueueURL),
+			ECRRepoURL:         OutputString(copied, OutputECRRepoURL),
+			ImageTag:           OutputString(copied, OutputImageTag),
+			DockerImage:        OutputString(copied, OutputDockerImage),
+			S3BucketName:       OutputString(copied, OutputS3BucketName),
+			S3Endpoint:         OutputString(copied, OutputS3Endpoint),
+			S3Region:           OutputString(copied, OutputS3Region),
+			S3AccessKey:        OutputString(copied, OutputS3AccessKey),
+			S3SecretKey:        OutputString(copied, OutputS3SecretKey),
+			S3PathStyle:        OutputBool(copied, OutputS3PathStyle),
+			ECSClusterName:     OutputString(copied, OutputECSClusterName),
+			TaskDefinitionARN:  OutputString(copied, OutputTaskDefinitionARN),
+			SubnetIDs:          OutputList(copied, OutputSubnetIDs),
+			SecurityGroupID:    OutputString(copied, OutputSecurityGroupID),
+			InstanceProfileARN: OutputString(copied, OutputInstanceProfile),
+			AMIID:              OutputString(copied, OutputAMIID),
+		},
+		Selfhosted: SelfhostedRuntimeOutputs{
+			Cloud:                          outputCloud,
+			ControllerSecurityMode:         OutputString(copied, OutputControllerSecurityMode),
+			CredentialScopeVersion:         OutputString(copied, OutputCredentialScopeVersion),
+			NATSURL:                        OutputString(copied, OutputNATSURL),
+			NATSStream:                     OutputString(copied, OutputNATSStream),
+			NATSUser:                       OutputString(copied, OutputNATSUser),
+			NATSPassword:                   OutputString(copied, OutputNATSPassword),
+			NATSOperatorUser:               OutputString(copied, OutputNATSOperatorUser),
+			NATSOperatorPassword:           OutputString(copied, OutputNATSOperatorPassword),
+			NATSTLSEnabled:                 OutputBool(copied, OutputNATSTLSEnabled),
+			NATSMTLSEnabled:                OutputBool(copied, OutputNATSMTLSEnabled),
+			NATSAuthEnabled:                OutputBool(copied, OutputNATSAuthEnabled),
+			NATSOperatorClientCertPEM:      OutputString(copied, OutputNATSOperatorClientCertPEM),
+			NATSOperatorClientCertNotAfter: OutputString(copied, OutputNATSOperatorClientCertNotAfter),
+			NATSOperatorClientKeyPEM:       OutputString(copied, OutputNATSOperatorClientKeyPEM),
+			NATSWorkerClientCertNotAfter:   OutputString(copied, OutputNATSWorkerClientCertNotAfter),
+			S3Endpoint:                     OutputString(copied, OutputS3Endpoint),
+			S3Region:                       OutputString(copied, OutputS3Region),
+			S3AccessKey:                    OutputString(copied, OutputS3AccessKey),
+			S3SecretKey:                    OutputString(copied, OutputS3SecretKey),
+			S3OperatorAccessKey:            OutputString(copied, OutputS3OperatorAccessKey),
+			S3OperatorSecretKey:            OutputString(copied, OutputS3OperatorSecretKey),
+			S3PathStyle:                    OutputBool(copied, OutputS3PathStyle),
+			S3BucketName:                   OutputString(copied, OutputS3BucketName),
+			MinIOTLSEnabled:                OutputBool(copied, OutputMinIOTLSEnabled),
+			MinIOAuthEnabled:               OutputBool(copied, OutputMinIOAuthEnabled),
+			RegistryURL:                    OutputString(copied, OutputRegistryURL),
+			RegistryUsername:               OutputString(copied, OutputRegistryUsername),
+			RegistryPassword:               OutputString(copied, OutputRegistryPassword),
+			RegistryPublisherUsername:      OutputString(copied, OutputRegistryPublisherUsername),
+			RegistryPublisherPassword:      OutputString(copied, OutputRegistryPublisherPassword),
+			RegistryTLSEnabled:             OutputBool(copied, OutputRegistryTLSEnabled),
+			RegistryAuthEnabled:            OutputBool(copied, OutputRegistryAuthEnabled),
+			ControllerCAPEM:                OutputString(copied, OutputControllerCAPEM),
+			ControllerCAFingerprintSHA256:  OutputString(copied, OutputControllerCAFingerprintSHA256),
+			ControllerCertNotAfter:         OutputString(copied, OutputControllerCertNotAfter),
+			ControllerHost:                 OutputString(copied, OutputControllerHost),
+			ControllerIP:                   OutputString(copied, OutputControllerIP),
+			ControllerIPv6:                 OutputString(copied, OutputControllerIPv6),
+			GenerationID:                   OutputString(copied, OutputGenerationID),
+			DockerImage:                    OutputString(copied, OutputDockerImage),
+			QueueURL:                       OutputString(copied, OutputSQSQueueURL),
+			WorkerCount:                    OutputInt(copied, OutputWorkerCount),
+			WorkerHosts:                    OutputList(copied, OutputWorkerHosts),
+			WorkerIPs:                      OutputList(copied, OutputWorkerIPs),
+			WorkerIPv6s:                    OutputList(copied, OutputWorkerIPv6s),
+			WorkerPrivateIPs:               OutputList(copied, OutputWorkerPrivateIPs),
+			SSHKeyName:                     OutputString(copied, OutputSSHKeyName),
+		},
+	}
+}
+
+func (o TerraformOutputs) ValidateRequired(kind cloud.Kind) []string {
+	return MissingOutputKeys(o.Raw, RequiredOutputKeysForCloud(kind))
+}
+
+func (o TerraformOutputs) ToMap() map[string]string {
+	return copyStringMap(o.Raw)
+}
+
+func (o TerraformOutputs) RedactedMap() map[string]string {
+	return RedactOutputs(o.Raw)
+}
+
+func MissingOutputKeys(outputs map[string]string, keys []string) []string {
+	var missing []string
+	for _, key := range keys {
+		if outputs[key] == "" {
+			missing = append(missing, key)
+		}
+	}
+	return missing
+}
+
+func OutputString(outputs map[string]string, key string) string {
+	if outputs == nil {
+		return ""
+	}
+	return outputs[key]
+}
+
+func OutputBool(outputs map[string]string, key string) bool {
+	switch strings.ToLower(strings.TrimSpace(OutputString(outputs, key))) {
+	case "true", "1", "yes", "y", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func OutputInt(outputs map[string]string, key string) int {
+	n, err := strconv.Atoi(strings.TrimSpace(OutputString(outputs, key)))
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return n
+}
+
+func OutputList(outputs map[string]string, key string) []string {
+	value := strings.TrimSpace(OutputString(outputs, key))
+	if value == "" {
+		return nil
+	}
+	value = strings.Trim(value, "[]")
+	var fields []string
+	if strings.Contains(value, ",") {
+		fields = strings.Split(value, ",")
+	} else {
+		fields = strings.Fields(value)
+	}
+	result := make([]string, 0, len(fields))
+	for _, field := range fields {
+		field = strings.TrimSpace(field)
+		if field != "" {
+			result = append(result, field)
+		}
+	}
+	return result
+}
+
+func copyStringMap(src map[string]string) map[string]string {
+	if src == nil {
+		return map[string]string{}
+	}
+	dst := make(map[string]string, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}

--- a/internal/infra/outputs_test.go
+++ b/internal/infra/outputs_test.go
@@ -1,0 +1,150 @@
+package infra
+
+import (
+	"reflect"
+	"testing"
+
+	"heph4estus/internal/cloud"
+)
+
+func TestDecodeTerraformOutputs_AWS(t *testing.T) {
+	raw := map[string]string{
+		OutputToolName:          "nmap",
+		OutputSQSQueueURL:       "https://sqs.example.com/q",
+		OutputECRRepoURL:        "123.dkr.ecr.us-east-1.amazonaws.com/nmap",
+		OutputImageTag:          "heph-nmap-worker-20260608T032422Z-a1b2c3d4",
+		OutputDockerImage:       "123.dkr.ecr.us-east-1.amazonaws.com/nmap:tag",
+		OutputS3BucketName:      "bucket",
+		OutputECSClusterName:    "cluster",
+		OutputTaskDefinitionARN: "arn:aws:ecs:task-definition/td",
+		OutputSubnetIDs:         "[subnet-a subnet-b]",
+		OutputSecurityGroupID:   "sg-123",
+		OutputInstanceProfile:   "arn:aws:iam::role",
+		OutputAMIID:             "ami-123",
+	}
+
+	decoded := DecodeTerraformOutputs(cloud.KindAWS, raw)
+	if decoded.ToolName != "nmap" {
+		t.Fatalf("ToolName = %q, want nmap", decoded.ToolName)
+	}
+	if decoded.Cloud != cloud.KindAWS {
+		t.Fatalf("Cloud = %q, want aws", decoded.Cloud)
+	}
+	if decoded.AWS.SQSQueueURL != raw[OutputSQSQueueURL] {
+		t.Fatalf("SQSQueueURL = %q", decoded.AWS.SQSQueueURL)
+	}
+	if !reflect.DeepEqual(decoded.AWS.SubnetIDs, []string{"subnet-a", "subnet-b"}) {
+		t.Fatalf("SubnetIDs = %#v", decoded.AWS.SubnetIDs)
+	}
+	if decoded.AWS.InstanceProfileARN != raw[OutputInstanceProfile] || decoded.AWS.AMIID != raw[OutputAMIID] {
+		t.Fatalf("spot outputs = %q/%q", decoded.AWS.InstanceProfileARN, decoded.AWS.AMIID)
+	}
+}
+
+func TestDecodeTerraformOutputs_ProviderNative(t *testing.T) {
+	raw := map[string]string{
+		OutputToolName:                     "httpx",
+		OutputCloud:                        "hetzner",
+		OutputControllerSecurityMode:       "private-auth",
+		OutputCredentialScopeVersion:       "v1",
+		OutputNATSURL:                      "nats://ctrl:4222",
+		OutputNATSStream:                   "heph-tasks",
+		OutputNATSTLSEnabled:               "true",
+		OutputNATSMTLSEnabled:              "1",
+		OutputNATSAuthEnabled:              "yes",
+		OutputNATSOperatorClientCertPEM:    "operator-cert",
+		OutputNATSOperatorClientKeyPEM:     "operator-key",
+		OutputS3Endpoint:                   "https://ctrl:9000",
+		OutputS3Region:                     "us-east-1",
+		OutputS3AccessKey:                  "ak",
+		OutputS3SecretKey:                  "sk",
+		OutputS3PathStyle:                  "on",
+		OutputS3BucketName:                 "heph-results",
+		OutputMinIOTLSEnabled:              "true",
+		OutputMinIOAuthEnabled:             "y",
+		OutputRegistryURL:                  "https://registry.example.com",
+		OutputRegistryTLSEnabled:           "true",
+		OutputRegistryAuthEnabled:          "true",
+		OutputControllerCAPEM:              "ca",
+		OutputControllerHost:               "controller.heph.local",
+		OutputControllerIP:                 "203.0.113.10",
+		OutputGenerationID:                 "gen-1",
+		OutputDockerImage:                  "heph-httpx-worker:latest",
+		OutputSQSQueueURL:                  "heph-tasks",
+		OutputWorkerCount:                  "3",
+		OutputWorkerHosts:                  "203.0.113.11, 203.0.113.12",
+		OutputNATSWorkerClientCertNotAfter: "2026-07-01T00:00:00Z",
+	}
+
+	decoded := DecodeTerraformOutputs(cloud.KindHetzner, raw)
+	out := decoded.Selfhosted
+	if decoded.ToolName != "httpx" || decoded.Cloud != cloud.KindHetzner || out.Cloud != cloud.KindHetzner {
+		t.Fatalf("decoded identity = tool:%q cloud:%q runtime:%q", decoded.ToolName, decoded.Cloud, out.Cloud)
+	}
+	if !out.NATSTLSEnabled || !out.NATSMTLSEnabled || !out.NATSAuthEnabled {
+		t.Fatalf("expected NATS TLS/mTLS/auth true, got tls=%t mtls=%t auth=%t", out.NATSTLSEnabled, out.NATSMTLSEnabled, out.NATSAuthEnabled)
+	}
+	if !out.S3PathStyle || !out.MinIOTLSEnabled || !out.MinIOAuthEnabled || !out.RegistryTLSEnabled || !out.RegistryAuthEnabled {
+		t.Fatalf("expected storage/registry booleans true")
+	}
+	if out.WorkerCount != 3 {
+		t.Fatalf("WorkerCount = %d, want 3", out.WorkerCount)
+	}
+	if !reflect.DeepEqual(out.WorkerHosts, []string{"203.0.113.11", "203.0.113.12"}) {
+		t.Fatalf("WorkerHosts = %#v", out.WorkerHosts)
+	}
+	if out.NATSOperatorClientCertPEM != "operator-cert" || out.NATSOperatorClientKeyPEM != "operator-key" {
+		t.Fatalf("operator client identity = %q/%q", out.NATSOperatorClientCertPEM, out.NATSOperatorClientKeyPEM)
+	}
+}
+
+func TestTerraformOutputsMapsAreCopies(t *testing.T) {
+	raw := map[string]string{
+		OutputToolName:     "nmap",
+		OutputS3SecretKey:  "secret",
+		OutputS3BucketName: "bucket",
+	}
+	decoded := DecodeTerraformOutputs(cloud.KindAWS, raw)
+	raw[OutputToolName] = "mutated"
+
+	if decoded.ToolName != "nmap" {
+		t.Fatalf("ToolName mutated to %q", decoded.ToolName)
+	}
+	out := decoded.ToMap()
+	out[OutputToolName] = "changed"
+	if decoded.Raw[OutputToolName] != "nmap" {
+		t.Fatalf("ToMap should return a copy")
+	}
+	redacted := decoded.RedactedMap()
+	if redacted[OutputS3SecretKey] != redactedPlaceholder {
+		t.Fatalf("expected secret output redacted, got %q", redacted[OutputS3SecretKey])
+	}
+	if redacted[OutputS3BucketName] != "bucket" {
+		t.Fatalf("safe output = %q, want bucket", redacted[OutputS3BucketName])
+	}
+}
+
+func TestOutputParsers(t *testing.T) {
+	outputs := map[string]string{
+		"truthy": "ON",
+		"count":  "5",
+		"spaces": "[subnet-a subnet-b]",
+		"commas": "host-a, host-b",
+	}
+
+	if !OutputBool(outputs, "truthy") {
+		t.Fatal("expected truthy bool")
+	}
+	if OutputInt(outputs, "count") != 5 {
+		t.Fatalf("OutputInt = %d, want 5", OutputInt(outputs, "count"))
+	}
+	if !reflect.DeepEqual(OutputList(outputs, "spaces"), []string{"subnet-a", "subnet-b"}) {
+		t.Fatalf("space list = %#v", OutputList(outputs, "spaces"))
+	}
+	if !reflect.DeepEqual(OutputList(outputs, "commas"), []string{"host-a", "host-b"}) {
+		t.Fatalf("comma list = %#v", OutputList(outputs, "commas"))
+	}
+	if OutputInt(outputs, "missing") != 0 || OutputBool(outputs, "missing") || OutputString(outputs, "missing") != "" || OutputList(outputs, "missing") != nil {
+		t.Fatal("missing outputs should decode to zero values")
+	}
+}

--- a/internal/infra/runtime.go
+++ b/internal/infra/runtime.go
@@ -8,18 +8,18 @@ import "heph4estus/internal/cloud"
 // them, and their absence indicates stale or partial infrastructure.
 // tool_name is required to detect mismatches.
 var AWSRequiredOutputKeys = []string{
-	"tool_name",
-	"sqs_queue_url",
-	"s3_bucket_name",
-	"ecr_repo_url",
-	"image_tag",
-	"docker_image",
-	"ecs_cluster_name",
-	"task_definition_arn",
-	"subnet_ids",
-	"security_group_id",
-	"ami_id",
-	"instance_profile_arn",
+	OutputToolName,
+	OutputSQSQueueURL,
+	OutputS3BucketName,
+	OutputECRRepoURL,
+	OutputImageTag,
+	OutputDockerImage,
+	OutputECSClusterName,
+	OutputTaskDefinitionARN,
+	OutputSubnetIDs,
+	OutputSecurityGroupID,
+	OutputAMIID,
+	OutputInstanceProfile,
 }
 
 // SelfhostedRequiredOutputKeys lists the output keys for selfhosted
@@ -28,166 +28,63 @@ var AWSRequiredOutputKeys = []string{
 // mismatch detection. Later tracks may extend this if selfhosted gains its
 // own state-file contract.
 var SelfhostedRequiredOutputKeys = []string{
-	"tool_name",
+	OutputToolName,
 }
 
-// HetznerRequiredOutputKeys lists the Terraform output keys that must be
-// present for a Hetzner deploy to be considered ready. These are produced
-// by deployments/hetzner/ and include both controller endpoints and worker
-// metadata.
-var HetznerRequiredOutputKeys = []string{
-	"tool_name",
-	"cloud",
-	"controller_security_mode",
-	"credential_scope_version",
-	"nats_url",
-	"nats_stream",
-	"nats_user",
-	"nats_password",
-	"nats_operator_user",
-	"nats_operator_password",
-	"nats_tls_enabled",
-	"nats_mtls_enabled",
-	"nats_auth_enabled",
-	"nats_operator_client_cert_pem",
-	"nats_operator_client_cert_not_after",
-	"nats_operator_client_key_pem",
-	"nats_worker_client_cert_not_after",
-	"s3_endpoint",
-	"s3_access_key",
-	"s3_secret_key",
-	"s3_operator_access_key",
-	"s3_operator_secret_key",
-	"s3_bucket_name",
-	"minio_tls_enabled",
-	"minio_auth_enabled",
-	"registry_url",
-	"registry_username",
-	"registry_password",
-	"registry_publisher_username",
-	"registry_publisher_password",
-	"registry_tls_enabled",
-	"registry_auth_enabled",
-	"controller_ca_pem",
-	"controller_ca_fingerprint_sha256",
-	"controller_cert_not_after",
-	"controller_host",
-	"docker_image",
-	"sqs_queue_url",
-	"controller_ip",
-	"generation_id",
-	"worker_count",
-	"worker_hosts",
-}
-
-// LinodeRequiredOutputKeys lists the Terraform output keys that must be
-// present for a Linode deploy to be considered ready. The output contract
-// mirrors Hetzner — both provider-native VPS paths produce the same key
-// set so the lifecycle/factory code works uniformly.
-var LinodeRequiredOutputKeys = []string{
-	"tool_name",
-	"cloud",
-	"controller_security_mode",
-	"credential_scope_version",
-	"nats_url",
-	"nats_stream",
-	"nats_user",
-	"nats_password",
-	"nats_operator_user",
-	"nats_operator_password",
-	"nats_tls_enabled",
-	"nats_mtls_enabled",
-	"nats_auth_enabled",
-	"nats_operator_client_cert_pem",
-	"nats_operator_client_cert_not_after",
-	"nats_operator_client_key_pem",
-	"nats_worker_client_cert_not_after",
-	"s3_endpoint",
-	"s3_access_key",
-	"s3_secret_key",
-	"s3_operator_access_key",
-	"s3_operator_secret_key",
-	"s3_bucket_name",
-	"minio_tls_enabled",
-	"minio_auth_enabled",
-	"registry_url",
-	"registry_username",
-	"registry_password",
-	"registry_publisher_username",
-	"registry_publisher_password",
-	"registry_tls_enabled",
-	"registry_auth_enabled",
-	"controller_ca_pem",
-	"controller_ca_fingerprint_sha256",
-	"controller_cert_not_after",
-	"controller_host",
-	"docker_image",
-	"sqs_queue_url",
-	"controller_ip",
-	"generation_id",
-	"worker_count",
-	"worker_hosts",
-}
-
-// VultrRequiredOutputKeys lists the Terraform output keys that must be
-// present for a Vultr deploy to be considered ready. The output contract
-// mirrors Hetzner and Linode — all provider-native VPS paths produce the
-// same key set so the lifecycle/factory code works uniformly.
-var VultrRequiredOutputKeys = []string{
-	"tool_name",
-	"cloud",
-	"controller_security_mode",
-	"credential_scope_version",
-	"nats_url",
-	"nats_stream",
-	"nats_user",
-	"nats_password",
-	"nats_operator_user",
-	"nats_operator_password",
-	"nats_tls_enabled",
-	"nats_mtls_enabled",
-	"nats_auth_enabled",
-	"nats_operator_client_cert_pem",
-	"nats_operator_client_cert_not_after",
-	"nats_operator_client_key_pem",
-	"nats_worker_client_cert_not_after",
-	"s3_endpoint",
-	"s3_access_key",
-	"s3_secret_key",
-	"s3_operator_access_key",
-	"s3_operator_secret_key",
-	"s3_bucket_name",
-	"minio_tls_enabled",
-	"minio_auth_enabled",
-	"registry_url",
-	"registry_username",
-	"registry_password",
-	"registry_publisher_username",
-	"registry_publisher_password",
-	"registry_tls_enabled",
-	"registry_auth_enabled",
-	"controller_ca_pem",
-	"controller_ca_fingerprint_sha256",
-	"controller_cert_not_after",
-	"controller_host",
-	"docker_image",
-	"sqs_queue_url",
-	"controller_ip",
-	"generation_id",
-	"worker_count",
-	"worker_hosts",
+// ProviderNativeRequiredOutputKeys lists the Terraform output keys that must
+// be present for Hetzner, Linode, and Vultr deploys to be considered ready.
+// These providers share the same selfhosted runtime contract.
+var ProviderNativeRequiredOutputKeys = []string{
+	OutputToolName,
+	OutputCloud,
+	OutputControllerSecurityMode,
+	OutputCredentialScopeVersion,
+	OutputNATSURL,
+	OutputNATSStream,
+	OutputNATSUser,
+	OutputNATSPassword,
+	OutputNATSOperatorUser,
+	OutputNATSOperatorPassword,
+	OutputNATSTLSEnabled,
+	OutputNATSMTLSEnabled,
+	OutputNATSAuthEnabled,
+	OutputNATSOperatorClientCertPEM,
+	OutputNATSOperatorClientCertNotAfter,
+	OutputNATSOperatorClientKeyPEM,
+	OutputNATSWorkerClientCertNotAfter,
+	OutputS3Endpoint,
+	OutputS3AccessKey,
+	OutputS3SecretKey,
+	OutputS3OperatorAccessKey,
+	OutputS3OperatorSecretKey,
+	OutputS3BucketName,
+	OutputMinIOTLSEnabled,
+	OutputMinIOAuthEnabled,
+	OutputRegistryURL,
+	OutputRegistryUsername,
+	OutputRegistryPassword,
+	OutputRegistryPublisherUsername,
+	OutputRegistryPublisherPassword,
+	OutputRegistryTLSEnabled,
+	OutputRegistryAuthEnabled,
+	OutputControllerCAPEM,
+	OutputControllerCAFingerprintSHA256,
+	OutputControllerCertNotAfter,
+	OutputControllerHost,
+	OutputDockerImage,
+	OutputSQSQueueURL,
+	OutputControllerIP,
+	OutputGenerationID,
+	OutputWorkerCount,
+	OutputWorkerHosts,
 }
 
 // RequiredOutputKeysForCloud returns the required output keys for the given
 // cloud provider family. Unknown kinds fall back to the AWS set.
 func RequiredOutputKeysForCloud(kind cloud.Kind) []string {
 	switch kind.Canonical() {
-	case cloud.KindHetzner:
-		return HetznerRequiredOutputKeys
-	case cloud.KindLinode:
-		return LinodeRequiredOutputKeys
-	case cloud.KindVultr:
-		return VultrRequiredOutputKeys
+	case cloud.KindHetzner, cloud.KindLinode, cloud.KindVultr:
+		return ProviderNativeRequiredOutputKeys
 	default:
 		if kind.IsSelfhostedFamily() {
 			return SelfhostedRequiredOutputKeys

--- a/internal/tui/views/deploy/model.go
+++ b/internal/tui/views/deploy/model.go
@@ -3,7 +3,6 @@ package deploy
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -417,7 +416,7 @@ func (m *Model) advanceStage(completed string) tea.Cmd {
 }
 
 func (m *Model) emitNavigateToStatus() tea.Cmd {
-	outputs := m.outputs
+	outputs := infra.DecodeTerraformOutputs(m.config.Cloud, m.outputs)
 	cfg := m.config
 
 	target := cfg.PostDeployView
@@ -429,55 +428,7 @@ func (m *Model) emitNavigateToStatus() tea.Cmd {
 	return func() tea.Msg {
 		return core.NavigateWithDataMsg{
 			Target: target,
-			Data: core.InfraOutputs{
-				Cloud:                 cfg.Cloud,
-				FleetWorkerCount:      parseInt(outputs["worker_count"]),
-				SQSQueueURL:           outputs["sqs_queue_url"],
-				ECRRepoURL:            outputs["ecr_repo_url"],
-				ImageTag:              outputs["image_tag"],
-				S3BucketName:          outputs["s3_bucket_name"],
-				S3Endpoint:            outputs["s3_endpoint"],
-				S3Region:              outputs["s3_region"],
-				S3AccessKey:           outputs["s3_access_key"],
-				S3SecretKey:           outputs["s3_secret_key"],
-				S3PathStyle:           parseBool(outputs["s3_path_style"]),
-				ECSClusterName:        outputs["ecs_cluster_name"],
-				TaskDefinitionARN:     outputs["task_definition_arn"],
-				SubnetIDs:             splitCSV(outputs["subnet_ids"]),
-				SecurityGroupID:       outputs["security_group_id"],
-				TargetsContent:        cfg.TargetsContent,
-				TargetsPath:           cfg.TargetsPath,
-				TargetCount:           cfg.TargetCount,
-				TargetChunks:          cfg.TargetChunks,
-				NmapOptions:           cfg.NmapOptions,
-				WorkerCount:           cfg.WorkerCount,
-				ComputeMode:           cfg.ComputeMode,
-				Placement:             cfg.Placement,
-				JitterMaxSeconds:      cfg.JitterMaxSeconds,
-				NmapTimingTemplate:    cfg.NmapTimingTemplate,
-				DNSServers:            cfg.DNSServers,
-				NoRDNS:                cfg.NoRDNS,
-				InstanceProfileARN:    outputs["instance_profile_arn"],
-				AMIID:                 outputs["ami_id"],
-				ToolName:              cfg.ToolName,
-				ToolOptions:           cfg.ToolOptions,
-				WordlistPath:          cfg.WordlistPath,
-				WordlistContent:       cfg.WordlistContent,
-				RuntimeTarget:         cfg.RuntimeTarget,
-				ChunkCount:            cfg.ChunkCount,
-				CleanupPolicy:         cfg.CleanupPolicy,
-				Reused:                reused,
-				OutputDir:             cfg.OutputDir,
-				TerraformDir:          cfg.TerraformDir,
-				ControllerIP:          outputs["controller_ip"],
-				GenerationID:          outputs["generation_id"],
-				NATSUrl:               outputs["nats_url"],
-				ControllerCAPEM:       outputs["controller_ca_pem"],
-				ControllerHost:        outputs["controller_host"],
-				NATSClientCertPEM:     outputs["nats_operator_client_cert_pem"],
-				NATSClientKeyPEM:      outputs["nats_operator_client_key_pem"],
-				ExpectedWorkerVersion: outputs["docker_image"],
-			},
+			Data:   coreInfraOutputsFromTerraform(cfg, outputs, reused),
 		}
 	}
 }
@@ -518,38 +469,68 @@ func mergeOutputs(existing, new map[string]string) map[string]string {
 	return existing
 }
 
-func splitCSV(s string) []string {
-	if s == "" {
-		return nil
+func coreInfraOutputsFromTerraform(cfg core.DeployConfig, outputs infra.TerraformOutputs, reused bool) core.InfraOutputs {
+	aws := outputs.AWS
+	selfhosted := outputs.Selfhosted
+
+	return core.InfraOutputs{
+		Cloud:                 cfg.Cloud,
+		FleetWorkerCount:      selfhosted.WorkerCount,
+		SQSQueueURL:           firstNonEmpty(aws.SQSQueueURL, selfhosted.QueueURL),
+		ECRRepoURL:            aws.ECRRepoURL,
+		ImageTag:              aws.ImageTag,
+		S3BucketName:          firstNonEmpty(aws.S3BucketName, selfhosted.S3BucketName),
+		S3Endpoint:            firstNonEmpty(aws.S3Endpoint, selfhosted.S3Endpoint),
+		S3Region:              firstNonEmpty(aws.S3Region, selfhosted.S3Region),
+		S3AccessKey:           firstNonEmpty(aws.S3AccessKey, selfhosted.S3AccessKey),
+		S3SecretKey:           firstNonEmpty(aws.S3SecretKey, selfhosted.S3SecretKey),
+		S3PathStyle:           aws.S3PathStyle || selfhosted.S3PathStyle,
+		ECSClusterName:        aws.ECSClusterName,
+		TaskDefinitionARN:     aws.TaskDefinitionARN,
+		SubnetIDs:             aws.SubnetIDs,
+		SecurityGroupID:       aws.SecurityGroupID,
+		TargetsContent:        cfg.TargetsContent,
+		TargetsPath:           cfg.TargetsPath,
+		TargetCount:           cfg.TargetCount,
+		TargetChunks:          cfg.TargetChunks,
+		NmapOptions:           cfg.NmapOptions,
+		WorkerCount:           cfg.WorkerCount,
+		ComputeMode:           cfg.ComputeMode,
+		Placement:             cfg.Placement,
+		JitterMaxSeconds:      cfg.JitterMaxSeconds,
+		NmapTimingTemplate:    cfg.NmapTimingTemplate,
+		DNSServers:            cfg.DNSServers,
+		NoRDNS:                cfg.NoRDNS,
+		InstanceProfileARN:    aws.InstanceProfileARN,
+		AMIID:                 aws.AMIID,
+		ToolName:              cfg.ToolName,
+		ToolOptions:           cfg.ToolOptions,
+		WordlistPath:          cfg.WordlistPath,
+		WordlistContent:       cfg.WordlistContent,
+		RuntimeTarget:         cfg.RuntimeTarget,
+		ChunkCount:            cfg.ChunkCount,
+		CleanupPolicy:         cfg.CleanupPolicy,
+		Reused:                reused,
+		OutputDir:             cfg.OutputDir,
+		TerraformDir:          cfg.TerraformDir,
+		ControllerIP:          selfhosted.ControllerIP,
+		GenerationID:          selfhosted.GenerationID,
+		NATSUrl:               selfhosted.NATSURL,
+		ControllerCAPEM:       selfhosted.ControllerCAPEM,
+		ControllerHost:        selfhosted.ControllerHost,
+		NATSClientCertPEM:     selfhosted.NATSOperatorClientCertPEM,
+		NATSClientKeyPEM:      selfhosted.NATSOperatorClientKeyPEM,
+		ExpectedWorkerVersion: firstNonEmpty(selfhosted.DockerImage, aws.DockerImage),
 	}
-	// Handle terraform list output format like [subnet-xxx subnet-yyy]
-	s = strings.Trim(s, "[]")
-	parts := strings.Split(s, " ")
-	var result []string
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			result = append(result, p)
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
 		}
 	}
-	return result
-}
-
-func parseInt(s string) int {
-	n, err := strconv.Atoi(strings.TrimSpace(s))
-	if err != nil || n <= 0 {
-		return 0
-	}
-	return n
-}
-
-func parseBool(s string) bool {
-	switch strings.ToLower(strings.TrimSpace(s)) {
-	case "true", "1", "yes", "y", "on":
-		return true
-	default:
-		return false
-	}
+	return ""
 }
 
 // simpleLogger satisfies logger.Logger for the default deployer.

--- a/internal/tui/views/deploy/model_test.go
+++ b/internal/tui/views/deploy/model_test.go
@@ -9,6 +9,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"heph4estus/internal/cloud"
+	"heph4estus/internal/infra"
 	"heph4estus/internal/tui/core"
 )
 
@@ -136,6 +137,88 @@ func TestDeployModel_LifecycleReuse(t *testing.T) {
 		if infraOut.ImageTag != outputs["image_tag"] {
 			t.Fatalf("ImageTag = %q, want %q", infraOut.ImageTag, outputs["image_tag"])
 		}
+	}
+}
+
+func TestCoreInfraOutputsFromTerraform_AWS(t *testing.T) {
+	decoded := infra.DecodeTerraformOutputs(cloud.KindAWS, map[string]string{
+		"sqs_queue_url":        "https://sqs.example.com/q",
+		"ecr_repo_url":         "123.dkr.ecr.us-east-1.amazonaws.com/nmap",
+		"image_tag":            "heph-nmap-worker-20260608T032422Z-a1b2c3d4",
+		"docker_image":         "123.dkr.ecr.us-east-1.amazonaws.com/nmap:tag",
+		"s3_bucket_name":       "bucket",
+		"ecs_cluster_name":     "cluster",
+		"task_definition_arn":  "arn:aws:ecs:td",
+		"subnet_ids":           "[subnet-a subnet-b]",
+		"security_group_id":    "sg-123",
+		"instance_profile_arn": "arn:aws:iam::role",
+		"ami_id":               "ami-123",
+	})
+	cfg := core.DeployConfig{
+		Cloud:          cloud.KindAWS,
+		TargetsContent: "1.1.1.1\n",
+		WorkerCount:    5,
+		ComputeMode:    "spot",
+		CleanupPolicy:  "destroy-after",
+		OutputDir:      "/tmp/out",
+	}
+
+	infraOut := coreInfraOutputsFromTerraform(cfg, decoded, true)
+	if infraOut.SQSQueueURL != "https://sqs.example.com/q" || infraOut.ECRRepoURL == "" || infraOut.S3BucketName != "bucket" {
+		t.Fatalf("AWS runtime outputs not mapped: %#v", infraOut)
+	}
+	if len(infraOut.SubnetIDs) != 2 || infraOut.SubnetIDs[0] != "subnet-a" || infraOut.SubnetIDs[1] != "subnet-b" {
+		t.Fatalf("SubnetIDs = %#v", infraOut.SubnetIDs)
+	}
+	if infraOut.ExpectedWorkerVersion != "123.dkr.ecr.us-east-1.amazonaws.com/nmap:tag" {
+		t.Fatalf("ExpectedWorkerVersion = %q", infraOut.ExpectedWorkerVersion)
+	}
+	if !infraOut.Reused || infraOut.CleanupPolicy != "destroy-after" || infraOut.OutputDir != "/tmp/out" {
+		t.Fatalf("lifecycle fields not preserved: reused=%t cleanup=%q out=%q", infraOut.Reused, infraOut.CleanupPolicy, infraOut.OutputDir)
+	}
+}
+
+func TestCoreInfraOutputsFromTerraform_ProviderNative(t *testing.T) {
+	decoded := infra.DecodeTerraformOutputs(cloud.KindHetzner, map[string]string{
+		"cloud":                         "hetzner",
+		"sqs_queue_url":                 "heph-tasks",
+		"s3_bucket_name":                "heph-results",
+		"s3_endpoint":                   "https://ctrl:9000",
+		"s3_region":                     "us-east-1",
+		"s3_access_key":                 "ak",
+		"s3_secret_key":                 "sk",
+		"s3_path_style":                 "true",
+		"worker_count":                  "3",
+		"controller_ip":                 "203.0.113.10",
+		"generation_id":                 "gen-1",
+		"nats_url":                      "nats://ctrl:4222",
+		"controller_ca_pem":             "ca",
+		"controller_host":               "controller.heph.local",
+		"nats_operator_client_cert_pem": "operator-cert",
+		"nats_operator_client_key_pem":  "operator-key",
+		"docker_image":                  "registry/heph-httpx-worker:latest",
+	})
+	cfg := core.DeployConfig{
+		Cloud:       cloud.KindHetzner,
+		ToolName:    "httpx",
+		WorkerCount: 10,
+	}
+
+	infraOut := coreInfraOutputsFromTerraform(cfg, decoded, false)
+	if infraOut.FleetWorkerCount != 3 || infraOut.SQSQueueURL != "heph-tasks" || infraOut.S3BucketName != "heph-results" {
+		t.Fatalf("provider-native runtime outputs not mapped: %#v", infraOut)
+	}
+	if !infraOut.S3PathStyle || infraOut.S3Endpoint != "https://ctrl:9000" || infraOut.S3AccessKey != "ak" || infraOut.S3SecretKey != "sk" {
+		t.Fatalf("provider-native storage outputs not mapped: %#v", infraOut)
+	}
+	if infraOut.ControllerIP != "203.0.113.10" || infraOut.GenerationID != "gen-1" || infraOut.NATSUrl != "nats://ctrl:4222" {
+		t.Fatalf("fleet metadata not mapped: %#v", infraOut)
+	}
+	if infraOut.NATSClientCertPEM != "operator-cert" || infraOut.NATSClientKeyPEM != "operator-key" {
+		t.Fatalf("NATS identity not mapped: %q/%q", infraOut.NATSClientCertPEM, infraOut.NATSClientKeyPEM)
+	}
+	if infraOut.ExpectedWorkerVersion != "registry/heph-httpx-worker:latest" {
+		t.Fatalf("ExpectedWorkerVersion = %q", infraOut.ExpectedWorkerVersion)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds a typed Terraform output contract in internal/infra while preserving the raw map boundary for compatibility.
- Centralizes Terraform output key constants and parsing helpers for strings, bools, ints, and list-like Terraform output values.
- Collapses duplicated provider-native required output lists into one shared Hetzner/Linode/Vultr contract.
- Migrates lifecycle probing, provider-native runtime setup, cloud factory conversion, and TUI deploy navigation onto the typed output boundary.

## Commits
- refactor(infra): add typed terraform output contracts
- refactor(infra): use typed outputs for lifecycle validation
- refactor(runtime): consume typed provider-native outputs
- refactor(tui): map deploy outputs through typed contract

## Validation
- make fmt-check
- env GOCACHE=/tmp/heph-go-build make vet
- env GOCACHE=/tmp/heph-go-build make test
- env XDG_CACHE_HOME=/tmp/heph-cache GOCACHE=/tmp/heph-go-build make lint
- git diff --check

## Notes
- Terraform output names are unchanged.
- ProbeResult.Outputs and other raw map compatibility boundaries remain intact.
- This PR intentionally avoids scan orchestration, TUI status, and command package restructuring; those remain later Phase 12 work.
- Existing untracked local roadmap/docs artifacts were left out of this branch.