### PR TITLE
PR 12.4: Shared TUI status core

### DIFF
--- a/internal/tui/statuscore/status.go
+++ b/internal/tui/statuscore/status.go
@@ -1,0 +1,365 @@
+package statuscore
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"heph4estus/internal/cloud"
+	awscloud "heph4estus/internal/cloud/aws"
+	"heph4estus/internal/jobs"
+	"heph4estus/internal/operator"
+	"heph4estus/internal/tui/core"
+)
+
+const (
+	SpotThreshold    = 50
+	CounterThreshold = 10_000
+	PollInterval     = 2 * time.Second
+)
+
+type Phase int
+
+const (
+	PhaseUploading Phase = iota
+	PhaseEnqueuing
+	PhaseLaunching
+	PhaseScanning
+	PhaseExporting
+	PhaseDestroying
+	PhaseComplete
+)
+
+type RateSample struct {
+	Time  time.Time
+	Count int
+}
+
+type WorkerLauncher interface {
+	LaunchWorkers(ctx context.Context, opts cloud.ContainerOpts) (string, error)
+	LaunchSpotWorkers(ctx context.Context, opts cloud.SpotOpts) ([]string, error)
+}
+
+type ProgressTracker interface {
+	CountResults(ctx context.Context, bucket, prefix string) (int, error)
+}
+
+type LaunchOptions struct {
+	Infra         core.InfraOutputs
+	Launcher      WorkerLauncher
+	ContainerName string
+	ToolName      string
+	WorkerEnv     map[string]string
+}
+
+type LaunchResult struct {
+	Launched    int
+	Total       int
+	Err         error
+	Spot        bool
+	InstanceIDs []string
+}
+
+type ExportResult struct {
+	Dir   string
+	Count int
+	Err   error
+}
+
+type DestroyResult struct {
+	Err error
+}
+
+type ProgressResult struct {
+	Completed int
+	Err       error
+}
+
+type CompletionAction int
+
+const (
+	CompletionContinue CompletionAction = iota
+	CompletionNavigate
+	CompletionExport
+	CompletionDestroy
+)
+
+type CompletionResult struct {
+	Action  CompletionAction
+	Warning string
+}
+
+func UseSpot(infra core.InfraOutputs) bool {
+	if infra.Cloud.IsSelfhostedFamily() {
+		return false
+	}
+	switch infra.ComputeMode {
+	case "spot":
+		return true
+	case "fargate":
+		return false
+	default:
+		return infra.WorkerCount >= SpotThreshold
+	}
+}
+
+func DefaultWorkerEnv(infra core.InfraOutputs, toolName string) map[string]string {
+	toolName = resolveToolName(infra, toolName)
+	return map[string]string{
+		"QUEUE_URL":          infra.SQSQueueURL,
+		"S3_BUCKET":          infra.S3BucketName,
+		"TOOL_NAME":          toolName,
+		"JITTER_MAX_SECONDS": strconv.Itoa(infra.JitterMaxSeconds),
+	}
+}
+
+func Launch(ctx context.Context, opts LaunchOptions) LaunchResult {
+	infra := opts.Infra
+	total := infra.WorkerCount
+	toolName := resolveToolName(infra, opts.ToolName)
+	if UseSpot(infra) {
+		return launchSpot(ctx, opts)
+	}
+	if infra.Cloud.IsProviderNative() {
+		launched := infra.FleetWorkerCount
+		if launched <= 0 {
+			launched = infra.WorkerCount
+		}
+		if launched <= 0 {
+			launched = 1
+		}
+		return LaunchResult{Launched: launched, Total: launched}
+	}
+
+	env := opts.WorkerEnv
+	if env == nil {
+		env = DefaultWorkerEnv(infra, toolName)
+	}
+	containerName := opts.ContainerName
+	if containerName == "" {
+		containerName = fmt.Sprintf("%s-worker", toolName)
+	}
+	_, err := opts.Launcher.LaunchWorkers(ctx, cloud.ContainerOpts{
+		Cluster:        infra.ECSClusterName,
+		TaskDefinition: infra.TaskDefinitionARN,
+		ContainerName:  containerName,
+		Subnets:        infra.SubnetIDs,
+		SecurityGroups: []string{infra.SecurityGroupID},
+		Env:            env,
+		Count:          infra.WorkerCount,
+	})
+	return LaunchResult{Launched: infra.WorkerCount, Total: total, Err: err}
+}
+
+func launchSpot(ctx context.Context, opts LaunchOptions) LaunchResult {
+	infra := opts.Infra
+	total := infra.WorkerCount
+	toolName := resolveToolName(infra, opts.ToolName)
+	imageTag := strings.TrimSpace(infra.ImageTag)
+	if imageTag == "" {
+		return LaunchResult{Total: total, Err: fmt.Errorf("terraform outputs missing image_tag"), Spot: true}
+	}
+	env := opts.WorkerEnv
+	if env == nil {
+		env = DefaultWorkerEnv(infra, toolName)
+	}
+	userData := awscloud.GenerateUserData(awscloud.UserDataOpts{
+		ECRRepoURL: infra.ECRRepoURL,
+		ImageTag:   imageTag,
+		Region:     RegionFromECR(infra.ECRRepoURL),
+		EnvVars:    env,
+	})
+	ids, err := opts.Launcher.LaunchSpotWorkers(ctx, cloud.SpotOpts{
+		AMI:             infra.AMIID,
+		Count:           infra.WorkerCount,
+		SecurityGroups:  []string{infra.SecurityGroupID},
+		SubnetIDs:       infra.SubnetIDs,
+		InstanceProfile: infra.InstanceProfileARN,
+		UserData:        userData,
+		Tags: map[string]string{
+			"Project": "heph4estus",
+			"Tool":    toolName,
+		},
+	})
+	return LaunchResult{Launched: len(ids), Total: total, Err: err, Spot: true, InstanceIDs: ids}
+}
+
+func resolveToolName(infra core.InfraOutputs, toolName string) string {
+	if toolName != "" {
+		return toolName
+	}
+	return infra.ToolName
+}
+
+func ShouldExport(infra core.InfraOutputs, storage cloud.Storage) bool {
+	return infra.CleanupPolicy == "destroy-after" && infra.OutputDir != "" && storage != nil
+}
+
+func CompleteScan(infra core.InfraOutputs, storage cloud.Storage) CompletionResult {
+	if ShouldExport(infra, storage) {
+		return CompletionResult{Action: CompletionExport}
+	}
+	if infra.CleanupPolicy == "destroy-after" {
+		if infra.Cloud.IsSelfhostedFamily() && !infra.Cloud.IsProviderNative() {
+			return CompletionResult{
+				Action:  CompletionNavigate,
+				Warning: "destroy-after skipped: selfhosted does not support auto-destroy",
+			}
+		}
+		if infra.OutputDir == "" {
+			return CompletionResult{
+				Action:  CompletionNavigate,
+				Warning: "destroy-after skipped: no output directory configured",
+			}
+		}
+	}
+	return CompletionResult{Action: CompletionNavigate}
+}
+
+func CompleteExport(infra *core.InfraOutputs, destroyer core.Destroyer, result ExportResult) CompletionResult {
+	if result.Err != nil {
+		return CompletionResult{
+			Action:  CompletionNavigate,
+			Warning: fmt.Sprintf("destroy-after skipped: export failed (%v)", result.Err),
+		}
+	}
+	infra.Exported = true
+	infra.ExportDir = result.Dir
+	if infra.Cloud.IsSelfhostedFamily() && !infra.Cloud.IsProviderNative() {
+		return CompletionResult{
+			Action:  CompletionNavigate,
+			Warning: "destroy-after skipped: selfhosted does not support auto-destroy",
+		}
+	}
+	if destroyer != nil {
+		return CompletionResult{Action: CompletionDestroy}
+	}
+	return CompletionResult{
+		Action:  CompletionNavigate,
+		Warning: "destroy-after skipped: no terraform directory",
+	}
+}
+
+func CompleteDestroy(infra *core.InfraOutputs, result DestroyResult) string {
+	if result.Err != nil {
+		infra.DestroyErr = result.Err.Error()
+		return fmt.Sprintf("destroy failed: %v", result.Err)
+	}
+	infra.Destroyed = true
+	return ""
+}
+
+func ExportResults(ctx context.Context, storage cloud.Storage, infra core.InfraOutputs, toolName string) ExportResult {
+	if toolName == "" {
+		toolName = infra.ToolName
+	}
+	result, err := operator.ExportJob(ctx, storage, infra.S3BucketName, toolName, infra.JobID, infra.OutputDir)
+	if err != nil {
+		return ExportResult{Err: err}
+	}
+	return ExportResult{Dir: result.Dir, Count: result.ResultCount + result.ArtifactCount}
+}
+
+func RunAutoDestroy(ctx context.Context, destroyer core.Destroyer) DestroyResult {
+	return DestroyResult{Err: destroyer.Destroy(ctx)}
+}
+
+func PollProgress(ctx context.Context, tracker ProgressTracker, infra core.InfraOutputs, toolName string) ProgressResult {
+	if toolName == "" {
+		toolName = infra.ToolName
+	}
+	count, err := tracker.CountResults(ctx, infra.S3BucketName, jobs.ResultPrefix(toolName, infra.JobID))
+	return ProgressResult{Completed: count, Err: err}
+}
+
+func NavigateToResults(target core.ViewID, infra core.InfraOutputs) tea.Cmd {
+	return func() tea.Msg {
+		return core.NavigateWithDataMsg{Target: target, Data: infra}
+	}
+}
+
+func TrackPhase(tracker *operator.Tracker, jobID string, phase operator.Phase) {
+	if tracker != nil && jobID != "" {
+		_ = tracker.UpdatePhase(jobID, phase)
+	}
+}
+
+func TrackFail(tracker *operator.Tracker, jobID string, err error) {
+	if tracker != nil && jobID != "" {
+		_ = tracker.Fail(jobID, err)
+	}
+}
+
+func LifecycleSummary(infra core.InfraOutputs, labelStyle lipgloss.Style) string {
+	var b strings.Builder
+	infraLabel := "freshly deployed"
+	if infra.Reused {
+		infraLabel = "reused"
+	}
+	fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Infra:"), infraLabel)
+	if infra.CleanupPolicy != "" {
+		fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Cleanup:"), infra.CleanupPolicy)
+	}
+	if infra.Placement.Summary() != "" {
+		fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Placement:"), infra.Placement.Summary())
+	}
+	return b.String()
+}
+
+func WarningText(warning string) string {
+	if warning == "" {
+		return ""
+	}
+	return "\n  " + core.MutedStyle.Render(warning) + "\n"
+}
+
+func UpdateRateSamples(samples []RateSample, completed int, now time.Time) []RateSample {
+	samples = append(samples, RateSample{Time: now, Count: completed})
+	cutoff := now.Add(-30 * time.Second)
+	for len(samples) > 1 && samples[0].Time.Before(cutoff) {
+		samples = samples[1:]
+	}
+	return samples
+}
+
+func CalcRateETA(samples []RateSample, total, completed int) (targetsPerMin float64, remaining time.Duration) {
+	if len(samples) < 2 {
+		return 0, 0
+	}
+	first := samples[0]
+	last := samples[len(samples)-1]
+	dt := last.Time.Sub(first.Time).Minutes()
+	if dt <= 0 {
+		return 0, 0
+	}
+	dc := float64(last.Count - first.Count)
+	rate := dc / dt
+	if rate <= 0 {
+		return 0, 0
+	}
+	left := float64(total - completed)
+	eta := time.Duration(left/rate*60) * time.Second
+	return rate, eta
+}
+
+func ProgressBar(current, total, width int) string {
+	if total <= 0 {
+		return strings.Repeat("░", width)
+	}
+	filled := min(current*width/total, width)
+	return "[" + strings.Repeat("█", filled) + strings.Repeat("░", width-filled) + "]"
+}
+
+func RegionFromECR(url string) string {
+	parts := strings.Split(url, ".")
+	for i, p := range parts {
+		if p == "ecr" && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+	return "us-east-1"
+}

--- a/internal/tui/statuscore/status_test.go
+++ b/internal/tui/statuscore/status_test.go
@@ -1,0 +1,305 @@
+package statuscore
+
+import (
+	"context"
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"heph4estus/internal/cloud"
+	"heph4estus/internal/tui/core"
+)
+
+type launchRecorder struct {
+	containerCalls int
+	spotCalls      int
+	containerOpts  cloud.ContainerOpts
+	spotOpts       cloud.SpotOpts
+	containerErr   error
+	spotErr        error
+	spotIDs        []string
+}
+
+func (r *launchRecorder) LaunchWorkers(_ context.Context, opts cloud.ContainerOpts) (string, error) {
+	r.containerCalls++
+	r.containerOpts = opts
+	return "task-1", r.containerErr
+}
+
+func (r *launchRecorder) LaunchSpotWorkers(_ context.Context, opts cloud.SpotOpts) ([]string, error) {
+	r.spotCalls++
+	r.spotOpts = opts
+	if r.spotIDs == nil {
+		r.spotIDs = []string{"i-1", "i-2"}
+	}
+	return r.spotIDs, r.spotErr
+}
+
+type fakeStorage struct{}
+
+func (fakeStorage) Upload(context.Context, string, string, []byte) error { return nil }
+func (fakeStorage) Download(context.Context, string, string) ([]byte, error) {
+	return nil, nil
+}
+func (fakeStorage) List(context.Context, string, string) ([]string, error) { return nil, nil }
+func (fakeStorage) Count(context.Context, string, string) (int, error)     { return 0, nil }
+
+type progressRecorder struct {
+	bucket string
+	prefix string
+	count  int
+	err    error
+}
+
+func (r *progressRecorder) CountResults(_ context.Context, bucket, prefix string) (int, error) {
+	r.bucket = bucket
+	r.prefix = prefix
+	return r.count, r.err
+}
+
+type destroyRecorder struct {
+	called bool
+	err    error
+}
+
+func (r *destroyRecorder) Destroy(context.Context) error {
+	r.called = true
+	return r.err
+}
+
+func baseInfra() core.InfraOutputs {
+	return core.InfraOutputs{
+		SQSQueueURL:        "queue-url",
+		S3BucketName:       "bucket",
+		ECSClusterName:     "cluster",
+		TaskDefinitionARN:  "task-def",
+		ECRRepoURL:         "123456789012.dkr.ecr.us-west-2.amazonaws.com/nmap-worker",
+		ImageTag:           "worker-v1",
+		SubnetIDs:          []string{"subnet-1"},
+		SecurityGroupID:    "sg-1",
+		InstanceProfileARN: "profile",
+		AMIID:              "ami-1",
+		ToolName:           "nmap",
+		JobID:              "job-123",
+		WorkerCount:        2,
+		JitterMaxSeconds:   7,
+	}
+}
+
+func TestUseSpotModes(t *testing.T) {
+	low := baseInfra()
+	low.WorkerCount = SpotThreshold - 1
+	if UseSpot(low) {
+		t.Fatal("auto below threshold should not use spot")
+	}
+
+	high := baseInfra()
+	high.WorkerCount = SpotThreshold
+	if !UseSpot(high) {
+		t.Fatal("auto at threshold should use spot")
+	}
+
+	forcedFargate := baseInfra()
+	forcedFargate.WorkerCount = SpotThreshold
+	forcedFargate.ComputeMode = "fargate"
+	if UseSpot(forcedFargate) {
+		t.Fatal("fargate mode should not use spot")
+	}
+
+	forcedSpot := baseInfra()
+	forcedSpot.ComputeMode = "spot"
+	if !UseSpot(forcedSpot) {
+		t.Fatal("spot mode should use spot")
+	}
+
+	selfhosted := baseInfra()
+	selfhosted.Cloud = cloud.KindManual
+	selfhosted.ComputeMode = "spot"
+	if UseSpot(selfhosted) {
+		t.Fatal("manual selfhosted should not use spot")
+	}
+}
+
+func TestLaunchWorkersAndProviderNative(t *testing.T) {
+	launcher := &launchRecorder{}
+	infra := baseInfra()
+	infra.ComputeMode = "fargate"
+
+	result := Launch(context.Background(), LaunchOptions{Infra: infra, Launcher: launcher})
+	if result.Err != nil {
+		t.Fatalf("launch failed: %v", result.Err)
+	}
+	if launcher.containerCalls != 1 || launcher.spotCalls != 0 {
+		t.Fatalf("launch calls = container %d spot %d", launcher.containerCalls, launcher.spotCalls)
+	}
+	if launcher.containerOpts.ContainerName != "nmap-worker" {
+		t.Fatalf("container name = %q", launcher.containerOpts.ContainerName)
+	}
+	if launcher.containerOpts.Env["TOOL_NAME"] != "nmap" || launcher.containerOpts.Env["JITTER_MAX_SECONDS"] != "7" {
+		t.Fatalf("unexpected env: %#v", launcher.containerOpts.Env)
+	}
+	if result.Launched != 2 || result.Total != 2 {
+		t.Fatalf("launch result = %#v", result)
+	}
+
+	providerNative := baseInfra()
+	providerNative.Cloud = cloud.KindHetzner
+	providerNative.WorkerCount = 10
+	providerNative.FleetWorkerCount = 3
+	launcher = &launchRecorder{}
+	result = Launch(context.Background(), LaunchOptions{Infra: providerNative, Launcher: launcher})
+	if launcher.containerCalls != 0 || launcher.spotCalls != 0 {
+		t.Fatalf("provider-native should not launch workers, got container %d spot %d", launcher.containerCalls, launcher.spotCalls)
+	}
+	if result.Launched != 3 || result.Total != 3 {
+		t.Fatalf("provider-native launch result = %#v", result)
+	}
+}
+
+func TestLaunchSpot(t *testing.T) {
+	infra := baseInfra()
+	infra.ComputeMode = "spot"
+	launcher := &launchRecorder{}
+
+	result := Launch(context.Background(), LaunchOptions{Infra: infra, Launcher: launcher, ToolName: "nmap"})
+	if result.Err != nil {
+		t.Fatalf("spot launch failed: %v", result.Err)
+	}
+	if !result.Spot || result.Launched != 2 || len(result.InstanceIDs) != 2 {
+		t.Fatalf("spot launch result = %#v", result)
+	}
+	if launcher.spotCalls != 1 || launcher.containerCalls != 0 {
+		t.Fatalf("launch calls = container %d spot %d", launcher.containerCalls, launcher.spotCalls)
+	}
+	if launcher.spotOpts.Tags["Tool"] != "nmap" || launcher.spotOpts.UserData == "" {
+		t.Fatalf("unexpected spot opts: %#v", launcher.spotOpts)
+	}
+
+	missingTag := baseInfra()
+	missingTag.ComputeMode = "spot"
+	missingTag.ImageTag = " "
+	launcher = &launchRecorder{}
+	result = Launch(context.Background(), LaunchOptions{Infra: missingTag, Launcher: launcher})
+	if result.Err == nil || !result.Spot || launcher.spotCalls != 0 {
+		t.Fatalf("missing tag result = %#v, spot calls = %d", result, launcher.spotCalls)
+	}
+}
+
+func TestCompletionDecisions(t *testing.T) {
+	infra := baseInfra()
+	infra.CleanupPolicy = "destroy-after"
+	infra.OutputDir = "/tmp/results"
+	if got := CompleteScan(infra, fakeStorage{}); got.Action != CompletionExport || got.Warning != "" {
+		t.Fatalf("complete scan with export = %#v", got)
+	}
+
+	infra.OutputDir = ""
+	if got := CompleteScan(infra, nil); got.Action != CompletionNavigate || got.Warning != "destroy-after skipped: no output directory configured" {
+		t.Fatalf("complete scan without output = %#v", got)
+	}
+
+	infra.OutputDir = "/tmp/results"
+	infra.Cloud = cloud.KindManual
+	if got := CompleteScan(infra, nil); got.Action != CompletionNavigate || got.Warning != "destroy-after skipped: selfhosted does not support auto-destroy" {
+		t.Fatalf("complete scan selfhosted = %#v", got)
+	}
+}
+
+func TestCompleteExportAndDestroy(t *testing.T) {
+	boom := errors.New("boom")
+	infra := baseInfra()
+	result := CompleteExport(&infra, &destroyRecorder{}, ExportResult{Err: boom})
+	if result.Action != CompletionNavigate || result.Warning == "" || infra.Exported {
+		t.Fatalf("export failure result = %#v exported=%v", result, infra.Exported)
+	}
+
+	infra = baseInfra()
+	destroyer := &destroyRecorder{}
+	result = CompleteExport(&infra, destroyer, ExportResult{Dir: "/tmp/exported", Count: 3})
+	if result.Action != CompletionDestroy || result.Warning != "" {
+		t.Fatalf("export success result = %#v", result)
+	}
+	if !infra.Exported || infra.ExportDir != "/tmp/exported" {
+		t.Fatalf("export state = exported %v dir %q", infra.Exported, infra.ExportDir)
+	}
+
+	destroyResult := RunAutoDestroy(context.Background(), destroyer)
+	if destroyResult.Err != nil || !destroyer.called {
+		t.Fatalf("destroy result = %#v called=%v", destroyResult, destroyer.called)
+	}
+
+	infra = baseInfra()
+	result = CompleteExport(&infra, nil, ExportResult{Dir: "/tmp/exported"})
+	if result.Action != CompletionNavigate || result.Warning != "destroy-after skipped: no terraform directory" {
+		t.Fatalf("export without destroyer = %#v", result)
+	}
+
+	infra = baseInfra()
+	infra.Cloud = cloud.KindManual
+	result = CompleteExport(&infra, &destroyRecorder{}, ExportResult{Dir: "/tmp/exported"})
+	if result.Action != CompletionNavigate || result.Warning != "destroy-after skipped: selfhosted does not support auto-destroy" {
+		t.Fatalf("selfhosted export result = %#v", result)
+	}
+}
+
+func TestCompleteDestroy(t *testing.T) {
+	infra := baseInfra()
+	if warning := CompleteDestroy(&infra, DestroyResult{}); warning != "" || !infra.Destroyed {
+		t.Fatalf("destroy success warning=%q destroyed=%v", warning, infra.Destroyed)
+	}
+
+	infra = baseInfra()
+	boom := errors.New("boom")
+	if warning := CompleteDestroy(&infra, DestroyResult{Err: boom}); warning != "destroy failed: boom" || infra.DestroyErr != "boom" {
+		t.Fatalf("destroy failure warning=%q err=%q", warning, infra.DestroyErr)
+	}
+}
+
+func TestProgressHelpers(t *testing.T) {
+	now := time.Now()
+	samples := []RateSample{
+		{Time: now.Add(-45 * time.Second), Count: 1},
+		{Time: now.Add(-20 * time.Second), Count: 20},
+	}
+	samples = UpdateRateSamples(samples, 40, now)
+	if len(samples) != 2 || samples[0].Count != 20 || samples[1].Count != 40 {
+		t.Fatalf("samples after prune = %#v", samples)
+	}
+
+	rate, eta := CalcRateETA(samples, 100, 40)
+	if math.Abs(rate-60) > 0.001 {
+		t.Fatalf("rate = %f", rate)
+	}
+	if eta != time.Minute {
+		t.Fatalf("eta = %s", eta)
+	}
+
+	if got := ProgressBar(5, 10, 10); got != "[█████░░░░░]" {
+		t.Fatalf("progress bar = %q", got)
+	}
+	if got := ProgressBar(0, 0, 3); got != "░░░" {
+		t.Fatalf("zero progress bar = %q", got)
+	}
+}
+
+func TestPollProgressAndNavigation(t *testing.T) {
+	tracker := &progressRecorder{count: 4}
+	infra := baseInfra()
+	result := PollProgress(context.Background(), tracker, infra, "nmap")
+	if result.Completed != 4 || result.Err != nil {
+		t.Fatalf("poll result = %#v", result)
+	}
+	if tracker.bucket != "bucket" || tracker.prefix != "scans/nmap/job-123/results/" {
+		t.Fatalf("poll args = bucket %q prefix %q", tracker.bucket, tracker.prefix)
+	}
+
+	msg := NavigateToResults(core.ViewNmapResults, infra)()
+	nav, ok := msg.(core.NavigateWithDataMsg)
+	if !ok {
+		t.Fatalf("navigate msg = %T", msg)
+	}
+	if nav.Target != core.ViewNmapResults {
+		t.Fatalf("target = %v", nav.Target)
+	}
+}

--- a/internal/tui/views/generic/status.go
+++ b/internal/tui/views/generic/status.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -13,26 +12,26 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"heph4estus/internal/cloud"
-	awscloud "heph4estus/internal/cloud/aws"
 	"heph4estus/internal/jobs"
 	"heph4estus/internal/modules"
 	"heph4estus/internal/operator"
 	targetlisttool "heph4estus/internal/tools/targetlist"
 	wordlisttool "heph4estus/internal/tools/wordlist"
 	"heph4estus/internal/tui/core"
+	"heph4estus/internal/tui/statuscore"
 	"heph4estus/internal/worker"
 )
 
