### PR TITLE
PR 12.5: Thin CLI commands

### DIFF
--- a/cmd/heph/cmd_lifecycle_test.go
+++ b/cmd/heph/cmd_lifecycle_test.go
@@ -16,7 +16,10 @@ import (
 	"heph4estus/internal/infra"
 	"heph4estus/internal/modules"
 	"heph4estus/internal/operator"
+	"heph4estus/internal/scanapp"
 	nmaptool "heph4estus/internal/tools/nmap"
+	targetlisttool "heph4estus/internal/tools/targetlist"
+	wordlisttool "heph4estus/internal/tools/wordlist"
 	"heph4estus/internal/worker"
 )
 
@@ -133,6 +136,63 @@ func targetListModule(fileInput bool) *modules.ModuleDefinition {
 		DefaultMemory: 512,
 		Timeout:       "1m",
 	}
+}
+
+func preflightTargetListFile(path string, workers int) (*targetlisttool.Metadata, error) {
+	return scanapp.PreflightTargetListFile(path, workers)
+}
+
+func preflightWordlistFile(tool, path, runtimeTarget, options string, chunks, workers int) (*wordlisttool.Metadata, error) {
+	return scanapp.PreflightWordlistFile(tool, path, runtimeTarget, options, chunks, workers)
+}
+
+func runTargetListScan(ctx context.Context, tool, jobID, inputFile string, preflight *targetlisttool.Metadata, mod *modules.ModuleDefinition, options string, workers int, computeMode, format string, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, outputs infra.TerraformOutputs, bucket, queueURL string, tracker *operator.Tracker, cloudKind cloud.Kind, placementPolicy fleet.PlacementPolicy) (bool, error) {
+	return scanapp.RunTargetListScan(ctx, scanapp.TargetListOptions{
+		ToolName:    tool,
+		JobID:       jobID,
+		InputFile:   inputFile,
+		Preflight:   preflight,
+		Module:      mod,
+		ToolOptions: options,
+		Workers:     workers,
+		ComputeMode: computeMode,
+		Format:      format,
+		Queue:       queue,
+		Storage:     storage,
+		Compute:     compute,
+		Outputs:     outputs,
+		Bucket:      bucket,
+		QueueURL:    queueURL,
+		Tracker:     tracker,
+		CloudKind:   cloudKind,
+		Placement:   placementPolicy,
+		Statusf:     logStatus,
+		FleetWaiter: waitForProviderNativeFleetFunc,
+	})
+}
+
+func runNmapScanWithDeps(ctx context.Context, tasks []nmaptool.ScanTask, workers int, computeMode string, jitterMax int, format string, outputs infra.TerraformOutputs, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, tracker *operator.Tracker, jobID string, placementPolicy fleet.PlacementPolicy, cloudKind ...cloud.Kind) (bool, error) {
+	kind := cloud.KindAWS
+	if len(cloudKind) > 0 {
+		kind = cloudKind[0]
+	}
+	return scanapp.RunNmapScan(ctx, scanapp.NmapScanOptions{
+		Tasks:       tasks,
+		Workers:     workers,
+		ComputeMode: computeMode,
+		JitterMax:   jitterMax,
+		Format:      format,
+		Outputs:     outputs,
+		Queue:       queue,
+		Storage:     storage,
+		Compute:     compute,
+		Tracker:     tracker,
+		JobID:       jobID,
+		Placement:   placementPolicy,
+		CloudKind:   kind,
+		Statusf:     logStatus,
+		FleetWaiter: waitForProviderNativeFleetFunc,
+	})
 }
 
 func TestPreflightTargetListFileRejectsEmptyTargets(t *testing.T) {

--- a/cmd/heph/cmd_nmap.go
+++ b/cmd/heph/cmd_nmap.go
@@ -1,13 +1,9 @@
 package main
 
 import (
-	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
-	"strconv"
-	"strings"
 
 	"heph4estus/internal/cloud"
 	"heph4estus/internal/fleet"
@@ -15,9 +11,8 @@ import (
 	"heph4estus/internal/jobs"
 	"heph4estus/internal/logger"
 	"heph4estus/internal/operator"
+	"heph4estus/internal/scanapp"
 	"heph4estus/internal/scanruntime"
-	"heph4estus/internal/tools/nmap"
-	"heph4estus/internal/worker"
 )
 
 func runNmap(args []string, log logger.Logger) error {
@@ -93,229 +88,38 @@ func runNmap(args []string, log logger.Logger) error {
 		return fmt.Errorf("--port-chunks must be positive")
 	}
 
-	content, err := os.ReadFile(*inputFile)
-	if err != nil {
-		return fmt.Errorf("reading target file: %w", err)
-	}
-
-	// Parse targets.
-	scanner := nmap.NewScanner(log)
-	tasks := scanner.ParseTargetsWithMode(string(content), *defaultOptions, *mode, *portChunks)
-
-	// Inject nmap-specific options into each task at enqueue time (producer-side).
-	if *noRDNS {
-		for i := range tasks {
-			tasks[i].Options = "-n " + tasks[i].Options
-		}
-	}
-	if *timingTemplate != "" {
-		for i := range tasks {
-			tasks[i].Options = fmt.Sprintf("-T%s %s", *timingTemplate, tasks[i].Options)
-		}
-	}
-	if *dnsServers != "" {
-		for i := range tasks {
-			tasks[i].Options = fmt.Sprintf("--dns-servers %s %s", *dnsServers, tasks[i].Options)
-		}
-	}
-
-	if len(tasks) == 0 {
-		return fmt.Errorf("no targets found in %s", *inputFile)
-	}
-	jobID := jobs.NewID("nmap")
-	for i := range tasks {
-		tasks[i].JobID = jobID
-	}
-	if *mode == "target-ports" {
-		groups := countGroups(tasks)
-		logStatus("Mode: target-ports — %d target groups, %d total tasks (%d chunks/target) [job %s]", groups, len(tasks), *portChunks, jobID)
-	} else {
-		logStatus("Parsed %d targets from %s [job %s]", len(tasks), *inputFile, jobID)
-	}
-
-	ctx := mainContext()
-	env, err := scanruntime.Setup(ctx, scanruntime.SetupOptions{
-		ToolName:  "nmap",
-		CloudKind: cloudKind,
-		Workers:   *workers,
+	result, err := scanapp.RunNmap(mainContext(), scanapp.NmapOptions{
+		InputFile:      *inputFile,
+		DefaultOptions: *defaultOptions,
+		Workers:        *workers,
+		ComputeMode:    *computeMode,
+		Placement:      placementPolicy,
+		Mode:           *mode,
+		PortChunks:     *portChunks,
+		DNSServers:     *dnsServers,
+		TimingTemplate: *timingTemplate,
+		JitterMax:      *jitterMax,
+		NoRDNS:         *noRDNS,
+		Format:         *format,
+		OutDir:         *outDir,
+		CloudKind:      cloudKind,
 		LifecyclePolicy: infra.LifecyclePolicy{
 			NoDeploy:     *noDeploy,
 			AutoApprove:  *autoApprove,
 			DestroyAfter: *destroyAfter,
 		},
-		PromptFunc: deployPrompt,
-		Stream:     os.Stderr,
-		Log:        log,
-	})
-	if err != nil {
-		return err
-	}
-
-	// Track the job.
-	tracker := newTracker()
-	cleanupPolicy := scanruntime.CleanupPolicy(*destroyAfter)
-	_ = scanruntime.CreateJobRecord(scanruntime.JobRecordOptions{
-		Tracker:       tracker,
-		JobID:         jobID,
-		ToolName:      "nmap",
-		TotalTasks:    len(tasks),
-		Workers:       *workers,
-		ComputeMode:   *computeMode,
-		CloudKind:     cloudKind,
-		CleanupPolicy: cleanupPolicy,
-		Bucket:        env.Bucket,
-		Outputs:       env.Outputs,
-		Placement:     placementPolicy,
-	})
-
-	// Run the scan.
-	var (
-		provider cloud.Provider
-		scanErr  error
-		started  bool
-	)
-	provider, err = scanruntime.BuildProvider(ctx, scanruntime.ProviderOptions{
-		CloudKind:       cloudKind,
-		Outputs:         env.Outputs,
+		PromptFunc:      deployPrompt,
+		Stream:          os.Stderr,
+		Output:          os.Stdout,
 		Log:             log,
+		Statusf:         logStatus,
 		ProviderBuilder: buildRuntimeProvider,
+		FleetWaiter:     waitForProviderNativeFleetFunc,
 	})
-	if err != nil {
-		scanErr = fmt.Errorf("building cloud provider: %w", err)
-	} else {
-		started, scanErr = runNmapScanWithDeps(ctx, tasks, *workers, *computeMode, *jitterMax, *format, env.Outputs, provider.Queue(), provider.Storage(), provider.Compute(), tracker, jobID, placementPolicy, cloudKind)
+	if result.Started {
+		printRunSummary(result.JobID, result.Tool, result.Reused, result.CleanupPolicy, result.ExportDir)
 	}
-
-	var storage cloud.Storage
-	if provider != nil {
-		storage = provider.Storage()
-	}
-	finalized, finalizeErr := scanruntime.Finalize(ctx, scanruntime.FinalizeOptions{
-		JobID:        jobID,
-		ToolName:     "nmap",
-		Tracker:      tracker,
-		Started:      started,
-		ScanErr:      scanErr,
-		OutDir:       *outDir,
-		Storage:      storage,
-		Bucket:       env.Bucket,
-		DestroyAfter: *destroyAfter,
-		CloudKind:    cloudKind,
-		ToolConfig:   env.ToolConfig,
-		Stream:       os.Stderr,
-		Log:          log,
-		Statusf:      logStatus,
-	})
-	if finalizeErr != nil {
-		return finalizeErr
-	}
-
-	// Print run summary.
-	if started {
-		printRunSummary(jobID, "nmap", env.Reused, cleanupPolicy, finalized.ExportDir)
-	}
-
-	return scanErr
-}
-
-func runNmapScanWithDeps(ctx context.Context, tasks []nmap.ScanTask, workers int, computeMode string, jitterMax int, format string, outputs infra.TerraformOutputs, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, tracker *operator.Tracker, jobID string, placementPolicy fleet.PlacementPolicy, cloudKind ...cloud.Kind) (bool, error) {
-	genericTasks := make([]worker.Task, len(tasks))
-	for i, t := range tasks {
-		genericTasks[i] = worker.Task{
-			ToolName:    "nmap",
-			JobID:       t.JobID,
-			Target:      t.Target,
-			Options:     t.Options,
-			GroupID:     t.GroupID,
-			ChunkIdx:    t.ChunkIdx,
-			TotalChunks: t.TotalChunks,
-		}
-	}
-
-	kind := cloud.KindAWS
-	if len(cloudKind) > 0 {
-		kind = cloudKind[0]
-	}
-	queueURL := outputs.AWS.SQSQueueURL
-	if queueURL == "" {
-		queueURL = outputs.Selfhosted.QueueURL
-	}
-	bucket := outputs.AWS.S3BucketName
-	if bucket == "" {
-		bucket = outputs.Selfhosted.S3BucketName
-	}
-	return scanruntime.ExecuteQueuedScan(ctx, scanruntime.ExecuteOptions{
-		ToolName:     "nmap",
-		JobID:        jobID,
-		Tasks:        genericTasks,
-		EnqueueLabel: "targets",
-		Workers:      workers,
-		ComputeMode:  computeMode,
-		Queue:        queue,
-		Storage:      storage,
-		Compute:      compute,
-		Outputs:      outputs,
-		QueueURL:     queueURL,
-		Bucket:       bucket,
-		CloudKind:    kind,
-		Placement:    placementPolicy,
-		Tracker:      tracker,
-		WorkerEnv: map[string]string{
-			"QUEUE_URL":          queueURL,
-			"S3_BUCKET":          bucket,
-			"JITTER_MAX_SECONDS": strconv.Itoa(jitterMax),
-			"TOOL_NAME":          "nmap",
-		},
-		ContainerName: "nmap-worker",
-		CompleteLabel: "targets",
-		RenderResults: func(renderCtx context.Context, renderStorage cloud.Storage, renderBucket, prefix string) error {
-			return outputResults(renderCtx, renderStorage, renderBucket, prefix, format)
-		},
-		Statusf:     logStatus,
-		FleetWaiter: waitForProviderNativeFleetFunc,
-	})
-}
-
-func outputResults(ctx context.Context, storage cloud.Storage, bucket, prefix, format string) error {
-	keys, err := storage.List(ctx, bucket, prefix)
-	if err != nil {
-		return fmt.Errorf("listing results: %w", err)
-	}
-
-	if format == "json" {
-		encoder := json.NewEncoder(os.Stdout)
-		for _, key := range keys {
-			// Only process .json result files (skip .xml output files from generic worker).
-			if !strings.HasSuffix(key, ".json") {
-				continue
-			}
-			data, err := storage.Download(ctx, bucket, key)
-			if err != nil {
-				logStatus("Warning: failed to download %s: %v", key, err)
-				continue
-			}
-			var result worker.Result
-			if err := json.Unmarshal(data, &result); err != nil {
-				logStatus("Warning: failed to parse %s: %v", key, err)
-				continue
-			}
-			if err := encoder.Encode(result); err != nil {
-				return fmt.Errorf("encoding result: %w", err)
-			}
-		}
-	} else {
-		fmt.Printf("\n%-40s %s\n", "TARGET", "STATUS")
-		fmt.Println(strings.Repeat("─", 50))
-		for _, key := range keys {
-			if !strings.HasSuffix(key, ".json") {
-				continue
-			}
-			target := extractTargetFromKey(key)
-			fmt.Printf("%-40s %s\n", target, "done")
-		}
-		fmt.Printf("\n%d results written to s3://%s/%s\n", len(keys), bucket, prefix)
-	}
-	return nil
+	return err
 }
 
 func resolveComputeMode(mode string, workers int) bool {
@@ -329,16 +133,6 @@ func regionFromECR(url string) string {
 
 func extractTargetFromKey(key string) string {
 	return jobs.TargetFromKey(key)
-}
-
-func countGroups(tasks []nmap.ScanTask) int {
-	seen := make(map[string]bool)
-	for _, t := range tasks {
-		if t.GroupID != "" {
-			seen[t.GroupID] = true
-		}
-	}
-	return len(seen)
 }
 
 func splitOutputList(s string) []string {

--- a/cmd/heph/cmd_scan.go
+++ b/cmd/heph/cmd_scan.go
@@ -1,25 +1,18 @@
 package main
 
 import (
-	"context"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	"heph4estus/internal/cloud"
 	"heph4estus/internal/fleet"
 	"heph4estus/internal/infra"
-	"heph4estus/internal/jobs"
 	"heph4estus/internal/logger"
 	"heph4estus/internal/modules"
 	"heph4estus/internal/operator"
-	"heph4estus/internal/scanruntime"
-	targetlisttool "heph4estus/internal/tools/targetlist"
-	wordlisttool "heph4estus/internal/tools/wordlist"
-	"heph4estus/internal/worker"
+	"heph4estus/internal/scanapp"
 )
 
 func runScan(args []string, log logger.Logger) error {
@@ -126,401 +119,35 @@ func runScan(args []string, log logger.Logger) error {
 		}
 	}
 
-	// Validate local inputs before any lifecycle side effects.
-	var targetMeta *targetlisttool.Metadata
-	var wordlistMeta *wordlisttool.Metadata
-	if mod.InputType == modules.InputTypeWordlist {
-		wordlistMeta, err = preflightWordlistFile(*tool, *wordlistFile, *runtimeTarget, *options, *chunks, *workers)
-		if err != nil {
-			return err
-		}
-	} else {
-		targetMeta, err = preflightTargetListFile(*inputFile, *workers)
-		if err != nil {
-			return err
-		}
-	}
-
-	ctx := mainContext()
-	env, err := scanruntime.Setup(ctx, scanruntime.SetupOptions{
-		ToolName:  *tool,
-		CloudKind: cloudKind,
-		Workers:   *workers,
+	result, err := scanapp.RunGeneric(mainContext(), scanapp.GenericOptions{
+		ToolName:      *tool,
+		InputFile:     *inputFile,
+		WordlistFile:  *wordlistFile,
+		RuntimeTarget: *runtimeTarget,
+		ToolOptions:   *options,
+		Chunks:        *chunks,
+		Workers:       *workers,
+		ComputeMode:   *computeMode,
+		Format:        *format,
+		OutDir:        *outDir,
+		CloudKind:     cloudKind,
+		Placement:     placementPolicy,
 		LifecyclePolicy: infra.LifecyclePolicy{
 			NoDeploy:     *noDeploy,
 			AutoApprove:  *autoApprove,
 			DestroyAfter: *destroyAfter,
 		},
-		PromptFunc: deployPrompt,
-		Stream:     os.Stderr,
-		Log:        log,
-	})
-	if err != nil {
-		return err
-	}
-
-	provider, err := scanruntime.BuildProvider(ctx, scanruntime.ProviderOptions{
-		CloudKind:       cloudKind,
-		Outputs:         env.Outputs,
+		Module:          mod,
+		PromptFunc:      deployPrompt,
+		Stream:          os.Stderr,
+		Output:          os.Stdout,
 		Log:             log,
+		Statusf:         logStatus,
 		ProviderBuilder: buildRuntimeProvider,
+		FleetWaiter:     waitForProviderNativeFleetFunc,
 	})
-	if err != nil {
-		return fmt.Errorf("building cloud provider: %w", err)
+	if result.Started {
+		printRunSummary(result.JobID, result.Tool, result.Reused, result.CleanupPolicy, result.ExportDir)
 	}
-	queue := provider.Queue()
-	storage := provider.Storage()
-	compute := provider.Compute()
-
-	jobID := jobs.NewID(*tool)
-
-	// Track the job.
-	tracker := newTracker()
-	cleanupPolicy := scanruntime.CleanupPolicy(*destroyAfter)
-	_ = scanruntime.CreateJobRecord(scanruntime.JobRecordOptions{
-		Tracker:       tracker,
-		JobID:         jobID,
-		ToolName:      *tool,
-		Workers:       *workers,
-		ComputeMode:   *computeMode,
-		CloudKind:     cloudKind,
-		CleanupPolicy: cleanupPolicy,
-		Bucket:        env.Bucket,
-		Outputs:       env.Outputs,
-		Placement:     placementPolicy,
-	})
-
-	var (
-		scanErr error
-		started bool
-	)
-	if mod.InputType == modules.InputTypeWordlist {
-		started, scanErr = runWordlistScan(ctx, *tool, jobID, *wordlistFile, wordlistMeta, *runtimeTarget, *options, *chunks, *workers, *computeMode, *format, queue, storage, compute, env.Outputs, env.Bucket, env.QueueURL, tracker, cloudKind, placementPolicy)
-	} else {
-		started, scanErr = runTargetListScan(ctx, *tool, jobID, *inputFile, targetMeta, mod, *options, *workers, *computeMode, *format, queue, storage, compute, env.Outputs, env.Bucket, env.QueueURL, tracker, cloudKind, placementPolicy)
-	}
-
-	finalized, finalizeErr := scanruntime.Finalize(ctx, scanruntime.FinalizeOptions{
-		JobID:        jobID,
-		ToolName:     *tool,
-		Tracker:      tracker,
-		Started:      started,
-		ScanErr:      scanErr,
-		OutDir:       *outDir,
-		Storage:      storage,
-		Bucket:       env.Bucket,
-		DestroyAfter: *destroyAfter,
-		CloudKind:    cloudKind,
-		ToolConfig:   env.ToolConfig,
-		Stream:       os.Stderr,
-		Log:          log,
-		Statusf:      logStatus,
-	})
-	if finalizeErr != nil {
-		return finalizeErr
-	}
-
-	// Print run summary.
-	if started {
-		printRunSummary(jobID, *tool, env.Reused, cleanupPolicy, finalized.ExportDir)
-	}
-
-	return scanErr
-}
-
-func runTargetListScan(ctx context.Context, tool, jobID, inputFile string, preflight *targetlisttool.Metadata, mod *modules.ModuleDefinition, options string, workers int, computeMode, format string, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, outputs infra.TerraformOutputs, bucket, queueURL string, tracker *operator.Tracker, cloudKind cloud.Kind, placementPolicy fleet.PlacementPolicy) (bool, error) {
-	fileBacked := targetListUsesFileInput(mod)
-	var (
-		tempDir string
-		err     error
-	)
-	if fileBacked {
-		if err := targetlisttool.CleanupStaleTempDirs(targetlisttool.DefaultStaleTempAge); err != nil {
-			logStatus("Warning: failed to clean stale target-list temp dirs: %v", err)
-		}
-		tempDir, err = os.MkdirTemp("", "heph-targetlist-*")
-		if err != nil {
-			return false, fmt.Errorf("creating target-list temp dir: %w", err)
-		}
-		defer func() {
-			if err := os.RemoveAll(tempDir); err != nil {
-				logStatus("Warning: failed to remove target-list temp dir %s: %v", tempDir, err)
-			}
-		}()
-	}
-
-	plan, err := jobs.PlanTargetListFile(tool, jobID, options, inputFile, tempDir, workers, fileBacked)
-	if err != nil {
-		return false, fmt.Errorf("planning target-list job: %w", err)
-	}
-	defer func() {
-		if err := plan.Cleanup(); err != nil {
-			logStatus("Warning: failed to clean temporary target-list chunks: %v", err)
-		}
-	}()
-
-	sourceBytes := plan.TotalSourceBytes
-	if preflight != nil && preflight.TotalSourceBytes > 0 {
-		sourceBytes = preflight.TotalSourceBytes
-	}
-	if plan.FileBacked {
-		logStatus("Parsed %d targets from %s (%s); chunks effective=%d target=%s max=%s [job %s]",
-			plan.TotalTargets,
-			inputFile,
-			formatByteSize(sourceBytes),
-			plan.EffectiveChunks,
-			formatByteSize(plan.TargetChunkSize),
-			formatByteSize(plan.MaxChunkSize),
-			jobID,
-		)
-	} else {
-		logStatus("Parsed %d targets from %s [job %s]", plan.TotalTargets, inputFile, jobID)
-	}
-
-	if plan.FileBacked {
-		_ = tracker.UpdatePhase(jobID, operator.PhaseUploading)
-		logStatus("Uploading %d target-list chunks to s3://%s/...", plan.EffectiveChunks, bucket)
-		uploadCtx, uploadCancel := context.WithTimeout(ctx, scanruntime.EnqueueTimeout)
-		defer uploadCancel()
-		if err := jobs.UploadTargetListChunks(uploadCtx, storage, bucket, plan); err != nil {
-			return false, fmt.Errorf("uploading target-list chunks: %w", err)
-		}
-	}
-
-	if plan.FileBacked {
-		if err := plan.Cleanup(); err != nil {
-			logStatus("Warning: failed to clean temporary target-list chunks: %v", err)
-		}
-	}
-
-	// Update job record with total task count.
-	if store := tracker.Store(); store != nil {
-		if rec, loadErr := store.Load(jobID); loadErr == nil {
-			rec.TotalTasks = len(plan.Tasks)
-			rec.TotalTargets = plan.TotalTargets
-			_ = store.Update(rec)
-		}
-	}
-
-	unitLabel := "targets"
-	if plan.FileBacked {
-		unitLabel = "chunks"
-	}
-	return scanruntime.ExecuteQueuedScan(ctx, scanruntime.ExecuteOptions{
-		ToolName:      tool,
-		JobID:         jobID,
-		Tasks:         plan.Tasks,
-		EnqueueLabel:  "target tasks",
-		Workers:       workers,
-		ComputeMode:   computeMode,
-		Queue:         queue,
-		Storage:       storage,
-		Compute:       compute,
-		Outputs:       outputs,
-		QueueURL:      queueURL,
-		Bucket:        bucket,
-		CloudKind:     cloudKind,
-		Placement:     placementPolicy,
-		Tracker:       tracker,
-		ProgressLabel: unitLabel,
-		CompleteLabel: unitLabel,
-		RenderResults: func(renderCtx context.Context, renderStorage cloud.Storage, renderBucket, prefix string) error {
-			return outputGenericResults(renderCtx, renderStorage, renderBucket, prefix, format)
-		},
-		Statusf:     logStatus,
-		FleetWaiter: waitForProviderNativeFleetFunc,
-	})
-}
-
-func runWordlistScan(ctx context.Context, tool, jobID, wordlistFile string, preflight *wordlisttool.Metadata, runtimeTarget, options string, chunks, workers int, computeMode, format string, queue cloud.Queue, storage cloud.Storage, compute cloud.Compute, outputs infra.TerraformOutputs, bucket, queueURL string, tracker *operator.Tracker, cloudKind cloud.Kind, placementPolicy fleet.PlacementPolicy) (bool, error) {
-	if err := wordlisttool.CleanupStaleTempDirs(wordlisttool.DefaultStaleTempAge); err != nil {
-		logStatus("Warning: failed to clean stale wordlist temp dirs: %v", err)
-	}
-
-	tempDir, err := os.MkdirTemp("", "heph-wordlist-*")
-	if err != nil {
-		return false, fmt.Errorf("creating wordlist temp dir: %w", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			logStatus("Warning: failed to remove wordlist temp dir %s: %v", tempDir, err)
-		}
-	}()
-
-	plan, err := jobs.PlanWordlistFile(tool, jobID, runtimeTarget, options, wordlistFile, tempDir, chunks, workers)
-	if err != nil {
-		return false, fmt.Errorf("planning wordlist job: %w", err)
-	}
-	defer func() {
-		if err := plan.Cleanup(); err != nil {
-			logStatus("Warning: failed to clean temporary wordlist chunks: %v", err)
-		}
-	}()
-
-	requested := "auto"
-	if chunks > 0 {
-		requested = strconv.Itoa(chunks)
-	}
-	sourceBytes := plan.TotalSourceBytes
-	if preflight != nil && preflight.TotalSourceBytes > 0 {
-		sourceBytes = preflight.TotalSourceBytes
-	}
-	logStatus("Parsed %d entries from %s (%s); chunks requested=%s effective=%d target=%s max=%s [job %s]",
-		plan.TotalWords,
-		wordlistFile,
-		formatByteSize(sourceBytes),
-		requested,
-		plan.EffectiveChunks,
-		formatByteSize(plan.TargetChunkSize),
-		formatByteSize(plan.MaxChunkSize),
-		jobID,
-	)
-	if runtimeTarget != "" {
-		logStatus("Target: %s", runtimeTarget)
-	}
-
-	// Update job record with wordlist metadata.
-	_ = tracker.UpdatePhase(jobID, operator.PhaseUploading)
-	if store := tracker.Store(); store != nil {
-		if rec, loadErr := store.Load(jobID); loadErr == nil {
-			rec.TotalTasks = plan.EffectiveChunks
-			rec.TotalWords = plan.TotalWords
-			rec.RuntimeTarget = runtimeTarget
-			_ = store.Update(rec)
-		}
-	}
-
-	// Upload chunks.
-	logStatus("Uploading %d chunks to s3://%s/...", plan.EffectiveChunks, bucket)
-	uploadCtx, uploadCancel := context.WithTimeout(ctx, scanruntime.EnqueueTimeout)
-	defer uploadCancel()
-	if err := jobs.UploadChunks(uploadCtx, storage, bucket, plan); err != nil {
-		return false, fmt.Errorf("uploading wordlist chunks: %w", err)
-	}
-
-	if err := plan.Cleanup(); err != nil {
-		logStatus("Warning: failed to clean temporary wordlist chunks: %v", err)
-	}
-
-	return scanruntime.ExecuteQueuedScan(ctx, scanruntime.ExecuteOptions{
-		ToolName:      tool,
-		JobID:         jobID,
-		Tasks:         plan.Tasks,
-		EnqueueLabel:  "chunk tasks",
-		Workers:       workers,
-		ComputeMode:   computeMode,
-		Queue:         queue,
-		Storage:       storage,
-		Compute:       compute,
-		Outputs:       outputs,
-		QueueURL:      queueURL,
-		Bucket:        bucket,
-		CloudKind:     cloudKind,
-		Placement:     placementPolicy,
-		Tracker:       tracker,
-		ProgressLabel: "chunks",
-		CompleteLabel: "chunks",
-		RenderResults: func(renderCtx context.Context, renderStorage cloud.Storage, renderBucket, prefix string) error {
-			return outputGenericResults(renderCtx, renderStorage, renderBucket, prefix, format)
-		},
-		Statusf:     logStatus,
-		FleetWaiter: waitForProviderNativeFleetFunc,
-	})
-}
-
-func preflightTargetListFile(path string, workers int) (*targetlisttool.Metadata, error) {
-	meta, err := targetlisttool.InspectFile(path, targetlisttool.Policy{WorkerCount: workers})
-	if err != nil {
-		return nil, fmt.Errorf("validating target file: %w", err)
-	}
-	return meta, nil
-}
-
-func preflightWordlistFile(_, path, _, _ string, chunks, workers int) (*wordlisttool.Metadata, error) {
-	meta, err := wordlisttool.InspectFile(path, wordlisttool.Policy{
-		RequestedChunks: chunks,
-		WorkerCount:     workers,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("validating wordlist file: %w", err)
-	}
-	return meta, nil
-}
-
-func formatByteSize(n int64) string {
-	const mib = 1024 * 1024
-	if n%mib == 0 && n >= mib {
-		return fmt.Sprintf("%d MiB", n/mib)
-	}
-	return fmt.Sprintf("%d bytes", n)
-}
-
-func outputGenericResults(ctx context.Context, storage cloud.Storage, bucket, prefix, format string) error {
-	keys, err := storage.List(ctx, bucket, prefix)
-	if err != nil {
-		return fmt.Errorf("listing results: %w", err)
-	}
-
-	if format == "json" {
-		encoder := json.NewEncoder(os.Stdout)
-		for _, key := range keys {
-			if !strings.HasSuffix(key, ".json") {
-				continue
-			}
-			data, err := storage.Download(ctx, bucket, key)
-			if err != nil {
-				logStatus("Warning: failed to download %s: %v", key, err)
-				continue
-			}
-			var result worker.Result
-			if err := json.Unmarshal(data, &result); err != nil {
-				logStatus("Warning: failed to parse %s: %v", key, err)
-				continue
-			}
-			if err := encoder.Encode(result); err != nil {
-				return fmt.Errorf("encoding result: %w", err)
-			}
-		}
-	} else {
-		fmt.Printf("\n%-40s %-10s %s\n", "TARGET", "CHUNK", "STATUS")
-		fmt.Println(strings.Repeat("─", 60))
-		var failures int
-		for _, key := range keys {
-			if !strings.HasSuffix(key, ".json") {
-				continue
-			}
-			target := extractTargetFromKey(key)
-			status := "OK"
-			chunkLabel := ""
-			data, err := storage.Download(ctx, bucket, key)
-			if err != nil {
-				status = "???"
-			} else {
-				var result worker.Result
-				if err := json.Unmarshal(data, &result); err == nil {
-					if result.Target != "" {
-						target = result.Target
-					}
-					if result.TotalChunks > 0 {
-						chunkLabel = fmt.Sprintf("%d/%d", result.ChunkIdx+1, result.TotalChunks)
-					}
-					if result.Error != "" {
-						status = "ERROR"
-						failures++
-					}
-				}
-			}
-			fmt.Printf("%-40s %-10s %s\n", target, chunkLabel, status)
-		}
-		fmt.Printf("\n%d results written to s3://%s/%s", len(keys), bucket, prefix)
-		if failures > 0 {
-			fmt.Printf(" (%d failed)", failures)
-		}
-		fmt.Println()
-	}
-	return nil
-}
-
-func targetListUsesFileInput(mod *modules.ModuleDefinition) bool {
-	return mod != nil && mod.NeedsInput() && !mod.NeedsTarget()
+	return err
 }

--- a/cmd/heph/main.go
+++ b/cmd/heph/main.go
@@ -71,17 +71,6 @@ func run(args []string, log logger.Logger) error {
 	}
 }
 
-// newTracker returns a job tracker backed by the default store.
-// If the config directory is unavailable, returns a noop tracker
-// so CLI commands still work without job persistence.
-func newTracker() *operator.Tracker {
-	store, err := operator.NewJobStore()
-	if err != nil {
-		return operator.NoopTracker()
-	}
-	return operator.NewTracker(store)
-}
-
 func main() {
 	log := logger.NewSimpleLogger()
 

--- a/internal/scanapp/scanapp.go
+++ b/internal/scanapp/scanapp.go
@@ -1,0 +1,925 @@
+package scanapp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"heph4estus/internal/cloud"
+	"heph4estus/internal/fleet"
+	"heph4estus/internal/infra"
+	"heph4estus/internal/jobs"
+	"heph4estus/internal/logger"
+	"heph4estus/internal/modules"
+	"heph4estus/internal/operator"
+	"heph4estus/internal/scanruntime"
+	nmaptool "heph4estus/internal/tools/nmap"
+	targetlisttool "heph4estus/internal/tools/targetlist"
+	wordlisttool "heph4estus/internal/tools/wordlist"
+	"heph4estus/internal/worker"
+)
+
+// RunResult summarizes a CLI scan run for command-layer output decisions.
+type RunResult struct {
+	JobID         string
+	Tool          string
+	Started       bool
+	Reused        bool
+	CleanupPolicy string
+	ExportDir     string
+}
+
+// GenericOptions contains the already parsed and validated generic scan intent.
+type GenericOptions struct {
+	ToolName        string
+	InputFile       string
+	WordlistFile    string
+	RuntimeTarget   string
+	ToolOptions     string
+	Chunks          int
+	Workers         int
+	ComputeMode     string
+	Format          string
+	OutDir          string
+	CloudKind       cloud.Kind
+	Placement       fleet.PlacementPolicy
+	LifecyclePolicy infra.LifecyclePolicy
+	Module          *modules.ModuleDefinition
+	PromptFunc      func(string) bool
+	Stream          io.Writer
+	Output          io.Writer
+	Log             logger.Logger
+	Statusf         scanruntime.StatusFunc
+	ProviderBuilder scanruntime.ProviderBuilder
+	FleetWaiter     scanruntime.ProviderNativeFleetWaiter
+	Tracker         *operator.Tracker
+}
+
+// NmapOptions contains the already parsed and validated nmap scan intent.
+type NmapOptions struct {
+	InputFile       string
+	DefaultOptions  string
+	Workers         int
+	ComputeMode     string
+	Placement       fleet.PlacementPolicy
+	Mode            string
+	PortChunks      int
+	DNSServers      string
+	TimingTemplate  string
+	JitterMax       int
+	NoRDNS          bool
+	Format          string
+	OutDir          string
+	CloudKind       cloud.Kind
+	LifecyclePolicy infra.LifecyclePolicy
+	PromptFunc      func(string) bool
+	Stream          io.Writer
+	Output          io.Writer
+	Log             logger.Logger
+	Statusf         scanruntime.StatusFunc
+	ProviderBuilder scanruntime.ProviderBuilder
+	FleetWaiter     scanruntime.ProviderNativeFleetWaiter
+	Tracker         *operator.Tracker
+}
+
+// TargetListOptions executes a planned target-list scan against injected deps.
+type TargetListOptions struct {
+	ToolName    string
+	JobID       string
+	InputFile   string
+	Preflight   *targetlisttool.Metadata
+	Module      *modules.ModuleDefinition
+	ToolOptions string
+	Workers     int
+	ComputeMode string
+	Format      string
+	Queue       cloud.Queue
+	Storage     cloud.Storage
+	Compute     cloud.Compute
+	Outputs     infra.TerraformOutputs
+	Bucket      string
+	QueueURL    string
+	Tracker     *operator.Tracker
+	CloudKind   cloud.Kind
+	Placement   fleet.PlacementPolicy
+	Output      io.Writer
+	Statusf     scanruntime.StatusFunc
+	FleetWaiter scanruntime.ProviderNativeFleetWaiter
+}
+
+// WordlistOptions executes a planned wordlist scan against injected deps.
+type WordlistOptions struct {
+	ToolName      string
+	JobID         string
+	WordlistFile  string
+	Preflight     *wordlisttool.Metadata
+	RuntimeTarget string
+	ToolOptions   string
+	Chunks        int
+	Workers       int
+	ComputeMode   string
+	Format        string
+	Queue         cloud.Queue
+	Storage       cloud.Storage
+	Compute       cloud.Compute
+	Outputs       infra.TerraformOutputs
+	Bucket        string
+	QueueURL      string
+	Tracker       *operator.Tracker
+	CloudKind     cloud.Kind
+	Placement     fleet.PlacementPolicy
+	Output        io.Writer
+	Statusf       scanruntime.StatusFunc
+	FleetWaiter   scanruntime.ProviderNativeFleetWaiter
+}
+
+// NmapScanOptions executes parsed nmap tasks against injected deps.
+type NmapScanOptions struct {
+	Tasks       []nmaptool.ScanTask
+	Workers     int
+	ComputeMode string
+	JitterMax   int
+	Format      string
+	Outputs     infra.TerraformOutputs
+	Queue       cloud.Queue
+	Storage     cloud.Storage
+	Compute     cloud.Compute
+	Tracker     *operator.Tracker
+	JobID       string
+	Placement   fleet.PlacementPolicy
+	CloudKind   cloud.Kind
+	Output      io.Writer
+	Statusf     scanruntime.StatusFunc
+	FleetWaiter scanruntime.ProviderNativeFleetWaiter
+}
+
+// DefaultTracker returns a tracker backed by the default local job store.
+func DefaultTracker() *operator.Tracker {
+	store, err := operator.NewJobStore()
+	if err != nil {
+		return operator.NoopTracker()
+	}
+	return operator.NewTracker(store)
+}
+
+func RunGeneric(ctx context.Context, opts GenericOptions) (RunResult, error) {
+	opts.Log = loggerOrDefault(opts.Log)
+	opts.Stream = writerOrDefault(opts.Stream, os.Stderr)
+	opts.Output = writerOrDefault(opts.Output, os.Stdout)
+	opts.Statusf = statusOrNoop(opts.Statusf)
+	if opts.Tracker == nil {
+		opts.Tracker = DefaultTracker()
+	}
+
+	var (
+		targetMeta   *targetlisttool.Metadata
+		wordlistMeta *wordlisttool.Metadata
+		err          error
+	)
+	if opts.Module != nil && opts.Module.InputType == modules.InputTypeWordlist {
+		wordlistMeta, err = PreflightWordlistFile(opts.ToolName, opts.WordlistFile, opts.RuntimeTarget, opts.ToolOptions, opts.Chunks, opts.Workers)
+	} else {
+		targetMeta, err = PreflightTargetListFile(opts.InputFile, opts.Workers)
+	}
+	if err != nil {
+		return RunResult{}, err
+	}
+
+	env, err := scanruntime.Setup(ctx, scanruntime.SetupOptions{
+		ToolName:        opts.ToolName,
+		CloudKind:       opts.CloudKind,
+		Workers:         opts.Workers,
+		LifecyclePolicy: opts.LifecyclePolicy,
+		PromptFunc:      opts.PromptFunc,
+		Stream:          opts.Stream,
+		Log:             opts.Log,
+	})
+	if err != nil {
+		return RunResult{}, err
+	}
+
+	provider, err := scanruntime.BuildProvider(ctx, scanruntime.ProviderOptions{
+		CloudKind:       opts.CloudKind,
+		Outputs:         env.Outputs,
+		Log:             opts.Log,
+		ProviderBuilder: opts.ProviderBuilder,
+	})
+	if err != nil {
+		return RunResult{}, fmt.Errorf("building cloud provider: %w", err)
+	}
+
+	jobID := jobs.NewID(opts.ToolName)
+	cleanupPolicy := scanruntime.CleanupPolicy(opts.LifecyclePolicy.DestroyAfter)
+	_ = scanruntime.CreateJobRecord(scanruntime.JobRecordOptions{
+		Tracker:       opts.Tracker,
+		JobID:         jobID,
+		ToolName:      opts.ToolName,
+		Workers:       opts.Workers,
+		ComputeMode:   opts.ComputeMode,
+		CloudKind:     opts.CloudKind,
+		CleanupPolicy: cleanupPolicy,
+		Bucket:        env.Bucket,
+		Outputs:       env.Outputs,
+		Placement:     opts.Placement,
+	})
+
+	var started bool
+	var scanErr error
+	if opts.Module != nil && opts.Module.InputType == modules.InputTypeWordlist {
+		started, scanErr = RunWordlistScan(ctx, WordlistOptions{
+			ToolName:      opts.ToolName,
+			JobID:         jobID,
+			WordlistFile:  opts.WordlistFile,
+			Preflight:     wordlistMeta,
+			RuntimeTarget: opts.RuntimeTarget,
+			ToolOptions:   opts.ToolOptions,
+			Chunks:        opts.Chunks,
+			Workers:       opts.Workers,
+			ComputeMode:   opts.ComputeMode,
+			Format:        opts.Format,
+			Queue:         provider.Queue(),
+			Storage:       provider.Storage(),
+			Compute:       provider.Compute(),
+			Outputs:       env.Outputs,
+			Bucket:        env.Bucket,
+			QueueURL:      env.QueueURL,
+			Tracker:       opts.Tracker,
+			CloudKind:     opts.CloudKind,
+			Placement:     opts.Placement,
+			Output:        opts.Output,
+			Statusf:       opts.Statusf,
+			FleetWaiter:   opts.FleetWaiter,
+		})
+	} else {
+		started, scanErr = RunTargetListScan(ctx, TargetListOptions{
+			ToolName:    opts.ToolName,
+			JobID:       jobID,
+			InputFile:   opts.InputFile,
+			Preflight:   targetMeta,
+			Module:      opts.Module,
+			ToolOptions: opts.ToolOptions,
+			Workers:     opts.Workers,
+			ComputeMode: opts.ComputeMode,
+			Format:      opts.Format,
+			Queue:       provider.Queue(),
+			Storage:     provider.Storage(),
+			Compute:     provider.Compute(),
+			Outputs:     env.Outputs,
+			Bucket:      env.Bucket,
+			QueueURL:    env.QueueURL,
+			Tracker:     opts.Tracker,
+			CloudKind:   opts.CloudKind,
+			Placement:   opts.Placement,
+			Output:      opts.Output,
+			Statusf:     opts.Statusf,
+			FleetWaiter: opts.FleetWaiter,
+		})
+	}
+
+	finalized, finalizeErr := scanruntime.Finalize(ctx, scanruntime.FinalizeOptions{
+		JobID:        jobID,
+		ToolName:     opts.ToolName,
+		Tracker:      opts.Tracker,
+		Started:      started,
+		ScanErr:      scanErr,
+		OutDir:       opts.OutDir,
+		Storage:      provider.Storage(),
+		Bucket:       env.Bucket,
+		DestroyAfter: opts.LifecyclePolicy.DestroyAfter,
+		CloudKind:    opts.CloudKind,
+		ToolConfig:   env.ToolConfig,
+		Stream:       opts.Stream,
+		Log:          opts.Log,
+		Statusf:      opts.Statusf,
+	})
+	if finalizeErr != nil {
+		return RunResult{}, finalizeErr
+	}
+
+	return RunResult{
+		JobID:         jobID,
+		Tool:          opts.ToolName,
+		Started:       started,
+		Reused:        env.Reused,
+		CleanupPolicy: cleanupPolicy,
+		ExportDir:     finalized.ExportDir,
+	}, scanErr
+}
+
+func RunNmap(ctx context.Context, opts NmapOptions) (RunResult, error) {
+	opts.Log = loggerOrDefault(opts.Log)
+	opts.Stream = writerOrDefault(opts.Stream, os.Stderr)
+	opts.Output = writerOrDefault(opts.Output, os.Stdout)
+	opts.Statusf = statusOrNoop(opts.Statusf)
+	if opts.Tracker == nil {
+		opts.Tracker = DefaultTracker()
+	}
+
+	content, err := os.ReadFile(opts.InputFile)
+	if err != nil {
+		return RunResult{}, fmt.Errorf("reading target file: %w", err)
+	}
+
+	scanner := nmaptool.NewScanner(opts.Log)
+	tasks := scanner.ParseTargetsWithMode(string(content), opts.DefaultOptions, opts.Mode, opts.PortChunks)
+	for i := range tasks {
+		if opts.NoRDNS {
+			tasks[i].Options = "-n " + tasks[i].Options
+		}
+		if opts.TimingTemplate != "" {
+			tasks[i].Options = fmt.Sprintf("-T%s %s", opts.TimingTemplate, tasks[i].Options)
+		}
+		if opts.DNSServers != "" {
+			tasks[i].Options = fmt.Sprintf("--dns-servers %s %s", opts.DNSServers, tasks[i].Options)
+		}
+	}
+	if len(tasks) == 0 {
+		return RunResult{}, fmt.Errorf("no targets found in %s", opts.InputFile)
+	}
+
+	jobID := jobs.NewID("nmap")
+	for i := range tasks {
+		tasks[i].JobID = jobID
+	}
+	if opts.Mode == "target-ports" {
+		opts.Statusf("Mode: target-ports — %d target groups, %d total tasks (%d chunks/target) [job %s]", countGroups(tasks), len(tasks), opts.PortChunks, jobID)
+	} else {
+		opts.Statusf("Parsed %d targets from %s [job %s]", len(tasks), opts.InputFile, jobID)
+	}
+
+	env, err := scanruntime.Setup(ctx, scanruntime.SetupOptions{
+		ToolName:        "nmap",
+		CloudKind:       opts.CloudKind,
+		Workers:         opts.Workers,
+		LifecyclePolicy: opts.LifecyclePolicy,
+		PromptFunc:      opts.PromptFunc,
+		Stream:          opts.Stream,
+		Log:             opts.Log,
+	})
+	if err != nil {
+		return RunResult{}, err
+	}
+
+	cleanupPolicy := scanruntime.CleanupPolicy(opts.LifecyclePolicy.DestroyAfter)
+	_ = scanruntime.CreateJobRecord(scanruntime.JobRecordOptions{
+		Tracker:       opts.Tracker,
+		JobID:         jobID,
+		ToolName:      "nmap",
+		TotalTasks:    len(tasks),
+		Workers:       opts.Workers,
+		ComputeMode:   opts.ComputeMode,
+		CloudKind:     opts.CloudKind,
+		CleanupPolicy: cleanupPolicy,
+		Bucket:        env.Bucket,
+		Outputs:       env.Outputs,
+		Placement:     opts.Placement,
+	})
+
+	var (
+		provider cloud.Provider
+		scanErr  error
+		started  bool
+	)
+	provider, err = scanruntime.BuildProvider(ctx, scanruntime.ProviderOptions{
+		CloudKind:       opts.CloudKind,
+		Outputs:         env.Outputs,
+		Log:             opts.Log,
+		ProviderBuilder: opts.ProviderBuilder,
+	})
+	if err != nil {
+		scanErr = fmt.Errorf("building cloud provider: %w", err)
+	} else {
+		started, scanErr = RunNmapScan(ctx, NmapScanOptions{
+			Tasks:       tasks,
+			Workers:     opts.Workers,
+			ComputeMode: opts.ComputeMode,
+			JitterMax:   opts.JitterMax,
+			Format:      opts.Format,
+			Outputs:     env.Outputs,
+			Queue:       provider.Queue(),
+			Storage:     provider.Storage(),
+			Compute:     provider.Compute(),
+			Tracker:     opts.Tracker,
+			JobID:       jobID,
+			Placement:   opts.Placement,
+			CloudKind:   opts.CloudKind,
+			Output:      opts.Output,
+			Statusf:     opts.Statusf,
+			FleetWaiter: opts.FleetWaiter,
+		})
+	}
+
+	var storage cloud.Storage
+	if provider != nil {
+		storage = provider.Storage()
+	}
+	finalized, finalizeErr := scanruntime.Finalize(ctx, scanruntime.FinalizeOptions{
+		JobID:        jobID,
+		ToolName:     "nmap",
+		Tracker:      opts.Tracker,
+		Started:      started,
+		ScanErr:      scanErr,
+		OutDir:       opts.OutDir,
+		Storage:      storage,
+		Bucket:       env.Bucket,
+		DestroyAfter: opts.LifecyclePolicy.DestroyAfter,
+		CloudKind:    opts.CloudKind,
+		ToolConfig:   env.ToolConfig,
+		Stream:       opts.Stream,
+		Log:          opts.Log,
+		Statusf:      opts.Statusf,
+	})
+	if finalizeErr != nil {
+		return RunResult{}, finalizeErr
+	}
+
+	return RunResult{
+		JobID:         jobID,
+		Tool:          "nmap",
+		Started:       started,
+		Reused:        env.Reused,
+		CleanupPolicy: cleanupPolicy,
+		ExportDir:     finalized.ExportDir,
+	}, scanErr
+}
+
+func RunTargetListScan(ctx context.Context, opts TargetListOptions) (bool, error) {
+	opts.Output = writerOrDefault(opts.Output, io.Discard)
+	opts.Statusf = statusOrNoop(opts.Statusf)
+	opts.Tracker = trackerOrNoop(opts.Tracker)
+
+	fileBacked := targetListUsesFileInput(opts.Module)
+	var (
+		tempDir string
+		err     error
+	)
+	if fileBacked {
+		if err := targetlisttool.CleanupStaleTempDirs(targetlisttool.DefaultStaleTempAge); err != nil {
+			opts.Statusf("Warning: failed to clean stale target-list temp dirs: %v", err)
+		}
+		tempDir, err = os.MkdirTemp("", "heph-targetlist-*")
+		if err != nil {
+			return false, fmt.Errorf("creating target-list temp dir: %w", err)
+		}
+		defer func() {
+			if err := os.RemoveAll(tempDir); err != nil {
+				opts.Statusf("Warning: failed to remove target-list temp dir %s: %v", tempDir, err)
+			}
+		}()
+	}
+
+	plan, err := jobs.PlanTargetListFile(opts.ToolName, opts.JobID, opts.ToolOptions, opts.InputFile, tempDir, opts.Workers, fileBacked)
+	if err != nil {
+		return false, fmt.Errorf("planning target-list job: %w", err)
+	}
+	defer func() {
+		if err := plan.Cleanup(); err != nil {
+			opts.Statusf("Warning: failed to clean temporary target-list chunks: %v", err)
+		}
+	}()
+
+	sourceBytes := plan.TotalSourceBytes
+	if opts.Preflight != nil && opts.Preflight.TotalSourceBytes > 0 {
+		sourceBytes = opts.Preflight.TotalSourceBytes
+	}
+	if plan.FileBacked {
+		opts.Statusf("Parsed %d targets from %s (%s); chunks effective=%d target=%s max=%s [job %s]",
+			plan.TotalTargets,
+			opts.InputFile,
+			formatByteSize(sourceBytes),
+			plan.EffectiveChunks,
+			formatByteSize(plan.TargetChunkSize),
+			formatByteSize(plan.MaxChunkSize),
+			opts.JobID,
+		)
+	} else {
+		opts.Statusf("Parsed %d targets from %s [job %s]", plan.TotalTargets, opts.InputFile, opts.JobID)
+	}
+
+	if plan.FileBacked {
+		_ = opts.Tracker.UpdatePhase(opts.JobID, operator.PhaseUploading)
+		opts.Statusf("Uploading %d target-list chunks to s3://%s/...", plan.EffectiveChunks, opts.Bucket)
+		uploadCtx, uploadCancel := context.WithTimeout(ctx, scanruntime.EnqueueTimeout)
+		defer uploadCancel()
+		if err := jobs.UploadTargetListChunks(uploadCtx, opts.Storage, opts.Bucket, plan); err != nil {
+			return false, fmt.Errorf("uploading target-list chunks: %w", err)
+		}
+	}
+
+	if plan.FileBacked {
+		if err := plan.Cleanup(); err != nil {
+			opts.Statusf("Warning: failed to clean temporary target-list chunks: %v", err)
+		}
+	}
+
+	if store := opts.Tracker.Store(); store != nil {
+		if rec, loadErr := store.Load(opts.JobID); loadErr == nil {
+			rec.TotalTasks = len(plan.Tasks)
+			rec.TotalTargets = plan.TotalTargets
+			_ = store.Update(rec)
+		}
+	}
+
+	unitLabel := "targets"
+	if plan.FileBacked {
+		unitLabel = "chunks"
+	}
+	return scanruntime.ExecuteQueuedScan(ctx, scanruntime.ExecuteOptions{
+		ToolName:      opts.ToolName,
+		JobID:         opts.JobID,
+		Tasks:         plan.Tasks,
+		EnqueueLabel:  "target tasks",
+		Workers:       opts.Workers,
+		ComputeMode:   opts.ComputeMode,
+		Queue:         opts.Queue,
+		Storage:       opts.Storage,
+		Compute:       opts.Compute,
+		Outputs:       opts.Outputs,
+		QueueURL:      opts.QueueURL,
+		Bucket:        opts.Bucket,
+		CloudKind:     opts.CloudKind,
+		Placement:     opts.Placement,
+		Tracker:       opts.Tracker,
+		ProgressLabel: unitLabel,
+		CompleteLabel: unitLabel,
+		RenderResults: func(renderCtx context.Context, renderStorage cloud.Storage, renderBucket, prefix string) error {
+			return outputGenericResults(renderCtx, renderStorage, renderBucket, prefix, opts.Format, opts.Output, opts.Statusf)
+		},
+		Statusf:     opts.Statusf,
+		FleetWaiter: opts.FleetWaiter,
+	})
+}
+
+func RunWordlistScan(ctx context.Context, opts WordlistOptions) (bool, error) {
+	opts.Output = writerOrDefault(opts.Output, io.Discard)
+	opts.Statusf = statusOrNoop(opts.Statusf)
+	opts.Tracker = trackerOrNoop(opts.Tracker)
+
+	if err := wordlisttool.CleanupStaleTempDirs(wordlisttool.DefaultStaleTempAge); err != nil {
+		opts.Statusf("Warning: failed to clean stale wordlist temp dirs: %v", err)
+	}
+
+	tempDir, err := os.MkdirTemp("", "heph-wordlist-*")
+	if err != nil {
+		return false, fmt.Errorf("creating wordlist temp dir: %w", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			opts.Statusf("Warning: failed to remove wordlist temp dir %s: %v", tempDir, err)
+		}
+	}()
+
+	plan, err := jobs.PlanWordlistFile(opts.ToolName, opts.JobID, opts.RuntimeTarget, opts.ToolOptions, opts.WordlistFile, tempDir, opts.Chunks, opts.Workers)
+	if err != nil {
+		return false, fmt.Errorf("planning wordlist job: %w", err)
+	}
+	defer func() {
+		if err := plan.Cleanup(); err != nil {
+			opts.Statusf("Warning: failed to clean temporary wordlist chunks: %v", err)
+		}
+	}()
+
+	requested := "auto"
+	if opts.Chunks > 0 {
+		requested = strconv.Itoa(opts.Chunks)
+	}
+	sourceBytes := plan.TotalSourceBytes
+	if opts.Preflight != nil && opts.Preflight.TotalSourceBytes > 0 {
+		sourceBytes = opts.Preflight.TotalSourceBytes
+	}
+	opts.Statusf("Parsed %d entries from %s (%s); chunks requested=%s effective=%d target=%s max=%s [job %s]",
+		plan.TotalWords,
+		opts.WordlistFile,
+		formatByteSize(sourceBytes),
+		requested,
+		plan.EffectiveChunks,
+		formatByteSize(plan.TargetChunkSize),
+		formatByteSize(plan.MaxChunkSize),
+		opts.JobID,
+	)
+	if opts.RuntimeTarget != "" {
+		opts.Statusf("Target: %s", opts.RuntimeTarget)
+	}
+
+	_ = opts.Tracker.UpdatePhase(opts.JobID, operator.PhaseUploading)
+	if store := opts.Tracker.Store(); store != nil {
+		if rec, loadErr := store.Load(opts.JobID); loadErr == nil {
+			rec.TotalTasks = plan.EffectiveChunks
+			rec.TotalWords = plan.TotalWords
+			rec.RuntimeTarget = opts.RuntimeTarget
+			_ = store.Update(rec)
+		}
+	}
+
+	opts.Statusf("Uploading %d chunks to s3://%s/...", plan.EffectiveChunks, opts.Bucket)
+	uploadCtx, uploadCancel := context.WithTimeout(ctx, scanruntime.EnqueueTimeout)
+	defer uploadCancel()
+	if err := jobs.UploadChunks(uploadCtx, opts.Storage, opts.Bucket, plan); err != nil {
+		return false, fmt.Errorf("uploading wordlist chunks: %w", err)
+	}
+
+	if err := plan.Cleanup(); err != nil {
+		opts.Statusf("Warning: failed to clean temporary wordlist chunks: %v", err)
+	}
+
+	return scanruntime.ExecuteQueuedScan(ctx, scanruntime.ExecuteOptions{
+		ToolName:      opts.ToolName,
+		JobID:         opts.JobID,
+		Tasks:         plan.Tasks,
+		EnqueueLabel:  "chunk tasks",
+		Workers:       opts.Workers,
+		ComputeMode:   opts.ComputeMode,
+		Queue:         opts.Queue,
+		Storage:       opts.Storage,
+		Compute:       opts.Compute,
+		Outputs:       opts.Outputs,
+		QueueURL:      opts.QueueURL,
+		Bucket:        opts.Bucket,
+		CloudKind:     opts.CloudKind,
+		Placement:     opts.Placement,
+		Tracker:       opts.Tracker,
+		ProgressLabel: "chunks",
+		CompleteLabel: "chunks",
+		RenderResults: func(renderCtx context.Context, renderStorage cloud.Storage, renderBucket, prefix string) error {
+			return outputGenericResults(renderCtx, renderStorage, renderBucket, prefix, opts.Format, opts.Output, opts.Statusf)
+		},
+		Statusf:     opts.Statusf,
+		FleetWaiter: opts.FleetWaiter,
+	})
+}
+
+func RunNmapScan(ctx context.Context, opts NmapScanOptions) (bool, error) {
+	opts.Output = writerOrDefault(opts.Output, io.Discard)
+	opts.Statusf = statusOrNoop(opts.Statusf)
+	opts.Tracker = trackerOrNoop(opts.Tracker)
+
+	genericTasks := make([]worker.Task, len(opts.Tasks))
+	for i, task := range opts.Tasks {
+		genericTasks[i] = worker.Task{
+			ToolName:    "nmap",
+			JobID:       task.JobID,
+			Target:      task.Target,
+			Options:     task.Options,
+			GroupID:     task.GroupID,
+			ChunkIdx:    task.ChunkIdx,
+			TotalChunks: task.TotalChunks,
+		}
+	}
+
+	queueURL, bucket := queueAndBucket(opts.Outputs)
+	if opts.CloudKind == "" {
+		opts.CloudKind = cloud.KindAWS
+	}
+	return scanruntime.ExecuteQueuedScan(ctx, scanruntime.ExecuteOptions{
+		ToolName:     "nmap",
+		JobID:        opts.JobID,
+		Tasks:        genericTasks,
+		EnqueueLabel: "targets",
+		Workers:      opts.Workers,
+		ComputeMode:  opts.ComputeMode,
+		Queue:        opts.Queue,
+		Storage:      opts.Storage,
+		Compute:      opts.Compute,
+		Outputs:      opts.Outputs,
+		QueueURL:     queueURL,
+		Bucket:       bucket,
+		CloudKind:    opts.CloudKind,
+		Placement:    opts.Placement,
+		Tracker:      opts.Tracker,
+		WorkerEnv: map[string]string{
+			"QUEUE_URL":          queueURL,
+			"S3_BUCKET":          bucket,
+			"JITTER_MAX_SECONDS": strconv.Itoa(opts.JitterMax),
+			"TOOL_NAME":          "nmap",
+		},
+		ContainerName: "nmap-worker",
+		CompleteLabel: "targets",
+		RenderResults: func(renderCtx context.Context, renderStorage cloud.Storage, renderBucket, prefix string) error {
+			return outputNmapResults(renderCtx, renderStorage, renderBucket, prefix, opts.Format, opts.Output, opts.Statusf)
+		},
+		Statusf:     opts.Statusf,
+		FleetWaiter: opts.FleetWaiter,
+	})
+}
+
+func PreflightTargetListFile(path string, workers int) (*targetlisttool.Metadata, error) {
+	meta, err := targetlisttool.InspectFile(path, targetlisttool.Policy{WorkerCount: workers})
+	if err != nil {
+		return nil, fmt.Errorf("validating target file: %w", err)
+	}
+	return meta, nil
+}
+
+func PreflightWordlistFile(_, path, _, _ string, chunks, workers int) (*wordlisttool.Metadata, error) {
+	meta, err := wordlisttool.InspectFile(path, wordlisttool.Policy{
+		RequestedChunks: chunks,
+		WorkerCount:     workers,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("validating wordlist file: %w", err)
+	}
+	return meta, nil
+}
+
+func queueAndBucket(outputs infra.TerraformOutputs) (string, string) {
+	queueURL := outputs.AWS.SQSQueueURL
+	if queueURL == "" {
+		queueURL = outputs.Selfhosted.QueueURL
+	}
+	bucket := outputs.AWS.S3BucketName
+	if bucket == "" {
+		bucket = outputs.Selfhosted.S3BucketName
+	}
+	return queueURL, bucket
+}
+
+func formatByteSize(n int64) string {
+	const mib = 1024 * 1024
+	if n%mib == 0 && n >= mib {
+		return fmt.Sprintf("%d MiB", n/mib)
+	}
+	return fmt.Sprintf("%d bytes", n)
+}
+
+func outputGenericResults(ctx context.Context, storage cloud.Storage, bucket, prefix, format string, output io.Writer, statusf scanruntime.StatusFunc) error {
+	keys, err := storage.List(ctx, bucket, prefix)
+	if err != nil {
+		return fmt.Errorf("listing results: %w", err)
+	}
+
+	if format == "json" {
+		encoder := json.NewEncoder(output)
+		for _, key := range keys {
+			if !strings.HasSuffix(key, ".json") {
+				continue
+			}
+			data, err := storage.Download(ctx, bucket, key)
+			if err != nil {
+				statusf("Warning: failed to download %s: %v", key, err)
+				continue
+			}
+			var result worker.Result
+			if err := json.Unmarshal(data, &result); err != nil {
+				statusf("Warning: failed to parse %s: %v", key, err)
+				continue
+			}
+			if err := encoder.Encode(result); err != nil {
+				return fmt.Errorf("encoding result: %w", err)
+			}
+		}
+	} else {
+		if err := writeOutputf(output, "\n%-40s %-10s %s\n", "TARGET", "CHUNK", "STATUS"); err != nil {
+			return err
+		}
+		if err := writeOutputln(output, strings.Repeat("─", 60)); err != nil {
+			return err
+		}
+		var failures int
+		for _, key := range keys {
+			if !strings.HasSuffix(key, ".json") {
+				continue
+			}
+			target := jobs.TargetFromKey(key)
+			status := "OK"
+			chunkLabel := ""
+			data, err := storage.Download(ctx, bucket, key)
+			if err != nil {
+				status = "???"
+			} else {
+				var result worker.Result
+				if err := json.Unmarshal(data, &result); err == nil {
+					if result.Target != "" {
+						target = result.Target
+					}
+					if result.TotalChunks > 0 {
+						chunkLabel = fmt.Sprintf("%d/%d", result.ChunkIdx+1, result.TotalChunks)
+					}
+					if result.Error != "" {
+						status = "ERROR"
+						failures++
+					}
+				}
+			}
+			if err := writeOutputf(output, "%-40s %-10s %s\n", target, chunkLabel, status); err != nil {
+				return err
+			}
+		}
+		if err := writeOutputf(output, "\n%d results written to s3://%s/%s", len(keys), bucket, prefix); err != nil {
+			return err
+		}
+		if failures > 0 {
+			if err := writeOutputf(output, " (%d failed)", failures); err != nil {
+				return err
+			}
+		}
+		if err := writeOutputln(output); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func outputNmapResults(ctx context.Context, storage cloud.Storage, bucket, prefix, format string, output io.Writer, statusf scanruntime.StatusFunc) error {
+	keys, err := storage.List(ctx, bucket, prefix)
+	if err != nil {
+		return fmt.Errorf("listing results: %w", err)
+	}
+
+	if format == "json" {
+		encoder := json.NewEncoder(output)
+		for _, key := range keys {
+			if !strings.HasSuffix(key, ".json") {
+				continue
+			}
+			data, err := storage.Download(ctx, bucket, key)
+			if err != nil {
+				statusf("Warning: failed to download %s: %v", key, err)
+				continue
+			}
+			var result worker.Result
+			if err := json.Unmarshal(data, &result); err != nil {
+				statusf("Warning: failed to parse %s: %v", key, err)
+				continue
+			}
+			if err := encoder.Encode(result); err != nil {
+				return fmt.Errorf("encoding result: %w", err)
+			}
+		}
+	} else {
+		if err := writeOutputf(output, "\n%-40s %s\n", "TARGET", "STATUS"); err != nil {
+			return err
+		}
+		if err := writeOutputln(output, strings.Repeat("─", 50)); err != nil {
+			return err
+		}
+		for _, key := range keys {
+			if !strings.HasSuffix(key, ".json") {
+				continue
+			}
+			target := jobs.TargetFromKey(key)
+			if err := writeOutputf(output, "%-40s %s\n", target, "done"); err != nil {
+				return err
+			}
+		}
+		if err := writeOutputf(output, "\n%d results written to s3://%s/%s\n", len(keys), bucket, prefix); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeOutputf(output io.Writer, format string, args ...interface{}) error {
+	_, err := fmt.Fprintf(output, format, args...)
+	return err
+}
+
+func writeOutputln(output io.Writer, args ...interface{}) error {
+	_, err := fmt.Fprintln(output, args...)
+	return err
+}
+
+func targetListUsesFileInput(mod *modules.ModuleDefinition) bool {
+	return mod != nil && mod.NeedsInput() && !mod.NeedsTarget()
+}
+
+func countGroups(tasks []nmaptool.ScanTask) int {
+	seen := make(map[string]bool)
+	for _, task := range tasks {
+		if task.GroupID != "" {
+			seen[task.GroupID] = true
+		}
+	}
+	return len(seen)
+}
+
+func statusOrNoop(statusf scanruntime.StatusFunc) scanruntime.StatusFunc {
+	if statusf != nil {
+		return statusf
+	}
+	return func(string, ...interface{}) {}
+}
+
+func writerOrDefault(writer, fallback io.Writer) io.Writer {
+	if writer != nil {
+		return writer
+	}
+	return fallback
+}
+
+func loggerOrDefault(log logger.Logger) logger.Logger {
+	if log != nil {
+		return log
+	}
+	return logger.NewSimpleLogger()
+}
+
+func trackerOrNoop(tracker *operator.Tracker) *operator.Tracker {
+	if tracker != nil {
+		return tracker
+	}
+	return operator.NoopTracker()
+}

--- a/internal/scanapp/scanapp_test.go
+++ b/internal/scanapp/scanapp_test.go
@@ -1,0 +1,374 @@
+package scanapp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"heph4estus/internal/cloud"
+	"heph4estus/internal/fleet"
+	"heph4estus/internal/infra"
+	"heph4estus/internal/modules"
+	"heph4estus/internal/operator"
+	nmaptool "heph4estus/internal/tools/nmap"
+	"heph4estus/internal/worker"
+)
+
+type mockQueue struct {
+	sendBatchErr error
+	batches      [][]string
+}
+
+func (q *mockQueue) Send(context.Context, string, string) error { return nil }
+
+func (q *mockQueue) SendBatch(_ context.Context, _ string, bodies []string) error {
+	q.batches = append(q.batches, append([]string(nil), bodies...))
+	return q.sendBatchErr
+}
+
+func (q *mockQueue) Receive(context.Context, string) (*cloud.Message, error) { return nil, nil }
+func (q *mockQueue) Delete(context.Context, string, string) error            { return nil }
+
+type mockStorage struct {
+	count      int
+	listErr    error
+	uploadKeys []string
+}
+
+func (s *mockStorage) Upload(_ context.Context, _, key string, _ []byte) error {
+	s.uploadKeys = append(s.uploadKeys, key)
+	return nil
+}
+
+func (s *mockStorage) Download(context.Context, string, string) ([]byte, error) {
+	return []byte("{}"), nil
+}
+
+func (s *mockStorage) List(context.Context, string, string) ([]string, error) {
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return nil, nil
+}
+
+func (s *mockStorage) Count(context.Context, string, string) (int, error) {
+	return s.count, nil
+}
+
+type mockCompute struct {
+	runContainerErr error
+	runSpotErr      error
+	runContainerN   int
+	runSpotN        int
+}
+
+func (c *mockCompute) RunContainer(context.Context, cloud.ContainerOpts) (string, error) {
+	c.runContainerN++
+	return "task-1", c.runContainerErr
+}
+
+func (c *mockCompute) RunSpotInstances(context.Context, cloud.SpotOpts) ([]string, error) {
+	c.runSpotN++
+	if c.runSpotErr != nil {
+		return nil, c.runSpotErr
+	}
+	return []string{"i-1"}, nil
+}
+
+func (c *mockCompute) GetSpotStatus(context.Context, []string) ([]cloud.SpotStatus, error) {
+	return nil, nil
+}
+
+func testOutputs() map[string]string {
+	return map[string]string{
+		"sqs_queue_url":        "queue-url",
+		"s3_bucket_name":       "results-bucket",
+		"ecr_repo_url":         "123.dkr.ecr.us-east-1.amazonaws.com/repo",
+		"image_tag":            "heph-worker-20260608T032422Z-a1b2c3d4",
+		"docker_image":         "123.dkr.ecr.us-east-1.amazonaws.com/repo:heph-worker-20260608T032422Z-a1b2c3d4",
+		"ecs_cluster_name":     "cluster",
+		"task_definition_arn":  "task-def",
+		"subnet_ids":           "[subnet-a subnet-b]",
+		"security_group_id":    "sg-123",
+		"ami_id":               "ami-123",
+		"instance_profile_arn": "profile-arn",
+	}
+}
+
+func testRuntimeOutputs(kind cloud.Kind, outputs map[string]string) infra.TerraformOutputs {
+	return infra.DecodeTerraformOutputs(kind, outputs)
+}
+
+func writeTargetFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "targets.txt")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write target file: %v", err)
+	}
+	return path
+}
+
+func targetListModule(fileInput bool) *modules.ModuleDefinition {
+	exec := []string{"tool", "{{target}}"}
+	if fileInput {
+		exec = []string{"tool", "-l", "{{input}}"}
+	}
+	return &modules.ModuleDefinition{
+		Name:          "httpx",
+		Exec:          exec,
+		InputType:     modules.InputTypeTargetList,
+		OutputExt:     "jsonl",
+		InstallCmd:    "true",
+		DefaultCPU:    256,
+		DefaultMemory: 512,
+		Timeout:       "1m",
+	}
+}
+
+func TestPreflightWordlistFileAutoSizesOmittedChunks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "words.txt")
+	if err := os.WriteFile(path, []byte("a\nb\nc\n"), 0o644); err != nil {
+		t.Fatalf("write wordlist: %v", err)
+	}
+
+	meta, err := PreflightWordlistFile("ffuf", path, "https://example.com/FUZZ", "", 0, 2)
+	if err != nil {
+		t.Fatalf("PreflightWordlistFile: %v", err)
+	}
+	if meta.TotalWords != 3 || meta.EffectiveChunks != 2 {
+		t.Fatalf("wordlist metadata = words %d chunks %d", meta.TotalWords, meta.EffectiveChunks)
+	}
+}
+
+func TestRunTargetListScanStartedFalseOnLaunchFailure(t *testing.T) {
+	path := writeTargetFile(t, "example.com\n")
+	meta, err := PreflightTargetListFile(path, 1)
+	if err != nil {
+		t.Fatalf("preflight target file: %v", err)
+	}
+
+	started, err := RunTargetListScan(context.Background(), TargetListOptions{
+		ToolName:    "httpx",
+		JobID:       "job-1",
+		InputFile:   path,
+		Preflight:   meta,
+		Module:      targetListModule(false),
+		Workers:     1,
+		ComputeMode: "fargate",
+		Format:      "text",
+		Queue:       &mockQueue{},
+		Storage:     &mockStorage{},
+		Compute:     &mockCompute{runContainerErr: errors.New("launch failed")},
+		Outputs:     testRuntimeOutputs(cloud.KindAWS, testOutputs()),
+		Bucket:      "results-bucket",
+		QueueURL:    "queue-url",
+		Tracker:     operator.NoopTracker(),
+		CloudKind:   cloud.KindAWS,
+	})
+	if err == nil {
+		t.Fatal("expected launch error")
+	}
+	if started {
+		t.Fatal("expected started=false")
+	}
+}
+
+func TestRunTargetListScanUploadsChunksForInputModules(t *testing.T) {
+	path := writeTargetFile(t, "example.com\n10.0.0.1\n# skipped\n10.0.0.2\n")
+	meta, err := PreflightTargetListFile(path, 2)
+	if err != nil {
+		t.Fatalf("preflight target file: %v", err)
+	}
+	queue := &mockQueue{}
+	storage := &mockStorage{count: 2}
+
+	started, err := RunTargetListScan(context.Background(), TargetListOptions{
+		ToolName:    "httpx",
+		JobID:       "job-1",
+		InputFile:   path,
+		Preflight:   meta,
+		Module:      targetListModule(true),
+		Workers:     2,
+		ComputeMode: "fargate",
+		Format:      "text",
+		Queue:       queue,
+		Storage:     storage,
+		Compute:     &mockCompute{},
+		Outputs:     testRuntimeOutputs(cloud.KindAWS, testOutputs()),
+		Bucket:      "results-bucket",
+		QueueURL:    "queue-url",
+		Tracker:     operator.NoopTracker(),
+		CloudKind:   cloud.KindAWS,
+	})
+	if err != nil {
+		t.Fatalf("RunTargetListScan: %v", err)
+	}
+	if !started {
+		t.Fatal("expected started=true")
+	}
+	if len(storage.uploadKeys) != 2 {
+		t.Fatalf("uploaded chunks = %d, want 2", len(storage.uploadKeys))
+	}
+	if len(queue.batches) != 1 || len(queue.batches[0]) != 2 {
+		t.Fatalf("queued batches = %#v, want one batch with two tasks", queue.batches)
+	}
+	var task worker.Task
+	if err := json.Unmarshal([]byte(queue.batches[0][0]), &task); err != nil {
+		t.Fatalf("unmarshal task: %v", err)
+	}
+	if task.InputKey == "" || task.TotalChunks != 2 {
+		t.Fatalf("chunk task = %#v", task)
+	}
+}
+
+func TestRunNmapScanBatchesLargeEnqueue(t *testing.T) {
+	tasks := make([]nmaptool.ScanTask, 25)
+	for i := range tasks {
+		tasks[i] = nmaptool.ScanTask{
+			JobID:   "job-1",
+			Target:  fmt.Sprintf("192.0.2.%d", i),
+			Options: "-sS",
+		}
+	}
+	queue := &mockQueue{}
+
+	started, err := RunNmapScan(context.Background(), NmapScanOptions{
+		Tasks:       tasks,
+		Workers:     1,
+		ComputeMode: "fargate",
+		Format:      "text",
+		Outputs:     testRuntimeOutputs(cloud.KindAWS, testOutputs()),
+		Queue:       queue,
+		Storage:     &mockStorage{count: len(tasks)},
+		Compute:     &mockCompute{},
+		Tracker:     operator.NoopTracker(),
+		JobID:       "job-1",
+	})
+	if err != nil {
+		t.Fatalf("RunNmapScan: %v", err)
+	}
+	if !started {
+		t.Fatal("expected started=true")
+	}
+
+	gotSizes := make([]int, len(queue.batches))
+	for i, batch := range queue.batches {
+		gotSizes[i] = len(batch)
+	}
+	sort.Ints(gotSizes)
+	if wantSizes := []int{5, 10, 10}; fmt.Sprint(gotSizes) != fmt.Sprint(wantSizes) {
+		t.Fatalf("queued batch sizes = %v, want %v", gotSizes, wantSizes)
+	}
+}
+
+func TestRunNmapScanProviderNativeSkipsRunContainer(t *testing.T) {
+	tasks := []nmaptool.ScanTask{{
+		JobID:   "job-sh",
+		Target:  "10.0.0.1",
+		Options: "-sS",
+	}}
+	comp := &mockCompute{}
+
+	started, err := RunNmapScan(context.Background(), NmapScanOptions{
+		Tasks:       tasks,
+		Workers:     1,
+		ComputeMode: "auto",
+		Format:      "text",
+		Outputs: testRuntimeOutputs(cloud.KindHetzner, map[string]string{
+			"sqs_queue_url":  "nats-stream",
+			"s3_bucket_name": "minio-bucket",
+		}),
+		Queue:     &mockQueue{},
+		Storage:   &mockStorage{count: 1},
+		Compute:   comp,
+		Tracker:   operator.NoopTracker(),
+		JobID:     "job-sh",
+		CloudKind: cloud.KindHetzner,
+		FleetWaiter: func(context.Context, cloud.Kind, map[string]string, fleet.PlacementPolicy) (int, error) {
+			return 1, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunNmapScan: %v", err)
+	}
+	if !started {
+		t.Fatal("expected started=true")
+	}
+	if comp.runContainerN != 0 || comp.runSpotN != 0 {
+		t.Fatalf("provider-native path used compute: container=%d spot=%d", comp.runContainerN, comp.runSpotN)
+	}
+}
+
+func TestRunNmapScanSelfhostedNeverCallsSpot(t *testing.T) {
+	tasks := []nmaptool.ScanTask{{
+		JobID:   "job-sh",
+		Target:  "10.0.0.1",
+		Options: "-sS",
+	}}
+	comp := &mockCompute{runSpotErr: errors.New("spot should not be called")}
+
+	started, err := RunNmapScan(context.Background(), NmapScanOptions{
+		Tasks:       tasks,
+		Workers:     200,
+		ComputeMode: "auto",
+		Format:      "text",
+		Outputs: testRuntimeOutputs(cloud.KindManual, map[string]string{
+			"sqs_queue_url":  "nats-stream",
+			"s3_bucket_name": "minio-bucket",
+		}),
+		Queue:     &mockQueue{},
+		Storage:   &mockStorage{count: 1},
+		Compute:   comp,
+		Tracker:   operator.NoopTracker(),
+		JobID:     "job-sh",
+		CloudKind: cloud.KindManual,
+	})
+	if err != nil {
+		t.Fatalf("RunNmapScan: %v", err)
+	}
+	if !started {
+		t.Fatal("expected started=true")
+	}
+	if comp.runSpotN != 0 {
+		t.Fatalf("manual selfhosted path used spot %d times", comp.runSpotN)
+	}
+}
+
+func TestRunTargetListScanReturnsStartedTrueOnOutputFailure(t *testing.T) {
+	path := writeTargetFile(t, "example.com\n")
+	meta, err := PreflightTargetListFile(path, 1)
+	if err != nil {
+		t.Fatalf("preflight target file: %v", err)
+	}
+
+	started, err := RunTargetListScan(context.Background(), TargetListOptions{
+		ToolName:    "httpx",
+		JobID:       "job-1",
+		InputFile:   path,
+		Preflight:   meta,
+		Module:      targetListModule(false),
+		Workers:     1,
+		ComputeMode: "fargate",
+		Format:      "text",
+		Queue:       &mockQueue{},
+		Storage:     &mockStorage{count: 1, listErr: errors.New("list failed")},
+		Compute:     &mockCompute{},
+		Outputs:     testRuntimeOutputs(cloud.KindAWS, testOutputs()),
+		Bucket:      "results-bucket",
+		QueueURL:    "queue-url",
+		Tracker:     operator.NoopTracker(),
+		CloudKind:   cloud.KindAWS,
+	})
+	if err == nil || !strings.Contains(err.Error(), "list failed") {
+		t.Fatalf("expected output failure, got %v", err)
+	}
+	if !started {
+		t.Fatal("expected started=true")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds an internal scanapp service package for CLI scan use cases.
- Moves generic scan and nmap orchestration out of cmd/heph while preserving flag parsing, defaults, validation, stdout/stderr behavior, and run summaries in the command layer.
- Keeps scanruntime as the lower-level lifecycle/queue/worker runtime and uses scanapp for command-level scan application flow.
- Adds direct scanapp coverage for launch failure boundaries, chunk uploads, enqueue batching, provider-native compute skips, selfhosted spot avoidance, and output failure semantics.

## Commits
- refactor(cli): add scan app service
- refactor(cli): thin scan command wrappers

## Validation
- GOCACHE=/tmp/heph-go-cache go test ./internal/scanapp ./cmd/heph
- env GOCACHE=/tmp/heph-go-build make test
- make fmt-check
- env GOCACHE=/tmp/heph-go-build make vet
- env XDG_CACHE_HOME=/tmp/heph-cache GOCACHE=/tmp/heph-go-build make lint
- git diff --check

## Notes
- Public CLI flags, validation messages, result formats, job record fields, and lifecycle semantics are intended to remain unchanged.
- Scope is intentionally limited to heph scan and heph nmap; status, results, fleet, bench, infra, init, and rotation commands remain for later cleanup.
- Existing untracked local roadmap/docs artifacts were left out of this branch.