### PR TITLE
PR 12.3: Shared scan runtime

### DIFF
--- a/cmd/heph/cmd_lifecycle_test.go
+++ b/cmd/heph/cmd_lifecycle_test.go
@@ -13,6 +13,7 @@ import (
 
 	"heph4estus/internal/cloud"
 	"heph4estus/internal/fleet"
+	"heph4estus/internal/infra"
 	"heph4estus/internal/modules"
 	"heph4estus/internal/operator"
 	nmaptool "heph4estus/internal/tools/nmap"
@@ -102,6 +103,10 @@ func testOutputs() map[string]string {
 		"ami_id":               "ami-123",
 		"instance_profile_arn": "profile-arn",
 	}
+}
+
+func testRuntimeOutputs(kind cloud.Kind, outputs map[string]string) infra.TerraformOutputs {
+	return infra.DecodeTerraformOutputs(kind, outputs)
 }
 
 func writeTargetFile(t *testing.T, content string) string {
@@ -241,7 +246,7 @@ func TestRunTargetListScanStartedFalseOnLaunchFailure(t *testing.T) {
 		&mockQueue{},
 		&mockStorage{},
 		&mockCompute{runContainerErr: errors.New("launch failed")},
-		testOutputs(),
+		testRuntimeOutputs(cloud.KindAWS, testOutputs()),
 		"results-bucket",
 		"queue-url",
 		operator.NoopTracker(),
@@ -276,7 +281,7 @@ func TestRunTargetListScanStartedTrueOnOutputFailure(t *testing.T) {
 		&mockQueue{},
 		&mockStorage{count: 1, listErr: errors.New("list failed")},
 		&mockCompute{},
-		testOutputs(),
+		testRuntimeOutputs(cloud.KindAWS, testOutputs()),
 		"results-bucket",
 		"queue-url",
 		operator.NoopTracker(),
@@ -314,7 +319,7 @@ func TestRunTargetListScanUploadsChunksForInputModules(t *testing.T) {
 		queue,
 		storage,
 		&mockCompute{},
-		testOutputs(),
+		testRuntimeOutputs(cloud.KindAWS, testOutputs()),
 		"results-bucket",
 		"queue-url",
 		operator.NoopTracker(),
@@ -359,7 +364,7 @@ func TestRunNmapScanWithDepsStartedFalseOnLaunchFailure(t *testing.T) {
 		"fargate",
 		0,
 		"text",
-		testOutputs(),
+		testRuntimeOutputs(cloud.KindAWS, testOutputs()),
 		&mockQueue{},
 		&mockStorage{},
 		&mockCompute{runContainerErr: errors.New("launch failed")},
@@ -393,7 +398,7 @@ func TestRunNmapScanWithDepsBatchesLargeEnqueue(t *testing.T) {
 		"fargate",
 		0,
 		"text",
-		testOutputs(),
+		testRuntimeOutputs(cloud.KindAWS, testOutputs()),
 		queue,
 		&mockStorage{count: len(tasks)},
 		&mockCompute{},
@@ -451,7 +456,7 @@ func TestRunNmapScanWithDepsStartedTrueOnOutputFailure(t *testing.T) {
 		"fargate",
 		0,
 		"text",
-		testOutputs(),
+		testRuntimeOutputs(cloud.KindAWS, testOutputs()),
 		&mockQueue{},
 		&mockStorage{count: 1, listErr: errors.New("list failed")},
 		&mockCompute{},
@@ -488,10 +493,10 @@ func TestRunNmapScanWithDeps_ProviderNativeSkipsRunContainer(t *testing.T) {
 		"auto", // auto on VPS providers should NOT use spot
 		0,
 		"text",
-		map[string]string{
+		testRuntimeOutputs(cloud.KindHetzner, map[string]string{
 			"sqs_queue_url":  "nats-stream",
 			"s3_bucket_name": "minio-bucket",
-		},
+		}),
 		&mockQueue{},
 		&mockStorage{count: 1},
 		comp,
@@ -530,10 +535,10 @@ func TestRunNmapScanWithDeps_SelfhostedNeverCallsSpot(t *testing.T) {
 		"auto",
 		0,
 		"text",
-		map[string]string{
+		testRuntimeOutputs(cloud.KindManual, map[string]string{
 			"sqs_queue_url":  "nats-stream",
 			"s3_bucket_name": "minio-bucket",
-		},
+		}),
 		&mockQueue{},
 		&mockStorage{count: 1},
 		comp,
@@ -580,12 +585,12 @@ func TestRunTargetListScan_ProviderNativeSkipsRunContainer(t *testing.T) {
 		&mockQueue{},
 		&mockStorage{count: 1},
 		comp,
-		map[string]string{
+		testRuntimeOutputs(cloud.KindHetzner, map[string]string{
 			"sqs_queue_url":  "heph-tasks",
 			"s3_bucket_name": "heph-results",
 			"nats_url":       "nats://10.0.1.2:4222",
 			"worker_count":   "3",
-		},
+		}),
 		"heph-results",
 		"heph-tasks",
 		operator.NoopTracker(),

--- a/cmd/heph/cmd_nmap.go
+++ b/cmd/heph/cmd_nmap.go
@@ -8,25 +8,16 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"heph4estus/internal/cloud"
-	awscloud "heph4estus/internal/cloud/aws"
-	"heph4estus/internal/cloud/factory"
 	"heph4estus/internal/fleet"
 	"heph4estus/internal/infra"
 	"heph4estus/internal/jobs"
 	"heph4estus/internal/logger"
 	"heph4estus/internal/operator"
+	"heph4estus/internal/scanruntime"
 	"heph4estus/internal/tools/nmap"
 	"heph4estus/internal/worker"
-)
-
-const (
-	spotThreshold  = 50
-	pollInterval   = 2 * time.Second
-	enqueueTimeout = 5 * time.Minute
-	launchTimeout  = 5 * time.Minute
 )
 
 func runNmap(args []string, log logger.Logger) error {
@@ -143,187 +134,91 @@ func runNmap(args []string, log logger.Logger) error {
 	}
 
 	ctx := mainContext()
+	env, err := scanruntime.Setup(ctx, scanruntime.SetupOptions{
+		ToolName:  "nmap",
+		CloudKind: cloudKind,
+		Workers:   *workers,
+		LifecyclePolicy: infra.LifecyclePolicy{
+			NoDeploy:     *noDeploy,
+			AutoApprove:  *autoApprove,
+			DestroyAfter: *destroyAfter,
+		},
+		PromptFunc: deployPrompt,
+		Stream:     os.Stderr,
+		Log:        log,
+	})
+	if err != nil {
+		return err
+	}
 
 	// Track the job.
 	tracker := newTracker()
-	cleanupPolicy := "reuse"
-	if *destroyAfter {
-		cleanupPolicy = "destroy-after"
-	}
-
-	var (
-		outputs map[string]string
-		bucket  string
-		reused  bool
-		toolCfg *infra.ToolConfig
-	)
-
-	if cloudKind.IsProviderNative() {
-		// Provider-native (Hetzner): Terraform deploy + selfhosted runtime.
-		toolCfg, err = infra.ResolveToolConfig("nmap", cloudKind)
-		if err != nil {
-			return err
-		}
-		toolCfg.TerraformVars["worker_count"] = strconv.Itoa(*workers)
-		ensureResult, ensureErr := infra.EnsureInfra(ctx, toolCfg, infra.LifecyclePolicy{
-			NoDeploy:     *noDeploy,
-			AutoApprove:  *autoApprove,
-			DestroyAfter: *destroyAfter,
-		}, "", os.Stderr, deployPrompt, log)
-		if ensureErr != nil {
-			return ensureErr
-		}
-		outputs = ensureResult.Outputs
-		reused = ensureResult.Reused
-		bucket = outputs["s3_bucket_name"]
-	} else if cloudKind.IsSelfhostedFamily() {
-		// Manual selfhosted: no Terraform/deploy — read queue ID and bucket from env.
-		shCfg := factory.SelfhostedConfigFromEnv()
-		if shCfg.QueueID == "" || shCfg.Bucket == "" {
-			return fmt.Errorf("%s requires SELFHOSTED_QUEUE_ID and SELFHOSTED_BUCKET environment variables", cloudKind.Canonical())
-		}
-		bucket = shCfg.Bucket
-		outputs = map[string]string{
-			"sqs_queue_url":  shCfg.QueueID,
-			"s3_bucket_name": shCfg.Bucket,
-		}
-	} else {
-		// AWS: resolve tool config and ensure infrastructure.
-		toolCfg, err = infra.ResolveToolConfig("nmap")
-		if err != nil {
-			return err
-		}
-		region := infra.AWSRegion()
-		ensureResult, ensureErr := infra.EnsureInfra(ctx, toolCfg, infra.LifecyclePolicy{
-			NoDeploy:     *noDeploy,
-			AutoApprove:  *autoApprove,
-			DestroyAfter: *destroyAfter,
-		}, region, os.Stderr, deployPrompt, log)
-		if ensureErr != nil {
-			return ensureErr
-		}
-		outputs = ensureResult.Outputs
-		reused = ensureResult.Reused
-		bucket = outputs["s3_bucket_name"]
-	}
-
-	_ = tracker.Create(&operator.JobRecord{
-		JobID:                 jobID,
-		ToolName:              "nmap",
-		Phase:                 operator.PhaseEnqueuing,
-		TotalTasks:            len(tasks),
-		WorkerCount:           *workers,
-		ComputeMode:           *computeMode,
-		Cloud:                 string(cloudKind),
-		CleanupPolicy:         cleanupPolicy,
-		Bucket:                bucket,
-		S3Endpoint:            outputs["s3_endpoint"],
-		S3Region:              outputs["s3_region"],
-		S3AccessKey:           outputs["s3_access_key"],
-		S3SecretKey:           outputs["s3_secret_key"],
-		S3PathStyle:           outputBool(outputs["s3_path_style"]),
-		Placement:             placementPolicy,
-		ExpectedWorkerVersion: outputs["docker_image"],
-		NATSUrl:               outputs["nats_url"],
-		ControllerIP:          outputs["controller_ip"],
-		GenerationID:          outputs["generation_id"],
-		ControllerCAPEM:       outputs["controller_ca_pem"],
-		ControllerHost:        outputs["controller_host"],
-		NATSClientCertPEM:     outputs["nats_operator_client_cert_pem"],
-		NATSClientKeyPEM:      outputs["nats_operator_client_key_pem"],
+	cleanupPolicy := scanruntime.CleanupPolicy(*destroyAfter)
+	_ = scanruntime.CreateJobRecord(scanruntime.JobRecordOptions{
+		Tracker:       tracker,
+		JobID:         jobID,
+		ToolName:      "nmap",
+		TotalTasks:    len(tasks),
+		Workers:       *workers,
+		ComputeMode:   *computeMode,
+		CloudKind:     cloudKind,
+		CleanupPolicy: cleanupPolicy,
+		Bucket:        env.Bucket,
+		Outputs:       env.Outputs,
+		Placement:     placementPolicy,
 	})
 
 	// Run the scan.
-	started, scanErr := runNmapScan(ctx, tasks, *workers, *computeMode, *jitterMax, *format, outputs, log, tracker, jobID, placementPolicy, cloudKind)
-
-	if scanErr != nil {
-		_ = tracker.Fail(jobID, scanErr)
-	} else if started {
-		_ = tracker.Complete(jobID)
+	var (
+		provider cloud.Provider
+		scanErr  error
+		started  bool
+	)
+	provider, err = scanruntime.BuildProvider(ctx, scanruntime.ProviderOptions{
+		CloudKind:       cloudKind,
+		Outputs:         env.Outputs,
+		Log:             log,
+		ProviderBuilder: buildRuntimeProvider,
+	})
+	if err != nil {
+		scanErr = fmt.Errorf("building cloud provider: %w", err)
+	} else {
+		started, scanErr = runNmapScanWithDeps(ctx, tasks, *workers, *computeMode, *jitterMax, *format, env.Outputs, provider.Queue(), provider.Storage(), provider.Compute(), tracker, jobID, placementPolicy, cloudKind)
 	}
 
-	// Export results locally before any cleanup.
-	var exportDir string
-	if *outDir != "" && scanErr == nil && started {
-		logStatus("Exporting results to %s...", *outDir)
-
-		exportProvider, provErr := buildRuntimeProvider(ctx, cloudKind, outputs, log)
-		if provErr != nil {
-			return fmt.Errorf("building cloud provider for export: %w", provErr)
-		}
-		storage := exportProvider.Storage()
-
-		result, exportErr := operator.ExportJob(ctx, storage, bucket, "nmap", jobID, *outDir)
-		if exportErr != nil {
-			return fmt.Errorf("export failed: %w", exportErr)
-		}
-		exportDir = result.Dir
-		logStatus("Exported %d results, %d artifacts to %s", result.ResultCount, result.ArtifactCount, result.Dir)
-
-		// Record the local output path in the job record.
-		if store := tracker.Store(); store != nil {
-			if rec, loadErr := store.Load(jobID); loadErr == nil {
-				rec.LocalOutputDir = result.Dir
-				_ = store.Update(rec)
-			}
-		}
+	var storage cloud.Storage
+	if provider != nil {
+		storage = provider.Storage()
 	}
-
-	// Destroy only after execution has actually started and export is done.
-	if *destroyAfter && started {
-		if cloudKind.IsSelfhostedFamily() && !cloudKind.IsProviderNative() {
-			logStatus("Skipping destroy: %s does not support auto-destroy", cloudKind.Canonical())
-		} else if toolCfg != nil {
-			logStatus("Destroying infrastructure (--destroy-after)...")
-			if destroyErr := infra.RunDestroy(ctx, toolCfg, os.Stderr, log); destroyErr != nil {
-				if scanErr != nil {
-					return fmt.Errorf("scan failed: %w; additionally, destroy failed: %v", scanErr, destroyErr)
-				}
-				return fmt.Errorf("scan completed but destroy failed: %w", destroyErr)
-			}
-		}
+	finalized, finalizeErr := scanruntime.Finalize(ctx, scanruntime.FinalizeOptions{
+		JobID:        jobID,
+		ToolName:     "nmap",
+		Tracker:      tracker,
+		Started:      started,
+		ScanErr:      scanErr,
+		OutDir:       *outDir,
+		Storage:      storage,
+		Bucket:       env.Bucket,
+		DestroyAfter: *destroyAfter,
+		CloudKind:    cloudKind,
+		ToolConfig:   env.ToolConfig,
+		Stream:       os.Stderr,
+		Log:          log,
+		Statusf:      logStatus,
+	})
+	if finalizeErr != nil {
+		return finalizeErr
 	}
 
 	// Print run summary.
 	if started {
-		printRunSummary(jobID, "nmap", reused, cleanupPolicy, exportDir)
+		printRunSummary(jobID, "nmap", env.Reused, cleanupPolicy, finalized.ExportDir)
 	}
 
 	return scanErr
 }
 
-func runNmapScan(ctx context.Context, tasks []nmap.ScanTask, workers int, computeMode string, jitterMax int, format string, outputs map[string]string, log logger.Logger, tracker *operator.Tracker, jobID string, placementPolicy fleet.PlacementPolicy, cloudKind cloud.Kind) (bool, error) {
-	queueURL := outputs["sqs_queue_url"]
-	bucket := outputs["s3_bucket_name"]
-	if queueURL == "" || bucket == "" {
-		return false, fmt.Errorf("terraform outputs missing sqs_queue_url or s3_bucket_name")
-	}
-
-	// Build the cloud provider. For provider-native paths, use Terraform
-	// outputs as the config source rather than environment variables.
-	var (
-		provider cloud.Provider
-		provErr  error
-	)
-	provider, provErr = buildRuntimeProvider(ctx, cloudKind, outputs, log)
-	if provErr != nil {
-		return false, fmt.Errorf("building cloud provider: %w", provErr)
-	}
-	return runNmapScanWithDeps(ctx, tasks, workers, computeMode, jitterMax, format, outputs, provider.Queue(), provider.Storage(), provider.Compute(), tracker, jobID, placementPolicy, cloudKind)
-}
-
-func runNmapScanWithDeps(ctx context.Context, tasks []nmap.ScanTask, workers int, computeMode string, jitterMax int, format string, outputs map[string]string, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, tracker *operator.Tracker, jobID string, placementPolicy fleet.PlacementPolicy, cloudKind ...cloud.Kind) (bool, error) {
-	queueURL := outputs["sqs_queue_url"]
-	bucket := outputs["s3_bucket_name"]
-	if queueURL == "" || bucket == "" {
-		return false, fmt.Errorf("terraform outputs missing sqs_queue_url or s3_bucket_name")
-	}
-
-	// Enqueue targets.
-	logStatus("Enqueueing %d targets...", len(tasks))
-	enqueueCtx, enqueueCancel := context.WithTimeout(ctx, enqueueTimeout)
-	defer enqueueCancel()
-
+func runNmapScanWithDeps(ctx context.Context, tasks []nmap.ScanTask, workers int, computeMode string, jitterMax int, format string, outputs infra.TerraformOutputs, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, tracker *operator.Tracker, jobID string, placementPolicy fleet.PlacementPolicy, cloudKind ...cloud.Kind) (bool, error) {
 	genericTasks := make([]worker.Task, len(tasks))
 	for i, t := range tasks {
 		genericTasks[i] = worker.Task{
@@ -336,111 +231,49 @@ func runNmapScanWithDeps(ctx context.Context, tasks []nmap.ScanTask, workers int
 			TotalChunks: t.TotalChunks,
 		}
 	}
-	enqueueResult, err := jobs.EnqueueTasks(enqueueCtx, queue, queueURL, genericTasks, jobs.EnqueueOptions{})
-	if err != nil {
-		return false, fmt.Errorf("enqueueing targets: %w", err)
+
+	kind := cloud.KindAWS
+	if len(cloudKind) > 0 {
+		kind = cloudKind[0]
 	}
-	logStatus("Enqueued %d targets", enqueueResult.SentTasks)
-
-	_ = tracker.UpdatePhase(jobID, operator.PhaseLaunching)
-
-	// Launch workers.
-	logStatus("Launching %d workers (mode: %s)...", workers, computeMode)
-	launchCtx, launchCancel := context.WithTimeout(ctx, launchTimeout)
-	defer launchCancel()
-
-	if len(cloudKind) > 0 && cloudKind[0].IsProviderNative() {
-		ready, err := waitForProviderNativeFleetFunc(launchCtx, cloudKind[0], outputs, placementPolicy)
-		if err != nil {
-			return false, err
-		}
-		logStatus("Using provider-native %s fleet (%d eligible workers, policy: %s)", cloudKind[0].Canonical(), ready, placementPolicy.Summary())
-	} else {
-		containerName := "nmap-worker"
-		workerEnv := map[string]string{
+	queueURL := outputs.AWS.SQSQueueURL
+	if queueURL == "" {
+		queueURL = outputs.Selfhosted.QueueURL
+	}
+	bucket := outputs.AWS.S3BucketName
+	if bucket == "" {
+		bucket = outputs.Selfhosted.S3BucketName
+	}
+	return scanruntime.ExecuteQueuedScan(ctx, scanruntime.ExecuteOptions{
+		ToolName:     "nmap",
+		JobID:        jobID,
+		Tasks:        genericTasks,
+		EnqueueLabel: "targets",
+		Workers:      workers,
+		ComputeMode:  computeMode,
+		Queue:        queue,
+		Storage:      storage,
+		Compute:      compute,
+		Outputs:      outputs,
+		QueueURL:     queueURL,
+		Bucket:       bucket,
+		CloudKind:    kind,
+		Placement:    placementPolicy,
+		Tracker:      tracker,
+		WorkerEnv: map[string]string{
 			"QUEUE_URL":          queueURL,
 			"S3_BUCKET":          bucket,
 			"JITTER_MAX_SECONDS": strconv.Itoa(jitterMax),
 			"TOOL_NAME":          "nmap",
-		}
-
-		// Selfhosted only supports RunContainer (no spot instances).
-		isSelfhosted := len(cloudKind) > 0 && cloudKind[0].IsSelfhostedFamily()
-		useSpot := !isSelfhosted && resolveComputeMode(computeMode, workers)
-		if useSpot {
-			ecrURL := outputs["ecr_repo_url"]
-			imageTag, err := awsImageTagFromOutputs(outputs)
-			if err != nil {
-				return false, err
-			}
-			userData := awscloud.GenerateUserData(awscloud.UserDataOpts{
-				ECRRepoURL: ecrURL,
-				ImageTag:   imageTag,
-				Region:     regionFromECR(ecrURL),
-				EnvVars:    workerEnv,
-			})
-			ids, err := compute.RunSpotInstances(launchCtx, cloud.SpotOpts{
-				AMI:             outputs["ami_id"],
-				Count:           workers,
-				SecurityGroups:  []string{outputs["security_group_id"]},
-				SubnetIDs:       splitOutputList(outputs["subnet_ids"]),
-				InstanceProfile: outputs["instance_profile_arn"],
-				UserData:        userData,
-				Tags: map[string]string{
-					"Project": "heph4estus",
-					"Tool":    "nmap",
-				},
-			})
-			if err != nil {
-				return false, fmt.Errorf("launching spot instances: %w", err)
-			}
-			logStatus("Launched %d spot instances", len(ids))
-		} else {
-			_, err := compute.RunContainer(launchCtx, cloud.ContainerOpts{
-				Cluster:        outputs["ecs_cluster_name"],
-				TaskDefinition: outputs["task_definition_arn"],
-				ContainerName:  containerName,
-				Subnets:        splitOutputList(outputs["subnet_ids"]),
-				SecurityGroups: []string{outputs["security_group_id"]},
-				Env:            workerEnv,
-				Count:          workers,
-			})
-			if err != nil {
-				return false, fmt.Errorf("launching workers: %w", err)
-			}
-			logStatus("Launched %d workers", workers)
-		}
-	}
-
-	_ = tracker.UpdatePhase(jobID, operator.PhaseScanning)
-
-	// Poll for progress.
-	logStatus("Scanning...")
-	startTime := time.Now()
-	totalTargets := len(tasks)
-	scanPrefix := jobs.ResultPrefix("nmap", jobID)
-
-	for {
-		count, err := storage.Count(ctx, bucket, scanPrefix)
-		if err != nil {
-			logStatus("Warning: progress check failed: %v", err)
-		} else {
-			elapsed := time.Since(startTime).Truncate(time.Second)
-			pct := float64(count) / float64(totalTargets) * 100
-			logStatus("Progress: %d/%d (%.1f%%) — elapsed %s", count, totalTargets, pct, elapsed)
-
-			if count >= totalTargets {
-				break
-			}
-		}
-		time.Sleep(pollInterval)
-	}
-
-	elapsed := time.Since(startTime).Truncate(time.Second)
-	logStatus("Scan complete: %d targets in %s", totalTargets, elapsed)
-
-	// Output results.
-	return true, outputResults(ctx, storage, bucket, scanPrefix, format)
+		},
+		ContainerName: "nmap-worker",
+		CompleteLabel: "targets",
+		RenderResults: func(renderCtx context.Context, renderStorage cloud.Storage, renderBucket, prefix string) error {
+			return outputResults(renderCtx, renderStorage, renderBucket, prefix, format)
+		},
+		Statusf:     logStatus,
+		FleetWaiter: waitForProviderNativeFleetFunc,
+	})
 }
 
 func outputResults(ctx context.Context, storage cloud.Storage, bucket, prefix, format string) error {
@@ -486,25 +319,12 @@ func outputResults(ctx context.Context, storage cloud.Storage, bucket, prefix, f
 }
 
 func resolveComputeMode(mode string, workers int) bool {
-	switch mode {
-	case "spot":
-		return true
-	case "fargate":
-		return false
-	default: // "auto"
-		return workers >= spotThreshold
-	}
+	return scanruntime.ResolveComputeMode(mode, workers)
 }
 
 // regionFromECR extracts the AWS region from an ECR repo URL.
 func regionFromECR(url string) string {
-	parts := strings.Split(url, ".")
-	for i, p := range parts {
-		if p == "ecr" && i+1 < len(parts) {
-			return parts[i+1]
-		}
-	}
-	return "us-east-1"
+	return scanruntime.RegionFromECR(url)
 }
 
 func extractTargetFromKey(key string) string {
@@ -522,16 +342,7 @@ func countGroups(tasks []nmap.ScanTask) int {
 }
 
 func splitOutputList(s string) []string {
-	s = strings.Trim(s, "[]")
-	parts := strings.Split(s, " ")
-	var result []string
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			result = append(result, p)
-		}
-	}
-	return result
+	return scanruntime.SplitOutputList(s)
 }
 
 // logStatus prints a status line to stderr (keeps stdout clean for results).

--- a/cmd/heph/cmd_scan.go
+++ b/cmd/heph/cmd_scan.go
@@ -8,17 +8,15 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"heph4estus/internal/cloud"
-	awscloud "heph4estus/internal/cloud/aws"
-	"heph4estus/internal/cloud/factory"
 	"heph4estus/internal/fleet"
 	"heph4estus/internal/infra"
 	"heph4estus/internal/jobs"
 	"heph4estus/internal/logger"
 	"heph4estus/internal/modules"
 	"heph4estus/internal/operator"
+	"heph4estus/internal/scanruntime"
 	targetlisttool "heph4estus/internal/tools/targetlist"
 	wordlisttool "heph4estus/internal/tools/wordlist"
 	"heph4estus/internal/worker"
@@ -144,73 +142,29 @@ func runScan(args []string, log logger.Logger) error {
 	}
 
 	ctx := mainContext()
-
-	var (
-		queueURL string
-		bucket   string
-		outputs  map[string]string
-		reused   bool
-		toolCfg  *infra.ToolConfig
-	)
-
-	if cloudKind.IsProviderNative() {
-		// Provider-native (Hetzner): Terraform deploy + selfhosted runtime.
-		toolCfg, err = infra.ResolveToolConfig(*tool, cloudKind)
-		if err != nil {
-			return err
-		}
-		toolCfg.TerraformVars["worker_count"] = strconv.Itoa(*workers)
-		ensureResult, ensureErr := infra.EnsureInfra(ctx, toolCfg, infra.LifecyclePolicy{
+	env, err := scanruntime.Setup(ctx, scanruntime.SetupOptions{
+		ToolName:  *tool,
+		CloudKind: cloudKind,
+		Workers:   *workers,
+		LifecyclePolicy: infra.LifecyclePolicy{
 			NoDeploy:     *noDeploy,
 			AutoApprove:  *autoApprove,
 			DestroyAfter: *destroyAfter,
-		}, "", os.Stderr, deployPrompt, log)
-		if ensureErr != nil {
-			return ensureErr
-		}
-		outputs = ensureResult.Outputs
-		reused = ensureResult.Reused
-		queueURL = outputs["sqs_queue_url"]
-		bucket = outputs["s3_bucket_name"]
-		if queueURL == "" || bucket == "" {
-			return fmt.Errorf("terraform outputs missing sqs_queue_url or s3_bucket_name")
-		}
-	} else if cloudKind.IsSelfhostedFamily() {
-		// Manual selfhosted: no Terraform/deploy — read queue ID and bucket from env.
-		shCfg := factory.SelfhostedConfigFromEnv()
-		queueURL = shCfg.QueueID
-		bucket = shCfg.Bucket
-		if queueURL == "" || bucket == "" {
-			return fmt.Errorf("%s requires SELFHOSTED_QUEUE_ID and SELFHOSTED_BUCKET environment variables", cloudKind.Canonical())
-		}
-	} else {
-		// AWS: resolve tool config and ensure infrastructure.
-		toolCfg, err = infra.ResolveToolConfig(*tool)
-		if err != nil {
-			return err
-		}
-		region := infra.AWSRegion()
-		ensureResult, ensureErr := infra.EnsureInfra(ctx, toolCfg, infra.LifecyclePolicy{
-			NoDeploy:     *noDeploy,
-			AutoApprove:  *autoApprove,
-			DestroyAfter: *destroyAfter,
-		}, region, os.Stderr, deployPrompt, log)
-		if ensureErr != nil {
-			return ensureErr
-		}
-		outputs = ensureResult.Outputs
-		reused = ensureResult.Reused
-		queueURL = outputs["sqs_queue_url"]
-		bucket = outputs["s3_bucket_name"]
-		if queueURL == "" || bucket == "" {
-			return fmt.Errorf("terraform outputs missing sqs_queue_url or s3_bucket_name")
-		}
+		},
+		PromptFunc: deployPrompt,
+		Stream:     os.Stderr,
+		Log:        log,
+	})
+	if err != nil {
+		return err
 	}
 
-	// Build the cloud provider. For provider-native paths, use Terraform
-	// outputs as the config source rather than environment variables.
-	var provider cloud.Provider
-	provider, err = buildRuntimeProvider(ctx, cloudKind, outputs, log)
+	provider, err := scanruntime.BuildProvider(ctx, scanruntime.ProviderOptions{
+		CloudKind:       cloudKind,
+		Outputs:         env.Outputs,
+		Log:             log,
+		ProviderBuilder: buildRuntimeProvider,
+	})
 	if err != nil {
 		return fmt.Errorf("building cloud provider: %w", err)
 	}
@@ -222,33 +176,18 @@ func runScan(args []string, log logger.Logger) error {
 
 	// Track the job.
 	tracker := newTracker()
-	cleanupPolicy := "reuse"
-	if *destroyAfter {
-		cleanupPolicy = "destroy-after"
-	}
-	_ = tracker.Create(&operator.JobRecord{
-		JobID:                 jobID,
-		ToolName:              *tool,
-		Phase:                 operator.PhaseEnqueuing,
-		WorkerCount:           *workers,
-		ComputeMode:           *computeMode,
-		Cloud:                 string(cloudKind),
-		CleanupPolicy:         cleanupPolicy,
-		Bucket:                bucket,
-		S3Endpoint:            outputs["s3_endpoint"],
-		S3Region:              outputs["s3_region"],
-		S3AccessKey:           outputs["s3_access_key"],
-		S3SecretKey:           outputs["s3_secret_key"],
-		S3PathStyle:           outputBool(outputs["s3_path_style"]),
-		Placement:             placementPolicy,
-		ExpectedWorkerVersion: outputs["docker_image"],
-		NATSUrl:               outputs["nats_url"],
-		ControllerIP:          outputs["controller_ip"],
-		GenerationID:          outputs["generation_id"],
-		ControllerCAPEM:       outputs["controller_ca_pem"],
-		ControllerHost:        outputs["controller_host"],
-		NATSClientCertPEM:     outputs["nats_operator_client_cert_pem"],
-		NATSClientKeyPEM:      outputs["nats_operator_client_key_pem"],
+	cleanupPolicy := scanruntime.CleanupPolicy(*destroyAfter)
+	_ = scanruntime.CreateJobRecord(scanruntime.JobRecordOptions{
+		Tracker:       tracker,
+		JobID:         jobID,
+		ToolName:      *tool,
+		Workers:       *workers,
+		ComputeMode:   *computeMode,
+		CloudKind:     cloudKind,
+		CleanupPolicy: cleanupPolicy,
+		Bucket:        env.Bucket,
+		Outputs:       env.Outputs,
+		Placement:     placementPolicy,
 	})
 
 	var (
@@ -256,61 +195,40 @@ func runScan(args []string, log logger.Logger) error {
 		started bool
 	)
 	if mod.InputType == modules.InputTypeWordlist {
-		started, scanErr = runWordlistScan(ctx, *tool, jobID, *wordlistFile, wordlistMeta, *runtimeTarget, *options, *chunks, *workers, *computeMode, *format, queue, storage, compute, outputs, bucket, queueURL, tracker, cloudKind, placementPolicy)
+		started, scanErr = runWordlistScan(ctx, *tool, jobID, *wordlistFile, wordlistMeta, *runtimeTarget, *options, *chunks, *workers, *computeMode, *format, queue, storage, compute, env.Outputs, env.Bucket, env.QueueURL, tracker, cloudKind, placementPolicy)
 	} else {
-		started, scanErr = runTargetListScan(ctx, *tool, jobID, *inputFile, targetMeta, mod, *options, *workers, *computeMode, *format, queue, storage, compute, outputs, bucket, queueURL, tracker, cloudKind, placementPolicy)
+		started, scanErr = runTargetListScan(ctx, *tool, jobID, *inputFile, targetMeta, mod, *options, *workers, *computeMode, *format, queue, storage, compute, env.Outputs, env.Bucket, env.QueueURL, tracker, cloudKind, placementPolicy)
 	}
 
-	if scanErr != nil {
-		_ = tracker.Fail(jobID, scanErr)
-	} else if started {
-		_ = tracker.Complete(jobID)
-	}
-
-	// Export results locally before any cleanup.
-	var exportDir string
-	if *outDir != "" && scanErr == nil && started {
-		logStatus("Exporting results to %s...", *outDir)
-		result, exportErr := operator.ExportJob(ctx, storage, bucket, *tool, jobID, *outDir)
-		if exportErr != nil {
-			return fmt.Errorf("export failed: %w", exportErr)
-		}
-		exportDir = result.Dir
-		logStatus("Exported %d results, %d artifacts to %s", result.ResultCount, result.ArtifactCount, result.Dir)
-
-		// Record the local output path in the job record.
-		if store := tracker.Store(); store != nil {
-			if rec, loadErr := store.Load(jobID); loadErr == nil {
-				rec.LocalOutputDir = result.Dir
-				_ = store.Update(rec)
-			}
-		}
-	}
-
-	// Destroy only after execution has actually started and export is done.
-	if *destroyAfter && started {
-		if cloudKind.IsSelfhostedFamily() && !cloudKind.IsProviderNative() {
-			logStatus("Skipping destroy: %s does not support auto-destroy", cloudKind.Canonical())
-		} else if toolCfg != nil {
-			logStatus("Destroying infrastructure (--destroy-after)...")
-			if destroyErr := infra.RunDestroy(ctx, toolCfg, os.Stderr, log); destroyErr != nil {
-				if scanErr != nil {
-					return fmt.Errorf("scan failed: %w; additionally, destroy failed: %v", scanErr, destroyErr)
-				}
-				return fmt.Errorf("scan completed but destroy failed: %w", destroyErr)
-			}
-		}
+	finalized, finalizeErr := scanruntime.Finalize(ctx, scanruntime.FinalizeOptions{
+		JobID:        jobID,
+		ToolName:     *tool,
+		Tracker:      tracker,
+		Started:      started,
+		ScanErr:      scanErr,
+		OutDir:       *outDir,
+		Storage:      storage,
+		Bucket:       env.Bucket,
+		DestroyAfter: *destroyAfter,
+		CloudKind:    cloudKind,
+		ToolConfig:   env.ToolConfig,
+		Stream:       os.Stderr,
+		Log:          log,
+		Statusf:      logStatus,
+	})
+	if finalizeErr != nil {
+		return finalizeErr
 	}
 
 	// Print run summary.
 	if started {
-		printRunSummary(jobID, *tool, reused, cleanupPolicy, exportDir)
+		printRunSummary(jobID, *tool, env.Reused, cleanupPolicy, finalized.ExportDir)
 	}
 
 	return scanErr
 }
 
-func runTargetListScan(ctx context.Context, tool, jobID, inputFile string, preflight *targetlisttool.Metadata, mod *modules.ModuleDefinition, options string, workers int, computeMode, format string, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, outputs map[string]string, bucket, queueURL string, tracker *operator.Tracker, cloudKind cloud.Kind, placementPolicy fleet.PlacementPolicy) (bool, error) {
+func runTargetListScan(ctx context.Context, tool, jobID, inputFile string, preflight *targetlisttool.Metadata, mod *modules.ModuleDefinition, options string, workers int, computeMode, format string, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, outputs infra.TerraformOutputs, bucket, queueURL string, tracker *operator.Tracker, cloudKind cloud.Kind, placementPolicy fleet.PlacementPolicy) (bool, error) {
 	fileBacked := targetListUsesFileInput(mod)
 	var (
 		tempDir string
@@ -362,24 +280,13 @@ func runTargetListScan(ctx context.Context, tool, jobID, inputFile string, prefl
 	if plan.FileBacked {
 		_ = tracker.UpdatePhase(jobID, operator.PhaseUploading)
 		logStatus("Uploading %d target-list chunks to s3://%s/...", plan.EffectiveChunks, bucket)
-		uploadCtx, uploadCancel := context.WithTimeout(ctx, enqueueTimeout)
+		uploadCtx, uploadCancel := context.WithTimeout(ctx, scanruntime.EnqueueTimeout)
 		defer uploadCancel()
 		if err := jobs.UploadTargetListChunks(uploadCtx, storage, bucket, plan); err != nil {
 			return false, fmt.Errorf("uploading target-list chunks: %w", err)
 		}
 	}
 
-	// Enqueue targets.
-	_ = tracker.UpdatePhase(jobID, operator.PhaseEnqueuing)
-	logStatus("Enqueueing %d target tasks...", len(plan.Tasks))
-	enqueueCtx, enqueueCancel := context.WithTimeout(ctx, enqueueTimeout)
-	defer enqueueCancel()
-
-	enqueueResult, err := jobs.EnqueueTasks(enqueueCtx, queue, queueURL, plan.Tasks, jobs.EnqueueOptions{})
-	if err != nil {
-		return false, fmt.Errorf("enqueueing targets: %w", err)
-	}
-	logStatus("Enqueued %d target tasks", enqueueResult.SentTasks)
 	if plan.FileBacked {
 		if err := plan.Cleanup(); err != nil {
 			logStatus("Warning: failed to clean temporary target-list chunks: %v", err)
@@ -394,24 +301,38 @@ func runTargetListScan(ctx context.Context, tool, jobID, inputFile string, prefl
 			_ = store.Update(rec)
 		}
 	}
-	_ = tracker.UpdatePhase(jobID, operator.PhaseLaunching)
 
-	// Launch workers.
-	if err := launchGenericWorkers(ctx, tool, workers, computeMode, compute, outputs, queueURL, bucket, cloudKind, placementPolicy); err != nil {
-		return false, err
-	}
-
-	_ = tracker.UpdatePhase(jobID, operator.PhaseScanning)
-
-	// Poll for progress.
 	unitLabel := "targets"
 	if plan.FileBacked {
 		unitLabel = "chunks"
 	}
-	return true, pollAndOutput(ctx, storage, bucket, tool, jobID, len(plan.Tasks), unitLabel, format)
+	return scanruntime.ExecuteQueuedScan(ctx, scanruntime.ExecuteOptions{
+		ToolName:      tool,
+		JobID:         jobID,
+		Tasks:         plan.Tasks,
+		EnqueueLabel:  "target tasks",
+		Workers:       workers,
+		ComputeMode:   computeMode,
+		Queue:         queue,
+		Storage:       storage,
+		Compute:       compute,
+		Outputs:       outputs,
+		QueueURL:      queueURL,
+		Bucket:        bucket,
+		CloudKind:     cloudKind,
+		Placement:     placementPolicy,
+		Tracker:       tracker,
+		ProgressLabel: unitLabel,
+		CompleteLabel: unitLabel,
+		RenderResults: func(renderCtx context.Context, renderStorage cloud.Storage, renderBucket, prefix string) error {
+			return outputGenericResults(renderCtx, renderStorage, renderBucket, prefix, format)
+		},
+		Statusf:     logStatus,
+		FleetWaiter: waitForProviderNativeFleetFunc,
+	})
 }
 
-func runWordlistScan(ctx context.Context, tool, jobID, wordlistFile string, preflight *wordlisttool.Metadata, runtimeTarget, options string, chunks, workers int, computeMode, format string, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, outputs map[string]string, bucket, queueURL string, tracker *operator.Tracker, cloudKind cloud.Kind, placementPolicy fleet.PlacementPolicy) (bool, error) {
+func runWordlistScan(ctx context.Context, tool, jobID, wordlistFile string, preflight *wordlisttool.Metadata, runtimeTarget, options string, chunks, workers int, computeMode, format string, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, outputs infra.TerraformOutputs, bucket, queueURL string, tracker *operator.Tracker, cloudKind cloud.Kind, placementPolicy fleet.PlacementPolicy) (bool, error) {
 	if err := wordlisttool.CleanupStaleTempDirs(wordlisttool.DefaultStaleTempAge); err != nil {
 		logStatus("Warning: failed to clean stale wordlist temp dirs: %v", err)
 	}
@@ -471,38 +392,40 @@ func runWordlistScan(ctx context.Context, tool, jobID, wordlistFile string, pref
 
 	// Upload chunks.
 	logStatus("Uploading %d chunks to s3://%s/...", plan.EffectiveChunks, bucket)
-	uploadCtx, uploadCancel := context.WithTimeout(ctx, enqueueTimeout)
+	uploadCtx, uploadCancel := context.WithTimeout(ctx, scanruntime.EnqueueTimeout)
 	defer uploadCancel()
 	if err := jobs.UploadChunks(uploadCtx, storage, bucket, plan); err != nil {
 		return false, fmt.Errorf("uploading wordlist chunks: %w", err)
 	}
 
-	// Enqueue tasks.
-	_ = tracker.UpdatePhase(jobID, operator.PhaseEnqueuing)
-	logStatus("Enqueueing %d chunk tasks...", len(plan.Tasks))
-	enqueueCtx, enqueueCancel := context.WithTimeout(ctx, enqueueTimeout)
-	defer enqueueCancel()
-
-	enqueueResult, err := jobs.EnqueueTasks(enqueueCtx, queue, queueURL, plan.Tasks, jobs.EnqueueOptions{})
-	if err != nil {
-		return false, fmt.Errorf("enqueueing chunk tasks: %w", err)
-	}
-	logStatus("Enqueued %d chunk tasks", enqueueResult.SentTasks)
 	if err := plan.Cleanup(); err != nil {
 		logStatus("Warning: failed to clean temporary wordlist chunks: %v", err)
 	}
 
-	_ = tracker.UpdatePhase(jobID, operator.PhaseLaunching)
-
-	// Launch workers.
-	if err := launchGenericWorkers(ctx, tool, workers, computeMode, compute, outputs, queueURL, bucket, cloudKind, placementPolicy); err != nil {
-		return false, err
-	}
-
-	_ = tracker.UpdatePhase(jobID, operator.PhaseScanning)
-
-	// Poll for progress.
-	return true, pollAndOutput(ctx, storage, bucket, tool, jobID, len(plan.Tasks), "chunks", format)
+	return scanruntime.ExecuteQueuedScan(ctx, scanruntime.ExecuteOptions{
+		ToolName:      tool,
+		JobID:         jobID,
+		Tasks:         plan.Tasks,
+		EnqueueLabel:  "chunk tasks",
+		Workers:       workers,
+		ComputeMode:   computeMode,
+		Queue:         queue,
+		Storage:       storage,
+		Compute:       compute,
+		Outputs:       outputs,
+		QueueURL:      queueURL,
+		Bucket:        bucket,
+		CloudKind:     cloudKind,
+		Placement:     placementPolicy,
+		Tracker:       tracker,
+		ProgressLabel: "chunks",
+		CompleteLabel: "chunks",
+		RenderResults: func(renderCtx context.Context, renderStorage cloud.Storage, renderBucket, prefix string) error {
+			return outputGenericResults(renderCtx, renderStorage, renderBucket, prefix, format)
+		},
+		Statusf:     logStatus,
+		FleetWaiter: waitForProviderNativeFleetFunc,
+	})
 }
 
 func preflightTargetListFile(path string, workers int) (*targetlisttool.Metadata, error) {
@@ -530,103 +453,6 @@ func formatByteSize(n int64) string {
 		return fmt.Sprintf("%d MiB", n/mib)
 	}
 	return fmt.Sprintf("%d bytes", n)
-}
-
-func launchGenericWorkers(ctx context.Context, tool string, workers int, computeMode string, compute cloud.Compute, outputs map[string]string, queueURL, bucket string, cloudKind cloud.Kind, placementPolicy fleet.PlacementPolicy) error {
-	logStatus("Launching %d workers (mode: %s)...", workers, computeMode)
-	launchCtx, launchCancel := context.WithTimeout(ctx, launchTimeout)
-	defer launchCancel()
-
-	if cloudKind.IsProviderNative() {
-		ready, err := waitForProviderNativeFleetFunc(launchCtx, cloudKind, outputs, placementPolicy)
-		if err != nil {
-			return err
-		}
-		logStatus("Using provider-native %s fleet (%d eligible workers, policy: %s)", cloudKind.Canonical(), ready, placementPolicy.Summary())
-		return nil
-	}
-
-	containerName := fmt.Sprintf("%s-worker", tool)
-	workerEnv := map[string]string{
-		"QUEUE_URL": queueURL,
-		"S3_BUCKET": bucket,
-		"TOOL_NAME": tool,
-	}
-
-	// Selfhosted only supports RunContainer (no spot instances).
-	useSpot := !cloudKind.IsSelfhostedFamily() && resolveComputeMode(computeMode, workers)
-	if useSpot {
-		ecrURL := outputs["ecr_repo_url"]
-		imageTag, err := awsImageTagFromOutputs(outputs)
-		if err != nil {
-			return err
-		}
-		userData := awscloud.GenerateUserData(awscloud.UserDataOpts{
-			ECRRepoURL: ecrURL,
-			ImageTag:   imageTag,
-			Region:     regionFromECR(ecrURL),
-			EnvVars:    workerEnv,
-		})
-		ids, err := compute.RunSpotInstances(launchCtx, cloud.SpotOpts{
-			AMI:             outputs["ami_id"],
-			Count:           workers,
-			SecurityGroups:  []string{outputs["security_group_id"]},
-			SubnetIDs:       splitOutputList(outputs["subnet_ids"]),
-			InstanceProfile: outputs["instance_profile_arn"],
-			UserData:        userData,
-			Tags: map[string]string{
-				"Project": "heph4estus",
-				"Tool":    tool,
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("launching spot instances: %w", err)
-		}
-		logStatus("Launched %d spot instances", len(ids))
-	} else {
-		_, err := compute.RunContainer(launchCtx, cloud.ContainerOpts{
-			Cluster:        outputs["ecs_cluster_name"],
-			TaskDefinition: outputs["task_definition_arn"],
-			ContainerName:  containerName,
-			Subnets:        splitOutputList(outputs["subnet_ids"]),
-			SecurityGroups: []string{outputs["security_group_id"]},
-			Env:            workerEnv,
-			Count:          workers,
-		})
-		if err != nil {
-			return fmt.Errorf("launching workers: %w", err)
-		}
-		logStatus("Launched %d workers", workers)
-	}
-	return nil
-}
-
-func pollAndOutput(ctx context.Context, storage cloud.Storage, bucket, tool, jobID string, totalTasks int, unitLabel, format string) error {
-	logStatus("Scanning...")
-	startTime := time.Now()
-	scanPrefix := jobs.ResultPrefix(tool, jobID)
-
-	for {
-		count, err := storage.Count(ctx, bucket, scanPrefix)
-		if err != nil {
-			logStatus("Warning: progress check failed: %v", err)
-		} else {
-			elapsed := time.Since(startTime).Truncate(time.Second)
-			pct := float64(count) / float64(totalTasks) * 100
-			logStatus("Progress: %d/%d %s (%.1f%%) — elapsed %s", count, totalTasks, unitLabel, pct, elapsed)
-
-			if count >= totalTasks {
-				break
-			}
-		}
-		time.Sleep(pollInterval)
-	}
-
-	elapsed := time.Since(startTime).Truncate(time.Second)
-	logStatus("Scan complete: %d %s in %s", totalTasks, unitLabel, elapsed)
-
-	// Output results.
-	return outputGenericResults(ctx, storage, bucket, scanPrefix, format)
 }
 
 func outputGenericResults(ctx context.Context, storage cloud.Storage, bucket, prefix, format string) error {

--- a/cmd/heph/provider_runtime.go
+++ b/cmd/heph/provider_runtime.go
@@ -3,27 +3,18 @@ package main
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"heph4estus/internal/cloud"
-	"heph4estus/internal/cloud/factory"
 	"heph4estus/internal/fleet"
 	"heph4estus/internal/infra"
 	"heph4estus/internal/logger"
+	"heph4estus/internal/scanruntime"
 )
 
 var waitForProviderNativeFleetFunc = waitForProviderNativeFleet
 
 func buildRuntimeProvider(ctx context.Context, kind cloud.Kind, outputs map[string]string, log logger.Logger) (cloud.Provider, error) {
-	if kind.IsProviderNative() && outputs != nil {
-		typed := infra.DecodeTerraformOutputs(kind, outputs)
-		return factory.Build(factory.Config{
-			Kind:       kind,
-			Selfhosted: factory.SelfhostedConfigFromTypedOutputs(typed.Selfhosted),
-			Logger:     log,
-		})
-	}
-	return factory.BuildForKind(ctx, kind, log)
+	return scanruntime.DefaultProviderBuilder(ctx, kind, outputs, log)
 }
 
 func waitForProviderNativeFleet(ctx context.Context, kind cloud.Kind, outputs map[string]string, policy fleet.PlacementPolicy) (int, error) {
@@ -71,13 +62,4 @@ func waitForProviderNativeFleet(ctx context.Context, kind cloud.Kind, outputs ma
 
 func fleetWorkerCount(outputs map[string]string) int {
 	return infra.OutputInt(outputs, infra.OutputWorkerCount)
-}
-
-func outputBool(value string) bool {
-	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "true", "1", "yes", "y", "on":
-		return true
-	default:
-		return false
-	}
 }

--- a/internal/scanruntime/runtime.go
+++ b/internal/scanruntime/runtime.go
@@ -1,0 +1,588 @@
+package scanruntime
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"heph4estus/internal/cloud"
+	awscloud "heph4estus/internal/cloud/aws"
+	"heph4estus/internal/cloud/factory"
+	"heph4estus/internal/fleet"
+	"heph4estus/internal/infra"
+	"heph4estus/internal/jobs"
+	"heph4estus/internal/logger"
+	"heph4estus/internal/operator"
+	"heph4estus/internal/worker"
+)
+
+const (
+	SpotThreshold  = 50
+	PollInterval   = 2 * time.Second
+	EnqueueTimeout = 5 * time.Minute
+	LaunchTimeout  = 5 * time.Minute
+)
+
+type StatusFunc func(format string, args ...interface{})
+
+type ProviderBuilder func(context.Context, cloud.Kind, map[string]string, logger.Logger) (cloud.Provider, error)
+type ProviderNativeFleetWaiter func(context.Context, cloud.Kind, map[string]string, fleet.PlacementPolicy) (int, error)
+type EnsureInfraFunc func(context.Context, *infra.ToolConfig, infra.LifecyclePolicy, string, io.Writer, func(string) bool, logger.Logger) (*infra.EnsureResult, error)
+type DestroyInfraFunc func(context.Context, *infra.ToolConfig, io.Writer, logger.Logger) error
+type ExportJobFunc func(context.Context, cloud.Storage, string, string, string, string) (*operator.ExportResult, error)
+type ResultRenderer func(context.Context, cloud.Storage, string, string) error
+
+type SetupOptions struct {
+	ToolName        string
+	CloudKind       cloud.Kind
+	Workers         int
+	LifecyclePolicy infra.LifecyclePolicy
+	PromptFunc      func(string) bool
+	Stream          io.Writer
+	Log             logger.Logger
+	EnsureInfra     EnsureInfraFunc
+}
+
+type Environment struct {
+	ToolConfig *infra.ToolConfig
+	Outputs    infra.TerraformOutputs
+	QueueURL   string
+	Bucket     string
+	Reused     bool
+}
+
+func Setup(ctx context.Context, opts SetupOptions) (*Environment, error) {
+	ensureInfra := opts.EnsureInfra
+	if ensureInfra == nil {
+		ensureInfra = infra.EnsureInfra
+	}
+
+	kind := opts.CloudKind.Canonical()
+	if kind == "" {
+		kind = cloud.DefaultKind
+	}
+
+	var (
+		toolCfg *infra.ToolConfig
+		raw     map[string]string
+		reused  bool
+	)
+
+	switch {
+	case kind.IsProviderNative():
+		cfg, err := infra.ResolveToolConfig(opts.ToolName, kind)
+		if err != nil {
+			return nil, err
+		}
+		cfg.TerraformVars[infra.OutputWorkerCount] = strconv.Itoa(opts.Workers)
+		result, err := ensureInfra(ctx, cfg, opts.LifecyclePolicy, "", opts.Stream, opts.PromptFunc, opts.Log)
+		if err != nil {
+			return nil, err
+		}
+		toolCfg = cfg
+		raw = result.Outputs
+		reused = result.Reused
+
+	case kind.IsSelfhostedFamily():
+		cfg := factory.SelfhostedConfigFromEnv()
+		if cfg.QueueID == "" || cfg.Bucket == "" {
+			return nil, fmt.Errorf("%s requires SELFHOSTED_QUEUE_ID and SELFHOSTED_BUCKET environment variables", kind.Canonical())
+		}
+		raw = map[string]string{
+			infra.OutputSQSQueueURL:  cfg.QueueID,
+			infra.OutputS3BucketName: cfg.Bucket,
+		}
+
+	default:
+		cfg, err := infra.ResolveToolConfig(opts.ToolName)
+		if err != nil {
+			return nil, err
+		}
+		result, err := ensureInfra(ctx, cfg, opts.LifecyclePolicy, infra.AWSRegion(), opts.Stream, opts.PromptFunc, opts.Log)
+		if err != nil {
+			return nil, err
+		}
+		toolCfg = cfg
+		raw = result.Outputs
+		reused = result.Reused
+	}
+
+	outputs := infra.DecodeTerraformOutputs(kind, raw)
+	queueURL, bucket := queueAndBucket(outputs)
+	if queueURL == "" || bucket == "" {
+		return nil, fmt.Errorf("terraform outputs missing sqs_queue_url or s3_bucket_name")
+	}
+
+	return &Environment{
+		ToolConfig: toolCfg,
+		Outputs:    outputs,
+		QueueURL:   queueURL,
+		Bucket:     bucket,
+		Reused:     reused,
+	}, nil
+}
+
+type ProviderOptions struct {
+	CloudKind       cloud.Kind
+	Outputs         infra.TerraformOutputs
+	Log             logger.Logger
+	ProviderBuilder ProviderBuilder
+}
+
+func BuildProvider(ctx context.Context, opts ProviderOptions) (cloud.Provider, error) {
+	builder := opts.ProviderBuilder
+	if builder == nil {
+		builder = DefaultProviderBuilder
+	}
+	return builder(ctx, opts.CloudKind, opts.Outputs.ToMap(), opts.Log)
+}
+
+func DefaultProviderBuilder(ctx context.Context, kind cloud.Kind, outputs map[string]string, log logger.Logger) (cloud.Provider, error) {
+	if kind.IsProviderNative() && outputs != nil {
+		typed := infra.DecodeTerraformOutputs(kind, outputs)
+		return factory.Build(factory.Config{
+			Kind:       kind,
+			Selfhosted: factory.SelfhostedConfigFromTypedOutputs(typed.Selfhosted),
+			Logger:     log,
+		})
+	}
+	return factory.BuildForKind(ctx, kind, log)
+}
+
+type JobRecordOptions struct {
+	Tracker       *operator.Tracker
+	JobID         string
+	ToolName      string
+	Phase         operator.Phase
+	TotalTasks    int
+	Workers       int
+	ComputeMode   string
+	CloudKind     cloud.Kind
+	CleanupPolicy string
+	Bucket        string
+	Outputs       infra.TerraformOutputs
+	Placement     fleet.PlacementPolicy
+}
+
+func CreateJobRecord(opts JobRecordOptions) error {
+	if opts.Tracker == nil {
+		return nil
+	}
+	phase := opts.Phase
+	if phase == "" {
+		phase = operator.PhaseEnqueuing
+	}
+	record := &operator.JobRecord{
+		JobID:                 opts.JobID,
+		ToolName:              opts.ToolName,
+		Phase:                 phase,
+		TotalTasks:            opts.TotalTasks,
+		WorkerCount:           opts.Workers,
+		ComputeMode:           opts.ComputeMode,
+		Cloud:                 string(opts.CloudKind),
+		CleanupPolicy:         opts.CleanupPolicy,
+		Bucket:                opts.Bucket,
+		S3Endpoint:            firstNonEmpty(opts.Outputs.Selfhosted.S3Endpoint, opts.Outputs.AWS.S3Endpoint),
+		S3Region:              firstNonEmpty(opts.Outputs.Selfhosted.S3Region, opts.Outputs.AWS.S3Region),
+		S3AccessKey:           firstNonEmpty(opts.Outputs.Selfhosted.S3AccessKey, opts.Outputs.AWS.S3AccessKey),
+		S3SecretKey:           firstNonEmpty(opts.Outputs.Selfhosted.S3SecretKey, opts.Outputs.AWS.S3SecretKey),
+		S3PathStyle:           opts.Outputs.Selfhosted.S3PathStyle || opts.Outputs.AWS.S3PathStyle,
+		Placement:             opts.Placement,
+		ExpectedWorkerVersion: firstNonEmpty(opts.Outputs.Selfhosted.DockerImage, opts.Outputs.AWS.DockerImage),
+		NATSUrl:               opts.Outputs.Selfhosted.NATSURL,
+		ControllerIP:          opts.Outputs.Selfhosted.ControllerIP,
+		GenerationID:          opts.Outputs.Selfhosted.GenerationID,
+		ControllerCAPEM:       opts.Outputs.Selfhosted.ControllerCAPEM,
+		ControllerHost:        opts.Outputs.Selfhosted.ControllerHost,
+		NATSClientCertPEM:     opts.Outputs.Selfhosted.NATSOperatorClientCertPEM,
+		NATSClientKeyPEM:      opts.Outputs.Selfhosted.NATSOperatorClientKeyPEM,
+	}
+	return opts.Tracker.Create(record)
+}
+
+type ExecuteOptions struct {
+	ToolName      string
+	JobID         string
+	Tasks         []worker.Task
+	EnqueueLabel  string
+	Workers       int
+	ComputeMode   string
+	Queue         cloud.Queue
+	Storage       cloud.Storage
+	Compute       cloud.Compute
+	Outputs       infra.TerraformOutputs
+	QueueURL      string
+	Bucket        string
+	CloudKind     cloud.Kind
+	Placement     fleet.PlacementPolicy
+	Tracker       *operator.Tracker
+	WorkerEnv     map[string]string
+	ContainerName string
+	ProgressLabel string
+	CompleteLabel string
+	RenderResults ResultRenderer
+	Statusf       StatusFunc
+	FleetWaiter   ProviderNativeFleetWaiter
+}
+
+func ExecuteQueuedScan(ctx context.Context, opts ExecuteOptions) (bool, error) {
+	queueURL := opts.QueueURL
+	bucket := opts.Bucket
+	if queueURL == "" || bucket == "" {
+		return false, fmt.Errorf("terraform outputs missing sqs_queue_url or s3_bucket_name")
+	}
+
+	label := opts.EnqueueLabel
+	if label == "" {
+		label = "tasks"
+	}
+	statusf := normalizeStatus(opts.Statusf)
+	if opts.Tracker != nil {
+		_ = opts.Tracker.UpdatePhase(opts.JobID, operator.PhaseEnqueuing)
+	}
+	statusf("Enqueueing %d %s...", len(opts.Tasks), label)
+	enqueueCtx, enqueueCancel := context.WithTimeout(ctx, EnqueueTimeout)
+	defer enqueueCancel()
+
+	result, err := jobs.EnqueueTasks(enqueueCtx, opts.Queue, queueURL, opts.Tasks, jobs.EnqueueOptions{})
+	if err != nil {
+		return false, fmt.Errorf("enqueueing %s: %w", label, err)
+	}
+	statusf("Enqueued %d %s", result.SentTasks, label)
+
+	if opts.Tracker != nil {
+		_ = opts.Tracker.UpdatePhase(opts.JobID, operator.PhaseLaunching)
+	}
+	if err := LaunchWorkers(ctx, LaunchOptions{
+		ToolName:      opts.ToolName,
+		Workers:       opts.Workers,
+		ComputeMode:   opts.ComputeMode,
+		Compute:       opts.Compute,
+		Outputs:       opts.Outputs,
+		QueueURL:      queueURL,
+		Bucket:        bucket,
+		CloudKind:     opts.CloudKind,
+		Placement:     opts.Placement,
+		WorkerEnv:     opts.WorkerEnv,
+		ContainerName: opts.ContainerName,
+		Statusf:       statusf,
+		FleetWaiter:   opts.FleetWaiter,
+	}); err != nil {
+		return false, err
+	}
+
+	if opts.Tracker != nil {
+		_ = opts.Tracker.UpdatePhase(opts.JobID, operator.PhaseScanning)
+	}
+	return true, PollAndRender(ctx, PollOptions{
+		Storage:       opts.Storage,
+		Bucket:        bucket,
+		ToolName:      opts.ToolName,
+		JobID:         opts.JobID,
+		TotalTasks:    len(opts.Tasks),
+		ProgressLabel: opts.ProgressLabel,
+		CompleteLabel: opts.CompleteLabel,
+		RenderResults: opts.RenderResults,
+		Statusf:       statusf,
+	})
+}
+
+type LaunchOptions struct {
+	ToolName      string
+	Workers       int
+	ComputeMode   string
+	Compute       cloud.Compute
+	Outputs       infra.TerraformOutputs
+	QueueURL      string
+	Bucket        string
+	CloudKind     cloud.Kind
+	Placement     fleet.PlacementPolicy
+	WorkerEnv     map[string]string
+	ContainerName string
+	Statusf       StatusFunc
+	FleetWaiter   ProviderNativeFleetWaiter
+}
+
+func LaunchWorkers(ctx context.Context, opts LaunchOptions) error {
+	statusf := normalizeStatus(opts.Statusf)
+	statusf("Launching %d workers (mode: %s)...", opts.Workers, opts.ComputeMode)
+	launchCtx, launchCancel := context.WithTimeout(ctx, LaunchTimeout)
+	defer launchCancel()
+
+	kind := opts.CloudKind.Canonical()
+	if kind.IsProviderNative() {
+		if opts.FleetWaiter == nil {
+			return fmt.Errorf("provider-native fleet waiter is required")
+		}
+		ready, err := opts.FleetWaiter(launchCtx, kind, opts.Outputs.ToMap(), opts.Placement)
+		if err != nil {
+			return err
+		}
+		statusf("Using provider-native %s fleet (%d eligible workers, policy: %s)", kind.Canonical(), ready, opts.Placement.Summary())
+		return nil
+	}
+
+	workerEnv := opts.WorkerEnv
+	if workerEnv == nil {
+		workerEnv = map[string]string{
+			"QUEUE_URL": opts.QueueURL,
+			"S3_BUCKET": opts.Bucket,
+			"TOOL_NAME": opts.ToolName,
+		}
+	}
+	containerName := opts.ContainerName
+	if containerName == "" {
+		containerName = fmt.Sprintf("%s-worker", opts.ToolName)
+	}
+
+	useSpot := !kind.IsSelfhostedFamily() && ResolveComputeMode(opts.ComputeMode, opts.Workers)
+	if useSpot {
+		awsOut := opts.Outputs.AWS
+		if strings.TrimSpace(awsOut.ImageTag) == "" {
+			return fmt.Errorf("terraform outputs missing image_tag")
+		}
+		userData := awscloud.GenerateUserData(awscloud.UserDataOpts{
+			ECRRepoURL: awsOut.ECRRepoURL,
+			ImageTag:   awsOut.ImageTag,
+			Region:     RegionFromECR(awsOut.ECRRepoURL),
+			EnvVars:    workerEnv,
+		})
+		ids, err := opts.Compute.RunSpotInstances(launchCtx, cloud.SpotOpts{
+			AMI:             awsOut.AMIID,
+			Count:           opts.Workers,
+			SecurityGroups:  []string{awsOut.SecurityGroupID},
+			SubnetIDs:       awsOut.SubnetIDs,
+			InstanceProfile: awsOut.InstanceProfileARN,
+			UserData:        userData,
+			Tags: map[string]string{
+				"Project": "heph4estus",
+				"Tool":    opts.ToolName,
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("launching spot instances: %w", err)
+		}
+		statusf("Launched %d spot instances", len(ids))
+		return nil
+	}
+
+	awsOut := opts.Outputs.AWS
+	_, err := opts.Compute.RunContainer(launchCtx, cloud.ContainerOpts{
+		Cluster:        awsOut.ECSClusterName,
+		TaskDefinition: awsOut.TaskDefinitionARN,
+		ContainerName:  containerName,
+		Subnets:        awsOut.SubnetIDs,
+		SecurityGroups: []string{awsOut.SecurityGroupID},
+		Env:            workerEnv,
+		Count:          opts.Workers,
+	})
+	if err != nil {
+		return fmt.Errorf("launching workers: %w", err)
+	}
+	statusf("Launched %d workers", opts.Workers)
+	return nil
+}
+
+type PollOptions struct {
+	Storage       cloud.Storage
+	Bucket        string
+	ToolName      string
+	JobID         string
+	TotalTasks    int
+	ProgressLabel string
+	CompleteLabel string
+	RenderResults ResultRenderer
+	Statusf       StatusFunc
+}
+
+func PollAndRender(ctx context.Context, opts PollOptions) error {
+	statusf := normalizeStatus(opts.Statusf)
+	statusf("Scanning...")
+	startTime := time.Now()
+	scanPrefix := jobs.ResultPrefix(opts.ToolName, opts.JobID)
+
+	for {
+		count, err := opts.Storage.Count(ctx, opts.Bucket, scanPrefix)
+		if err != nil {
+			statusf("Warning: progress check failed: %v", err)
+		} else {
+			elapsed := time.Since(startTime).Truncate(time.Second)
+			pct := float64(count) / float64(opts.TotalTasks) * 100
+			if opts.ProgressLabel != "" {
+				statusf("Progress: %d/%d %s (%.1f%%) — elapsed %s", count, opts.TotalTasks, opts.ProgressLabel, pct, elapsed)
+			} else {
+				statusf("Progress: %d/%d (%.1f%%) — elapsed %s", count, opts.TotalTasks, pct, elapsed)
+			}
+			if count >= opts.TotalTasks {
+				break
+			}
+		}
+		time.Sleep(PollInterval)
+	}
+
+	elapsed := time.Since(startTime).Truncate(time.Second)
+	if opts.CompleteLabel != "" {
+		statusf("Scan complete: %d %s in %s", opts.TotalTasks, opts.CompleteLabel, elapsed)
+	} else {
+		statusf("Scan complete: %d tasks in %s", opts.TotalTasks, elapsed)
+	}
+	if opts.RenderResults == nil {
+		return nil
+	}
+	return opts.RenderResults(ctx, opts.Storage, opts.Bucket, scanPrefix)
+}
+
+type FinalizeOptions struct {
+	JobID        string
+	ToolName     string
+	Tracker      *operator.Tracker
+	Started      bool
+	ScanErr      error
+	OutDir       string
+	Storage      cloud.Storage
+	Bucket       string
+	DestroyAfter bool
+	CloudKind    cloud.Kind
+	ToolConfig   *infra.ToolConfig
+	Stream       io.Writer
+	Log          logger.Logger
+	Statusf      StatusFunc
+	ExportJob    ExportJobFunc
+	DestroyInfra DestroyInfraFunc
+}
+
+type FinalizeResult struct {
+	ExportDir string
+}
+
+func Finalize(ctx context.Context, opts FinalizeOptions) (FinalizeResult, error) {
+	if opts.Tracker != nil {
+		if opts.ScanErr != nil {
+			_ = opts.Tracker.Fail(opts.JobID, opts.ScanErr)
+		} else if opts.Started {
+			_ = opts.Tracker.Complete(opts.JobID)
+		}
+	}
+
+	statusf := normalizeStatus(opts.Statusf)
+	exportJob := opts.ExportJob
+	if exportJob == nil {
+		exportJob = operator.ExportJob
+	}
+	destroyInfra := opts.DestroyInfra
+	if destroyInfra == nil {
+		destroyInfra = infra.RunDestroy
+	}
+
+	var result FinalizeResult
+	if opts.OutDir != "" && opts.ScanErr == nil && opts.Started {
+		statusf("Exporting results to %s...", opts.OutDir)
+		exportResult, err := exportJob(ctx, opts.Storage, opts.Bucket, opts.ToolName, opts.JobID, opts.OutDir)
+		if err != nil {
+			return result, fmt.Errorf("export failed: %w", err)
+		}
+		result.ExportDir = exportResult.Dir
+		statusf("Exported %d results, %d artifacts to %s", exportResult.ResultCount, exportResult.ArtifactCount, exportResult.Dir)
+		updateJobRecord(opts.Tracker, opts.JobID, func(rec *operator.JobRecord) {
+			rec.LocalOutputDir = exportResult.Dir
+		})
+	}
+
+	if opts.DestroyAfter && opts.Started {
+		kind := opts.CloudKind.Canonical()
+		if kind.IsSelfhostedFamily() && !kind.IsProviderNative() {
+			statusf("Skipping destroy: %s does not support auto-destroy", kind.Canonical())
+		} else if opts.ToolConfig != nil {
+			statusf("Destroying infrastructure (--destroy-after)...")
+			if err := destroyInfra(ctx, opts.ToolConfig, opts.Stream, opts.Log); err != nil {
+				if opts.ScanErr != nil {
+					return result, fmt.Errorf("scan failed: %w; additionally, destroy failed: %v", opts.ScanErr, err)
+				}
+				return result, fmt.Errorf("scan completed but destroy failed: %w", err)
+			}
+		}
+	}
+	return result, nil
+}
+
+func CleanupPolicy(destroyAfter bool) string {
+	if destroyAfter {
+		return "destroy-after"
+	}
+	return "reuse"
+}
+
+func ResolveComputeMode(mode string, workers int) bool {
+	switch mode {
+	case "spot":
+		return true
+	case "fargate":
+		return false
+	default:
+		return workers >= SpotThreshold
+	}
+}
+
+func RegionFromECR(url string) string {
+	parts := strings.Split(url, ".")
+	for i, p := range parts {
+		if p == "ecr" && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+	return "us-east-1"
+}
+
+func SplitOutputList(s string) []string {
+	s = strings.Trim(s, "[]")
+	parts := strings.Split(s, " ")
+	var result []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+func queueAndBucket(outputs infra.TerraformOutputs) (string, string) {
+	queueURL := firstNonEmpty(outputs.AWS.SQSQueueURL, outputs.Selfhosted.QueueURL)
+	bucket := firstNonEmpty(outputs.AWS.S3BucketName, outputs.Selfhosted.S3BucketName)
+	return queueURL, bucket
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func updateJobRecord(tracker *operator.Tracker, jobID string, mutate func(*operator.JobRecord)) {
+	if tracker == nil || mutate == nil {
+		return
+	}
+	store := tracker.Store()
+	if store == nil {
+		return
+	}
+	rec, err := store.Load(jobID)
+	if err != nil {
+		return
+	}
+	mutate(rec)
+	_ = store.Update(rec)
+}
+
+func normalizeStatus(statusf StatusFunc) StatusFunc {
+	if statusf != nil {
+		return statusf
+	}
+	return func(string, ...interface{}) {}
+}

--- a/internal/scanruntime/runtime_test.go
+++ b/internal/scanruntime/runtime_test.go
@@ -1,0 +1,250 @@
+package scanruntime
+
+import (
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"heph4estus/internal/cloud"
+	"heph4estus/internal/fleet"
+	"heph4estus/internal/infra"
+	"heph4estus/internal/logger"
+	"heph4estus/internal/operator"
+	"heph4estus/internal/worker"
+)
+
+type mockQueue struct {
+	sendBatchErr error
+	batches      [][]string
+}
+
+func (q *mockQueue) Send(context.Context, string, string) error { return nil }
+
+func (q *mockQueue) SendBatch(_ context.Context, _ string, bodies []string) error {
+	q.batches = append(q.batches, append([]string(nil), bodies...))
+	return q.sendBatchErr
+}
+
+func (q *mockQueue) Receive(context.Context, string) (*cloud.Message, error) { return nil, nil }
+func (q *mockQueue) Delete(context.Context, string, string) error            { return nil }
+
+type mockStorage struct {
+	count int
+}
+
+func (s *mockStorage) Upload(context.Context, string, string, []byte) error { return nil }
+func (s *mockStorage) Download(context.Context, string, string) ([]byte, error) {
+	return []byte("{}"), nil
+}
+func (s *mockStorage) List(context.Context, string, string) ([]string, error) { return nil, nil }
+func (s *mockStorage) Count(context.Context, string, string) (int, error) {
+	return s.count, nil
+}
+
+type mockCompute struct {
+	runContainerErr error
+	runSpotErr      error
+	runContainerN   int
+	runSpotN        int
+}
+
+func (c *mockCompute) RunContainer(context.Context, cloud.ContainerOpts) (string, error) {
+	c.runContainerN++
+	return "task-1", c.runContainerErr
+}
+
+func (c *mockCompute) RunSpotInstances(context.Context, cloud.SpotOpts) ([]string, error) {
+	c.runSpotN++
+	if c.runSpotErr != nil {
+		return nil, c.runSpotErr
+	}
+	return []string{"i-1"}, nil
+}
+
+func (c *mockCompute) GetSpotStatus(context.Context, []string) ([]cloud.SpotStatus, error) {
+	return nil, nil
+}
+
+func runtimeOutputs(kind cloud.Kind, values map[string]string) infra.TerraformOutputs {
+	return infra.DecodeTerraformOutputs(kind, values)
+}
+
+func awsRuntimeOutputs() infra.TerraformOutputs {
+	return runtimeOutputs(cloud.KindAWS, map[string]string{
+		infra.OutputSQSQueueURL:       "queue-url",
+		infra.OutputS3BucketName:      "bucket",
+		infra.OutputECRRepoURL:        "123.dkr.ecr.us-east-1.amazonaws.com/repo",
+		infra.OutputImageTag:          "image-tag",
+		infra.OutputDockerImage:       "repo:image-tag",
+		infra.OutputECSClusterName:    "cluster",
+		infra.OutputTaskDefinitionARN: "task-def",
+		infra.OutputSubnetIDs:         "[subnet-a subnet-b]",
+		infra.OutputSecurityGroupID:   "sg-123",
+		infra.OutputAMIID:             "ami-123",
+		infra.OutputInstanceProfile:   "profile-arn",
+	})
+}
+
+func TestCreateJobRecordUsesTypedOutputs(t *testing.T) {
+	store := operator.NewJobStoreAt(t.TempDir())
+	tracker := operator.NewTracker(store)
+	outputs := runtimeOutputs(cloud.KindHetzner, map[string]string{
+		infra.OutputSQSQueueURL:                    "nats-stream",
+		infra.OutputS3BucketName:                   "minio-bucket",
+		infra.OutputS3Endpoint:                     "https://minio.example",
+		infra.OutputS3Region:                       "us-east-1",
+		infra.OutputS3AccessKey:                    "access",
+		infra.OutputS3SecretKey:                    "secret",
+		infra.OutputS3PathStyle:                    "true",
+		infra.OutputDockerImage:                    "registry/tool:tag",
+		infra.OutputNATSURL:                        "tls://nats.example:4222",
+		infra.OutputControllerIP:                   "10.0.0.2",
+		infra.OutputGenerationID:                   "gen-1",
+		infra.OutputControllerCAPEM:                "ca",
+		infra.OutputControllerHost:                 "controller.local",
+		infra.OutputNATSOperatorClientCertPEM:      "cert",
+		infra.OutputNATSOperatorClientKeyPEM:       "key",
+		infra.OutputNATSOperatorClientCertNotAfter: "2035-01-01T00:00:00Z",
+	})
+
+	if err := CreateJobRecord(JobRecordOptions{
+		Tracker:       tracker,
+		JobID:         "job-1",
+		ToolName:      "httpx",
+		Workers:       3,
+		ComputeMode:   "auto",
+		CloudKind:     cloud.KindHetzner,
+		CleanupPolicy: "destroy-after",
+		Bucket:        "minio-bucket",
+		Outputs:       outputs,
+		Placement: fleet.PlacementPolicy{
+			Mode: fleet.PlacementModeDiversity,
+		},
+	}); err != nil {
+		t.Fatalf("CreateJobRecord: %v", err)
+	}
+
+	rec, err := store.Load("job-1")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if rec.Bucket != "minio-bucket" || rec.S3Endpoint != "https://minio.example" || !rec.S3PathStyle {
+		t.Fatalf("storage metadata not persisted: %#v", rec)
+	}
+	if rec.ExpectedWorkerVersion != "registry/tool:tag" || rec.NATSUrl != "tls://nats.example:4222" || rec.ControllerHost != "controller.local" {
+		t.Fatalf("provider-native metadata not persisted: %#v", rec)
+	}
+	if rec.CleanupPolicy != "destroy-after" || rec.WorkerCount != 3 || rec.Cloud != "hetzner" {
+		t.Fatalf("run metadata not persisted: %#v", rec)
+	}
+}
+
+func TestExecuteQueuedScanStartedFalseOnLaunchFailure(t *testing.T) {
+	started, err := ExecuteQueuedScan(context.Background(), ExecuteOptions{
+		ToolName:     "httpx",
+		JobID:        "job-1",
+		Tasks:        []worker.Task{{ToolName: "httpx", JobID: "job-1", Target: "example.com"}},
+		EnqueueLabel: "target tasks",
+		Workers:      1,
+		ComputeMode:  "fargate",
+		Queue:        &mockQueue{},
+		Storage:      &mockStorage{},
+		Compute:      &mockCompute{runContainerErr: errors.New("launch failed")},
+		Outputs:      awsRuntimeOutputs(),
+		QueueURL:     "queue-url",
+		Bucket:       "bucket",
+		CloudKind:    cloud.KindAWS,
+	})
+	if err == nil || !strings.Contains(err.Error(), "launching workers") {
+		t.Fatalf("expected launch error, got %v", err)
+	}
+	if started {
+		t.Fatal("expected started=false")
+	}
+}
+
+func TestExecuteQueuedScanProviderNativeSkipsCompute(t *testing.T) {
+	comp := &mockCompute{}
+	var waited bool
+	started, err := ExecuteQueuedScan(context.Background(), ExecuteOptions{
+		ToolName:     "httpx",
+		JobID:        "job-1",
+		Tasks:        []worker.Task{{ToolName: "httpx", JobID: "job-1", Target: "example.com"}},
+		EnqueueLabel: "target tasks",
+		Workers:      3,
+		ComputeMode:  "auto",
+		Queue:        &mockQueue{},
+		Storage:      &mockStorage{count: 1},
+		Compute:      comp,
+		Outputs: runtimeOutputs(cloud.KindHetzner, map[string]string{
+			infra.OutputSQSQueueURL:  "nats-stream",
+			infra.OutputS3BucketName: "minio-bucket",
+		}),
+		QueueURL:  "nats-stream",
+		Bucket:    "minio-bucket",
+		CloudKind: cloud.KindHetzner,
+		FleetWaiter: func(context.Context, cloud.Kind, map[string]string, fleet.PlacementPolicy) (int, error) {
+			waited = true
+			return 3, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteQueuedScan: %v", err)
+	}
+	if !started || !waited {
+		t.Fatalf("started=%v waited=%v, want true/true", started, waited)
+	}
+	if comp.runContainerN != 0 || comp.runSpotN != 0 {
+		t.Fatalf("provider-native launch used compute: container=%d spot=%d", comp.runContainerN, comp.runSpotN)
+	}
+}
+
+func TestFinalizeExportsBeforeDestroyAndRecordsOutput(t *testing.T) {
+	store := operator.NewJobStoreAt(t.TempDir())
+	tracker := operator.NewTracker(store)
+	if err := tracker.Create(&operator.JobRecord{JobID: "job-1", ToolName: "httpx"}); err != nil {
+		t.Fatalf("create record: %v", err)
+	}
+
+	var order []string
+	result, err := Finalize(context.Background(), FinalizeOptions{
+		JobID:        "job-1",
+		ToolName:     "httpx",
+		Tracker:      tracker,
+		Started:      true,
+		OutDir:       t.TempDir(),
+		Storage:      &mockStorage{},
+		Bucket:       "bucket",
+		DestroyAfter: true,
+		CloudKind:    cloud.KindAWS,
+		ToolConfig:   &infra.ToolConfig{ToolName: "httpx"},
+		ExportJob: func(context.Context, cloud.Storage, string, string, string, string) (*operator.ExportResult, error) {
+			order = append(order, "export")
+			return &operator.ExportResult{Dir: filepath.Join("out", "httpx", "job-1"), ResultCount: 2, ArtifactCount: 1}, nil
+		},
+		DestroyInfra: func(context.Context, *infra.ToolConfig, io.Writer, logger.Logger) error {
+			order = append(order, "destroy")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Finalize: %v", err)
+	}
+	if result.ExportDir != filepath.Join("out", "httpx", "job-1") {
+		t.Fatalf("ExportDir = %q", result.ExportDir)
+	}
+	if !reflect.DeepEqual(order, []string{"export", "destroy"}) {
+		t.Fatalf("order = %v, want export then destroy", order)
+	}
+	rec, err := store.Load("job-1")
+	if err != nil {
+		t.Fatalf("load record: %v", err)
+	}
+	if rec.LocalOutputDir != filepath.Join("out", "httpx", "job-1") {
+		t.Fatalf("LocalOutputDir = %q", rec.LocalOutputDir)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds an internal scanruntime package for shared CLI scan setup, job tracking, enqueue/launch/poll, export, and destroy-after finalization.
- Moves generic scan and nmap CLI orchestration onto the shared runtime while preserving command-specific planning and result rendering.
- Uses typed Terraform output contracts through the scan launch path instead of repeated raw output map reads.
- Adds focused runtime coverage for job metadata, launch failure boundaries, provider-native compute skips, and export-before-destroy ordering.

## Commits
- refactor(runtime): extract shared scan runtime

## Validation
- make fmt-check
- env GOCACHE=/tmp/heph-go-build make vet
- env GOCACHE=/tmp/heph-go-build make test
- env XDG_CACHE_HOME=/tmp/heph-cache GOCACHE=/tmp/heph-go-build make lint
- git diff --check

## Notes
- CLI flags, job JSON fields, result output formats, and scan behavior are intended to remain unchanged.
- TUI status consolidation remains later Phase 12 work.
- Result rendering stays in cmd/heph in this PR to keep the runtime extraction focused.
- Existing untracked local roadmap/docs artifacts were left out of this branch.