-type statusPhase int
+type statusPhase = statuscore.Phase
 
 const (
-	phaseUploading statusPhase = iota // wordlist only: uploading chunks
-	phaseEnqueuing
-	phaseLaunching
-	phaseScanning
-	phaseExporting  // exporting results locally before cleanup
-	phaseDestroying // auto-destroying infrastructure after export
-	phaseComplete
+	phaseUploading  = statuscore.PhaseUploading // wordlist only: uploading chunks
+	phaseEnqueuing  = statuscore.PhaseEnqueuing
+	phaseLaunching  = statuscore.PhaseLaunching
+	phaseScanning   = statuscore.PhaseScanning
+	phaseExporting  = statuscore.PhaseExporting  // exporting results locally before cleanup
+	phaseDestroying = statuscore.PhaseDestroying // auto-destroying infrastructure after export
+	phaseComplete   = statuscore.PhaseComplete
 )
 
 type enqueueProgressMsg struct {
@@ -75,7 +74,7 @@ type uploadCompleteMsg struct {
 	err     error
 }
 
-const SpotThreshold = 50
+const SpotThreshold = statuscore.SpotThreshold
 
 // GenericSubmitter abstracts target enqueueing and worker launching for generic tools.
 type GenericSubmitter interface {
@@ -179,7 +178,7 @@ type StatusModel struct {
 	errMsg               string
 
 	spotInstanceIDs []string
-	rateSamples     []rateSample
+	rateSamples     []statuscore.RateSample
 
 	// Cleanup / export state
 	cleanupWarning string
@@ -187,11 +186,6 @@ type StatusModel struct {
 	help   help.Model
 	width  int
 	height int
-}
-
-type rateSample struct {
-	time  time.Time
-	count int
 }
 
 // NewStatus creates a status view with real cloud clients.
@@ -245,16 +239,12 @@ func NewStatusWithDeps(infra core.InfraOutputs, sub GenericSubmitter, tracker Ge
 }
 
 func (m *StatusModel) trackPhase(phase operator.Phase) {
-	if m.jobTracker != nil && m.infra.JobID != "" {
-		_ = m.jobTracker.UpdatePhase(m.infra.JobID, phase)
-	}
+	statuscore.TrackPhase(m.jobTracker, m.infra.JobID, phase)
 }
 
 // trackFail marks the job as failed if a tracker is available.
 func (m *StatusModel) trackFail(err error) {
-	if m.jobTracker != nil && m.infra.JobID != "" {
-		_ = m.jobTracker.Fail(m.infra.JobID, err)
-	}
+	statuscore.TrackFail(m.jobTracker, m.infra.JobID, err)
 }
 
 func (m *StatusModel) trackCreate() {
@@ -557,27 +547,20 @@ func (m *StatusModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 			m.errMsg = fmt.Sprintf("Progress check failed: %v", msg.err)
 		} else {
 			m.completed = msg.completed
-			m.rateSamples = append(m.rateSamples, rateSample{time: time.Now(), count: msg.completed})
-			cutoff := time.Now().Add(-30 * time.Second)
-			for len(m.rateSamples) > 1 && m.rateSamples[0].time.Before(cutoff) {
-				m.rateSamples = m.rateSamples[1:]
-			}
+			m.rateSamples = statuscore.UpdateRateSamples(m.rateSamples, msg.completed, time.Now())
 		}
 
 		if m.completed >= m.totalTargets {
 			if m.jobTracker != nil && m.infra.JobID != "" {
 				_ = m.jobTracker.Complete(m.infra.JobID)
 			}
-			if m.shouldExport() {
+			result := statuscore.CompleteScan(m.infra, m.storage)
+			if result.Warning != "" {
+				m.cleanupWarning = result.Warning
+			}
+			if result.Action == statuscore.CompletionExport {
 				m.phase = phaseExporting
 				return m, m.exportResults()
-			}
-			if m.infra.CleanupPolicy == "destroy-after" {
-				if m.infra.Cloud.IsSelfhostedFamily() && !m.infra.Cloud.IsProviderNative() {
-					m.cleanupWarning = "destroy-after skipped: selfhosted does not support auto-destroy"
-				} else if m.infra.OutputDir == "" {
-					m.cleanupWarning = "destroy-after skipped: no output directory configured"
-				}
 			}
 			m.phase = phaseComplete
 			return m, m.navigateToResults()
@@ -585,33 +568,24 @@ func (m *StatusModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 		return m, m.pollProgress()
 
 	case exportCompleteMsg:
-		if msg.err != nil {
-			m.cleanupWarning = fmt.Sprintf("destroy-after skipped: export failed (%v)", msg.err)
-			m.phase = phaseComplete
-			return m, m.navigateToResults()
+		result := statuscore.CompleteExport(&m.infra, m.destroyer, statuscore.ExportResult{
+			Dir:   msg.dir,
+			Count: msg.count,
+			Err:   msg.err,
+		})
+		if result.Warning != "" {
+			m.cleanupWarning = result.Warning
 		}
-		m.infra.Exported = true
-		m.infra.ExportDir = msg.dir
-		// Auto-destroy if destroy-after policy and destroyer is available.
-		if m.infra.Cloud.IsSelfhostedFamily() && !m.infra.Cloud.IsProviderNative() {
-			m.cleanupWarning = "destroy-after skipped: selfhosted does not support auto-destroy"
-			m.phase = phaseComplete
-			return m, m.navigateToResults()
-		}
-		if m.destroyer != nil {
+		if result.Action == statuscore.CompletionDestroy {
 			m.phase = phaseDestroying
 			return m, m.runAutoDestroy()
 		}
-		m.cleanupWarning = "destroy-after skipped: no terraform directory"
 		m.phase = phaseComplete
 		return m, m.navigateToResults()
 
 	case autoDestroyCompleteMsg:
-		if msg.err != nil {
-			m.infra.DestroyErr = msg.err.Error()
-			m.cleanupWarning = fmt.Sprintf("destroy failed: %v", msg.err)
-		} else {
-			m.infra.Destroyed = true
+		if warning := statuscore.CompleteDestroy(&m.infra, statuscore.DestroyResult{Err: msg.err}); warning != "" {
+			m.cleanupWarning = warning
 		}
 		m.phase = phaseComplete
 		return m, m.navigateToResults()
@@ -630,18 +604,7 @@ func (m *StatusModel) View() string {
 	elapsed := time.Since(m.startTime).Truncate(time.Second)
 	labelStyle := lipgloss.NewStyle().Foreground(core.Gold).Width(14)
 
-	// Lifecycle summary — shown in all phases.
-	infraLabel := "freshly deployed"
-	if m.infra.Reused {
-		infraLabel = "reused"
-	}
-	fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Infra:"), infraLabel)
-	if m.infra.CleanupPolicy != "" {
-		fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Cleanup:"), m.infra.CleanupPolicy)
-	}
-	if m.infra.Placement.Summary() != "" {
-		fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Placement:"), m.infra.Placement.Summary())
-	}
+	b.WriteString(statuscore.LifecycleSummary(m.infra, labelStyle))
 	b.WriteString("\n")
 
 	unitLabel := "targets"
@@ -733,7 +696,7 @@ func (m *StatusModel) View() string {
 	}
 
 	if m.cleanupWarning != "" {
-		b.WriteString("\n  " + core.MutedStyle.Render(m.cleanupWarning) + "\n")
+		b.WriteString(statuscore.WarningText(m.cleanupWarning))
 	}
 	if m.errMsg != "" {
 		b.WriteString("\n  " + core.ErrorStyle.Render(m.errMsg) + "\n")
@@ -751,180 +714,64 @@ func (m *StatusModel) View() string {
 }
 
 func useSpot(infra core.InfraOutputs) bool {
-	// Selfhosted only supports RunContainer (no spot instances).
-	if infra.Cloud.IsSelfhostedFamily() {
-		return false
-	}
-	switch infra.ComputeMode {
-	case "spot":
-		return true
-	case "fargate":
-		return false
-	default:
-		return infra.WorkerCount >= SpotThreshold
-	}
+	return statuscore.UseSpot(infra)
 }
 
 func (m *StatusModel) launchWorkers() tea.Cmd {
 	infra := m.infra
 	sub := m.submitter
-
-	if useSpot(infra) {
-		return m.launchSpotWorkers()
-	}
-	if infra.Cloud.IsProviderNative() {
-		return func() tea.Msg {
-			launched := infra.FleetWorkerCount
-			if launched <= 0 {
-				launched = infra.WorkerCount
-			}
-			if launched <= 0 {
-				launched = 1
-			}
-			return launchProgressMsg{launched: launched, total: launched}
-		}
-	}
-
 	return func() tea.Msg {
-		_, err := sub.LaunchWorkers(context.Background(), cloud.ContainerOpts{
-			Cluster:        infra.ECSClusterName,
-			TaskDefinition: infra.TaskDefinitionARN,
-			ContainerName:  fmt.Sprintf("%s-worker", infra.ToolName),
-			Subnets:        infra.SubnetIDs,
-			SecurityGroups: []string{infra.SecurityGroupID},
-			Env: map[string]string{
-				"QUEUE_URL":          infra.SQSQueueURL,
-				"S3_BUCKET":          infra.S3BucketName,
-				"TOOL_NAME":          infra.ToolName,
-				"JITTER_MAX_SECONDS": strconv.Itoa(infra.JitterMaxSeconds),
-			},
-			Count: infra.WorkerCount,
+		result := statuscore.Launch(context.Background(), statuscore.LaunchOptions{
+			Infra:         infra,
+			Launcher:      sub,
+			ContainerName: fmt.Sprintf("%s-worker", infra.ToolName),
+			ToolName:      infra.ToolName,
+			WorkerEnv:     statuscore.DefaultWorkerEnv(infra, infra.ToolName),
 		})
-		return launchProgressMsg{launched: infra.WorkerCount, total: infra.WorkerCount, err: err}
-	}
-}
-
-func (m *StatusModel) launchSpotWorkers() tea.Cmd {
-	infra := m.infra
-	sub := m.submitter
-	return func() tea.Msg {
-		imageTag := strings.TrimSpace(infra.ImageTag)
-		if imageTag == "" {
-			return spotLaunchMsg{launchProgressMsg: launchProgressMsg{
-				total: infra.WorkerCount,
-				err:   fmt.Errorf("terraform outputs missing image_tag"),
-			}}
+		msg := launchProgressMsg{launched: result.Launched, total: result.Total, err: result.Err}
+		if result.Spot {
+			return spotLaunchMsg{launchProgressMsg: msg, instanceIDs: result.InstanceIDs}
 		}
-		userData := awscloud.GenerateUserData(awscloud.UserDataOpts{
-			ECRRepoURL: infra.ECRRepoURL,
-			ImageTag:   imageTag,
-			Region:     regionFromECR(infra.ECRRepoURL),
-			EnvVars: map[string]string{
-				"QUEUE_URL":          infra.SQSQueueURL,
-				"S3_BUCKET":          infra.S3BucketName,
-				"TOOL_NAME":          infra.ToolName,
-				"JITTER_MAX_SECONDS": strconv.Itoa(infra.JitterMaxSeconds),
-			},
-		})
-		ids, err := sub.LaunchSpotWorkers(context.Background(), cloud.SpotOpts{
-			AMI:             infra.AMIID,
-			Count:           infra.WorkerCount,
-			SecurityGroups:  []string{infra.SecurityGroupID},
-			SubnetIDs:       infra.SubnetIDs,
-			InstanceProfile: infra.InstanceProfileARN,
-			UserData:        userData,
-			Tags: map[string]string{
-				"Project": "heph4estus",
-				"Tool":    infra.ToolName,
-			},
-		})
-		msg := launchProgressMsg{launched: len(ids), total: infra.WorkerCount, err: err}
-		return spotLaunchMsg{launchProgressMsg: msg, instanceIDs: ids}
+		return msg
 	}
-}
-
-func (m *StatusModel) shouldExport() bool {
-	return m.infra.CleanupPolicy == "destroy-after" && m.infra.OutputDir != "" && m.storage != nil
 }
 
 func (m *StatusModel) exportResults() tea.Cmd {
 	storage := m.storage
 	infra := m.infra
 	return func() tea.Msg {
-		result, err := operator.ExportJob(
-			context.Background(), storage,
-			infra.S3BucketName, infra.ToolName, infra.JobID, infra.OutputDir,
-		)
-		if err != nil {
-			return exportCompleteMsg{err: err}
-		}
-		return exportCompleteMsg{dir: result.Dir, count: result.ResultCount + result.ArtifactCount}
+		result := statuscore.ExportResults(context.Background(), storage, infra, infra.ToolName)
+		return exportCompleteMsg{dir: result.Dir, count: result.Count, err: result.Err}
 	}
 }
 
 func (m *StatusModel) runAutoDestroy() tea.Cmd {
 	d := m.destroyer
 	return func() tea.Msg {
-		err := d.Destroy(context.Background())
-		return autoDestroyCompleteMsg{err: err}
+		result := statuscore.RunAutoDestroy(context.Background(), d)
+		return autoDestroyCompleteMsg{err: result.Err}
 	}
 }
 
 func (m *StatusModel) navigateToResults() tea.Cmd {
-	infra := m.infra
-	return func() tea.Msg {
-		return core.NavigateWithDataMsg{
-			Target: core.ViewGenericResults,
-			Data:   infra,
-		}
-	}
+	return statuscore.NavigateToResults(core.ViewGenericResults, m.infra)
 }
 
 func (m *StatusModel) pollProgress() tea.Cmd {
 	infra := m.infra
 	tracker := m.tracker
-	return tea.Tick(2*time.Second, func(time.Time) tea.Msg {
-		count, err := tracker.CountResults(context.Background(), infra.S3BucketName, jobs.ResultPrefix(infra.ToolName, infra.JobID))
-		return scanProgressMsg{completed: count, err: err}
+	return tea.Tick(statuscore.PollInterval, func(time.Time) tea.Msg {
+		result := statuscore.PollProgress(context.Background(), tracker, infra, infra.ToolName)
+		return scanProgressMsg{completed: result.Completed, err: result.Err}
 	})
 }
 
 func (m *StatusModel) calcRateETA() (targetsPerMin float64, remaining time.Duration) {
-	if len(m.rateSamples) < 2 {
-		return 0, 0
-	}
-	first := m.rateSamples[0]
-	last := m.rateSamples[len(m.rateSamples)-1]
-	dt := last.time.Sub(first.time).Minutes()
-	if dt <= 0 {
-		return 0, 0
-	}
-	dc := float64(last.count - first.count)
-	rate := dc / dt
-	if rate <= 0 {
-		return 0, 0
-	}
-	left := float64(m.totalTargets - m.completed)
-	eta := time.Duration(left/rate*60) * time.Second
-	return rate, eta
+	return statuscore.CalcRateETA(m.rateSamples, m.totalTargets, m.completed)
 }
 
 func progressBar(current, total, width int) string {
-	if total <= 0 {
-		return strings.Repeat("░", width)
-	}
-	filled := min(current*width/total, width)
-	return "[" + strings.Repeat("█", filled) + strings.Repeat("░", width-filled) + "]"
-}
-
-func regionFromECR(url string) string {
-	parts := strings.Split(url, ".")
-	for i, p := range parts {
-		if p == "ecr" && i+1 < len(parts) {
-			return parts[i+1]
-		}
-	}
-	return "us-east-1"
+	return statuscore.ProgressBar(current, total, width)
 }
 
 // parseTargetLines splits content into non-empty, non-comment target lines.

--- a/internal/tui/views/nmap/status.go
+++ b/internal/tui/views/nmap/status.go
@@ -3,7 +3,6 @@ package nmap
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -12,24 +11,24 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"heph4estus/internal/cloud"
-	awscloud "heph4estus/internal/cloud/aws"
 	"heph4estus/internal/jobs"
 	"heph4estus/internal/operator"
 	nmaptool "heph4estus/internal/tools/nmap"
 	"heph4estus/internal/tui/core"
+	"heph4estus/internal/tui/statuscore"
 	"heph4estus/internal/worker"
 )
 
 // Phase of the status view lifecycle.
-type statusPhase int
+type statusPhase = statuscore.Phase
 
 const (
-	phaseEnqueuing statusPhase = iota
-	phaseLaunching
-	phaseScanning
-	phaseExporting  // exporting results locally before cleanup
-	phaseDestroying // auto-destroying infrastructure after export
-	phaseComplete
+	phaseEnqueuing  = statuscore.PhaseEnqueuing
+	phaseLaunching  = statuscore.PhaseLaunching
+	phaseScanning   = statuscore.PhaseScanning
+	phaseExporting  = statuscore.PhaseExporting  // exporting results locally before cleanup
+	phaseDestroying = statuscore.PhaseDestroying // auto-destroying infrastructure after export
+	phaseComplete   = statuscore.PhaseComplete
 )
 
 // enqueueProgressMsg reports batch-send progress.
@@ -66,7 +65,7 @@ type autoDestroyCompleteMsg struct {
 
 // SpotThreshold is the worker count at or above which auto mode selects spot
 // instances instead of Fargate.
-const SpotThreshold = 50
+const SpotThreshold = statuscore.SpotThreshold
 
 // JobSubmitter abstracts target enqueueing and worker launching.
 type JobSubmitter interface {
@@ -103,7 +102,7 @@ func (s *realSubmitter) LaunchSpotWorkers(ctx context.Context, opts cloud.SpotOp
 // atomic ProgressCounter instead of Storage.Count(). At 10k+ targets,
 // Storage.Count() requires 10+ ListObjectsV2 pages per poll — the counter
 // is O(1) regardless of scale.
-const CounterThreshold = 10_000
+const CounterThreshold = statuscore.CounterThreshold
 
 // realTracker automatically selects the progress tracking strategy based on
 // job size. Below CounterThreshold it uses Storage.Count() (simple, no extra
@@ -162,16 +161,11 @@ type StatusModel struct {
 	cleanupWarning string // shown when destroy-after is gated
 
 	// Rolling rate samples
-	rateSamples []rateSample
+	rateSamples []statuscore.RateSample
 
 	help   help.Model
 	width  int
 	height int
-}
-
-type rateSample struct {
-	time  time.Time
-	count int
 }
 
 // NewStatus creates a status view with real cloud clients.
@@ -222,16 +216,12 @@ func NewStatusWithDeps(infra core.InfraOutputs, sub JobSubmitter, tracker Progre
 
 // trackPhase updates the job record if a tracker is available.
 func (m *StatusModel) trackPhase(phase operator.Phase) {
-	if m.jobTracker != nil && m.infra.JobID != "" {
-		_ = m.jobTracker.UpdatePhase(m.infra.JobID, phase)
-	}
+	statuscore.TrackPhase(m.jobTracker, m.infra.JobID, phase)
 }
 
 // trackFail marks the job as failed if a tracker is available.
 func (m *StatusModel) trackFail(err error) {
-	if m.jobTracker != nil && m.infra.JobID != "" {
-		_ = m.jobTracker.Fail(m.infra.JobID, err)
-	}
+	statuscore.TrackFail(m.jobTracker, m.infra.JobID, err)
 }
 
 func (m *StatusModel) trackCreate() {
@@ -368,29 +358,20 @@ func (m *StatusModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 			// Don't stop — try again
 		} else {
 			m.completed = msg.completed
-			m.rateSamples = append(m.rateSamples, rateSample{time: time.Now(), count: msg.completed})
-			// Keep only last 30s of samples
-			cutoff := time.Now().Add(-30 * time.Second)
-			for len(m.rateSamples) > 1 && m.rateSamples[0].time.Before(cutoff) {
-				m.rateSamples = m.rateSamples[1:]
-			}
+			m.rateSamples = statuscore.UpdateRateSamples(m.rateSamples, msg.completed, time.Now())
 		}
 
 		if m.completed >= m.totalTargets {
 			if m.jobTracker != nil && m.infra.JobID != "" {
 				_ = m.jobTracker.Complete(m.infra.JobID)
 			}
-			// Export gating: if destroy-after is set, export locally first.
-			if m.shouldExport() {
+			result := statuscore.CompleteScan(m.infra, m.storage)
+			if result.Warning != "" {
+				m.cleanupWarning = result.Warning
+			}
+			if result.Action == statuscore.CompletionExport {
 				m.phase = phaseExporting
 				return m, m.exportResults()
-			}
-			if m.infra.CleanupPolicy == "destroy-after" {
-				if m.infra.Cloud.IsSelfhostedFamily() && !m.infra.Cloud.IsProviderNative() {
-					m.cleanupWarning = "destroy-after skipped: selfhosted does not support auto-destroy"
-				} else if m.infra.OutputDir == "" {
-					m.cleanupWarning = "destroy-after skipped: no output directory configured"
-				}
 			}
 			m.phase = phaseComplete
 			return m, m.navigateToResults()
@@ -398,33 +379,24 @@ func (m *StatusModel) Update(msg tea.Msg) (core.View, tea.Cmd) {
 		return m, m.pollProgress()
 
 	case exportCompleteMsg:
-		if msg.err != nil {
-			m.cleanupWarning = fmt.Sprintf("destroy-after skipped: export failed (%v)", msg.err)
-			m.phase = phaseComplete
-			return m, m.navigateToResults()
+		result := statuscore.CompleteExport(&m.infra, m.destroyer, statuscore.ExportResult{
+			Dir:   msg.dir,
+			Count: msg.count,
+			Err:   msg.err,
+		})
+		if result.Warning != "" {
+			m.cleanupWarning = result.Warning
 		}
-		m.infra.Exported = true
-		m.infra.ExportDir = msg.dir
-		// Auto-destroy if destroy-after policy and destroyer is available.
-		if m.infra.Cloud.IsSelfhostedFamily() && !m.infra.Cloud.IsProviderNative() {
-			m.cleanupWarning = "destroy-after skipped: selfhosted does not support auto-destroy"
-			m.phase = phaseComplete
-			return m, m.navigateToResults()
-		}
-		if m.destroyer != nil {
+		if result.Action == statuscore.CompletionDestroy {
 			m.phase = phaseDestroying
 			return m, m.runAutoDestroy()
 		}
-		m.cleanupWarning = "destroy-after skipped: no terraform directory"
 		m.phase = phaseComplete
 		return m, m.navigateToResults()
 
 	case autoDestroyCompleteMsg:
-		if msg.err != nil {
-			m.infra.DestroyErr = msg.err.Error()
-			m.cleanupWarning = fmt.Sprintf("destroy failed: %v", msg.err)
-		} else {
-			m.infra.Destroyed = true
+		if warning := statuscore.CompleteDestroy(&m.infra, statuscore.DestroyResult{Err: msg.err}); warning != "" {
+			m.cleanupWarning = warning
 		}
 		m.phase = phaseComplete
 		return m, m.navigateToResults()
@@ -443,18 +415,7 @@ func (m *StatusModel) View() string {
 	elapsed := time.Since(m.startTime).Truncate(time.Second)
 	labelStyle := lipgloss.NewStyle().Foreground(core.Gold).Width(14)
 
-	// Lifecycle summary — shown in all phases.
-	infraLabel := "freshly deployed"
-	if m.infra.Reused {
-		infraLabel = "reused"
-	}
-	fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Infra:"), infraLabel)
-	if m.infra.CleanupPolicy != "" {
-		fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Cleanup:"), m.infra.CleanupPolicy)
-	}
-	if m.infra.Placement.Summary() != "" {
-		fmt.Fprintf(&b, "  %s%s\n", labelStyle.Render("Placement:"), m.infra.Placement.Summary())
-	}
+	b.WriteString(statuscore.LifecycleSummary(m.infra, labelStyle))
 	b.WriteString("\n")
 
 	switch m.phase {
@@ -516,7 +477,7 @@ func (m *StatusModel) View() string {
 	}
 
 	if m.cleanupWarning != "" {
-		b.WriteString("\n  " + core.MutedStyle.Render(m.cleanupWarning) + "\n")
+		b.WriteString(statuscore.WarningText(m.cleanupWarning))
 	}
 	if m.errMsg != "" {
 		b.WriteString("\n  " + core.ErrorStyle.Render(m.errMsg) + "\n")
@@ -535,95 +496,25 @@ func (m *StatusModel) View() string {
 
 // useSpot returns true if the compute mode resolves to spot instances.
 func useSpot(infra core.InfraOutputs) bool {
-	// Selfhosted only supports RunContainer (no spot instances).
-	if infra.Cloud.IsSelfhostedFamily() {
-		return false
-	}
-	switch infra.ComputeMode {
-	case "spot":
-		return true
-	case "fargate":
-		return false
-	default: // "auto" or empty
-		return infra.WorkerCount >= SpotThreshold
-	}
+	return statuscore.UseSpot(infra)
 }
 
 func (m *StatusModel) launchWorkers() tea.Cmd {
 	infra := m.infra
 	sub := m.submitter
-
-	if useSpot(infra) {
-		return m.launchSpotWorkers()
-	}
-	if infra.Cloud.IsProviderNative() {
-		return func() tea.Msg {
-			launched := infra.FleetWorkerCount
-			if launched <= 0 {
-				launched = infra.WorkerCount
-			}
-			if launched <= 0 {
-				launched = 1
-			}
-			return launchProgressMsg{launched: launched, total: launched}
-		}
-	}
-
 	return func() tea.Msg {
-		_, err := sub.LaunchWorkers(context.Background(), cloud.ContainerOpts{
-			Cluster:        infra.ECSClusterName,
-			TaskDefinition: infra.TaskDefinitionARN,
-			ContainerName:  "nmap-worker",
-			Subnets:        infra.SubnetIDs,
-			SecurityGroups: []string{infra.SecurityGroupID},
-			Env: map[string]string{
-				"QUEUE_URL":          infra.SQSQueueURL,
-				"S3_BUCKET":          infra.S3BucketName,
-				"JITTER_MAX_SECONDS": strconv.Itoa(infra.JitterMaxSeconds),
-				"TOOL_NAME":          "nmap",
-			},
-			Count: infra.WorkerCount,
+		result := statuscore.Launch(context.Background(), statuscore.LaunchOptions{
+			Infra:         infra,
+			Launcher:      sub,
+			ContainerName: "nmap-worker",
+			ToolName:      "nmap",
+			WorkerEnv:     statuscore.DefaultWorkerEnv(infra, "nmap"),
 		})
-		return launchProgressMsg{launched: infra.WorkerCount, total: infra.WorkerCount, err: err}
-	}
-}
-
-func (m *StatusModel) launchSpotWorkers() tea.Cmd {
-	infra := m.infra
-	sub := m.submitter
-	return func() tea.Msg {
-		imageTag := strings.TrimSpace(infra.ImageTag)
-		if imageTag == "" {
-			return spotLaunchMsg{launchProgressMsg: launchProgressMsg{
-				total: infra.WorkerCount,
-				err:   fmt.Errorf("terraform outputs missing image_tag"),
-			}}
+		msg := launchProgressMsg{launched: result.Launched, total: result.Total, err: result.Err}
+		if result.Spot {
+			return spotLaunchMsg{launchProgressMsg: msg, instanceIDs: result.InstanceIDs}
 		}
-		userData := awscloud.GenerateUserData(awscloud.UserDataOpts{
-			ECRRepoURL: infra.ECRRepoURL,
-			ImageTag:   imageTag,
-			Region:     regionFromECR(infra.ECRRepoURL),
-			EnvVars: map[string]string{
-				"QUEUE_URL":          infra.SQSQueueURL,
-				"S3_BUCKET":          infra.S3BucketName,
-				"JITTER_MAX_SECONDS": strconv.Itoa(infra.JitterMaxSeconds),
-				"TOOL_NAME":          "nmap",
-			},
-		})
-		ids, err := sub.LaunchSpotWorkers(context.Background(), cloud.SpotOpts{
-			AMI:             infra.AMIID,
-			Count:           infra.WorkerCount,
-			SecurityGroups:  []string{infra.SecurityGroupID},
-			SubnetIDs:       infra.SubnetIDs,
-			InstanceProfile: infra.InstanceProfileARN,
-			UserData:        userData,
-			Tags: map[string]string{
-				"Project": "heph4estus",
-				"Tool":    "nmap",
-			},
-		})
-		msg := launchProgressMsg{launched: len(ids), total: infra.WorkerCount, err: err}
-		return spotLaunchMsg{launchProgressMsg: msg, instanceIDs: ids}
+		return msg
 	}
 }
 
@@ -633,88 +524,40 @@ type spotLaunchMsg struct {
 	instanceIDs []string
 }
 
-func regionFromECR(url string) string {
-	parts := strings.Split(url, ".")
-	for i, p := range parts {
-		if p == "ecr" && i+1 < len(parts) {
-			return parts[i+1]
-		}
-	}
-	return "us-east-1"
-}
-
-// shouldExport returns true when the cleanup policy requires local export
-// before destroy-after can be honored.
-func (m *StatusModel) shouldExport() bool {
-	return m.infra.CleanupPolicy == "destroy-after" && m.infra.OutputDir != "" && m.storage != nil
-}
-
 func (m *StatusModel) exportResults() tea.Cmd {
 	storage := m.storage
 	infra := m.infra
 	return func() tea.Msg {
-		result, err := operator.ExportJob(
-			context.Background(), storage,
-			infra.S3BucketName, "nmap", infra.JobID, infra.OutputDir,
-		)
-		if err != nil {
-			return exportCompleteMsg{err: err}
-		}
-		return exportCompleteMsg{dir: result.Dir, count: result.ResultCount + result.ArtifactCount}
+		result := statuscore.ExportResults(context.Background(), storage, infra, "nmap")
+		return exportCompleteMsg{dir: result.Dir, count: result.Count, err: result.Err}
 	}
 }
 
 func (m *StatusModel) runAutoDestroy() tea.Cmd {
 	d := m.destroyer
 	return func() tea.Msg {
-		err := d.Destroy(context.Background())
-		return autoDestroyCompleteMsg{err: err}
+		result := statuscore.RunAutoDestroy(context.Background(), d)
+		return autoDestroyCompleteMsg{err: result.Err}
 	}
 }
 
 func (m *StatusModel) navigateToResults() tea.Cmd {
-	infra := m.infra
-	return func() tea.Msg {
-		return core.NavigateWithDataMsg{
-			Target: core.ViewNmapResults,
-			Data:   infra,
-		}
-	}
+	return statuscore.NavigateToResults(core.ViewNmapResults, m.infra)
 }
 
 func (m *StatusModel) pollProgress() tea.Cmd {
 	infra := m.infra
 	tracker := m.tracker
-	return tea.Tick(2*time.Second, func(time.Time) tea.Msg {
-		count, err := tracker.CountResults(context.Background(), infra.S3BucketName, jobs.ResultPrefix("nmap", infra.JobID))
-		return scanProgressMsg{completed: count, err: err}
+	return tea.Tick(statuscore.PollInterval, func(time.Time) tea.Msg {
+		result := statuscore.PollProgress(context.Background(), tracker, infra, "nmap")
+		return scanProgressMsg{completed: result.Completed, err: result.Err}
 	})
 }
 
 func (m *StatusModel) calcRateETA() (targetsPerMin float64, remaining time.Duration) {
-	if len(m.rateSamples) < 2 {
-		return 0, 0
-	}
-	first := m.rateSamples[0]
-	last := m.rateSamples[len(m.rateSamples)-1]
-	dt := last.time.Sub(first.time).Minutes()
-	if dt <= 0 {
-		return 0, 0
-	}
-	dc := float64(last.count - first.count)
-	rate := dc / dt
-	if rate <= 0 {
-		return 0, 0
-	}
-	left := float64(m.totalTargets - m.completed)
-	eta := time.Duration(left/rate*60) * time.Second
-	return rate, eta
+	return statuscore.CalcRateETA(m.rateSamples, m.totalTargets, m.completed)
 }
 
 func progressBar(current, total, width int) string {
-	if total <= 0 {
-		return strings.Repeat("░", width)
-	}
-	filled := min(current*width/total, width)
-	return "[" + strings.Repeat("█", filled) + strings.Repeat("░", width-filled) + "]"
+	return statuscore.ProgressBar(current, total, width)
 }


### PR DESCRIPTION
## Summary
- Adds an internal tui/statuscore package for shared TUI status lifecycle behavior across nmap and generic scans.
- Moves common launch mode resolution, provider-native launch handling, spot worker setup, progress polling, rate/ETA math, export-before-destroy decisions, auto-destroy finalization, and lifecycle summary rendering into the shared core.
- Refactors nmap and generic status views onto the shared helpers while keeping nmap option injection and generic target-list/wordlist planning local to their views.
- Adds focused statuscore coverage for launch paths, completion decisions, destroy handling, progress helpers, polling, and navigation.

## Commits
- refactor(tui): extract shared status core

## Validation
- make fmt-check
- env GOCACHE=/tmp/heph-go-build make vet
- env GOCACHE=/tmp/heph-go-build make test
- env XDG_CACHE_HOME=/tmp/heph-cache GOCACHE=/tmp/heph-go-build make lint
- git diff --check

## Notes
- TUI copy, keybindings, navigation targets, and result payloads are intended to remain unchanged.
- Generic target-list/wordlist upload/planning and nmap parsing/option injection intentionally remain package-local.
- This PR keeps the shared core to common fragments rather than introducing a single full renderer.
- Existing untracked local roadmap/docs artifacts were left out of this branch.